### PR TITLE
fixing library location in Config.cmake.in

### DIFF
--- a/cmake/templates/Config.cmake.in
+++ b/cmake/templates/Config.cmake.in
@@ -1,6 +1,6 @@
 @PACKAGE_INIT@
 
-set_and_check(VINECOPULIB_INCLUDE_DIR "@PACKAGE_include_install_dir@/vinecopulib")
+set_and_check(VINECOPULIB_INCLUDE_DIR "@PACKAGE_include_install_dir@")
 include("${CMAKE_CURRENT_LIST_DIR}/@targets_export_name@.cmake")
 check_required_components("@PROJECT_NAME@")
 set(VINECOPULIB_LIBRARIES vinecopulib)

--- a/include/vinecopulib.hpp
+++ b/include/vinecopulib.hpp
@@ -1,2 +1,2 @@
-#include <bicop/class.hpp>
-#include <vinecop/class.hpp>
+#include <vinecopulib/bicop/class.hpp>
+#include <vinecopulib/vinecop/class.hpp>


### PR DESCRIPTION
was not caught in vinecopulib tests as the actual location /usr/local was part of the default path on Linux/OSX, while on Windows we do not build the example program yet. The pyvinecopulib build failed due to it, though