### PR TITLE
include <exception> in fit_controls source files

### DIFF
--- a/src/bicop/fit_controls.cpp
+++ b/src/bicop/fit_controls.cpp
@@ -6,6 +6,7 @@
 
 #include <vinecopulib/bicop/fit_controls.hpp>
 #include <vinecopulib/misc/tools_stl.hpp>
+#include <exception>
 
 //! Tools for bivariate and vine copula modeling
 namespace vinecopulib

--- a/src/vinecop/fit_controls.cpp
+++ b/src/vinecop/fit_controls.cpp
@@ -6,6 +6,7 @@
 
 #include <vinecopulib/vinecop/fit_controls.hpp>
 #include <vinecopulib/misc/tools_stl.hpp>
+#include <exception>
 
 //! Tools for bivariate and vine copula modeling
 namespace vinecopulib


### PR DESCRIPTION
gcc4.9 builds fail because of this, but I should note that gcc4.9 is not fully c++11 compliant (just enables most of the features). I suggest we do this fix anyway.