### PR TITLE
Fix preselection when data contain 0 or 1

### DIFF
--- a/src/bicop/class.cpp
+++ b/src/bicop/class.cpp
@@ -367,16 +367,12 @@ namespace vinecopulib
             }
         } else {
             if (intersect(family_set, bicop_families::all).empty()) {
-                throw std::runtime_error(
-                        std::string("One of the families is not implemented")
-                );
+                throw std::runtime_error("One of the families is not implemented");
             }
             if (method == "itau") {
                 family_set = intersect(family_set, bicop_families::itau);
                 if (family_set.empty()) {
-                    throw std::runtime_error(
-                            std::string("No family with method itau provided")
-                    );
+                    throw std::runtime_error("No family with method itau provided");
                 }
             }
         }
@@ -393,7 +389,8 @@ namespace vinecopulib
 
         std::vector<double> c(2);
         if (preselect_families) {
-            c = get_c1c2(data, tau);
+            rotation_ = 0;
+            c = get_c1c2(cut_and_rotate(data), tau);
         }
 
         // Create the combinations of families and rotations to estimate

--- a/test/src_test/include/test_bicop_sanity_checks.hpp
+++ b/test/src_test/include/test_bicop_sanity_checks.hpp
@@ -35,5 +35,13 @@ namespace test_bicop_sanity_checks {
         EXPECT_ANY_THROW(Bicop(BicopFamily::gaussian, -10));
         EXPECT_ANY_THROW(Bicop(BicopFamily::gaussian, 10));
     }
-
+    
+    TEST(bicop_sanity_checks, select_can_handle_zeros_and_ones) {
+        Bicop bicop;
+        auto u = bicop.simulate(10);
+        u(0, 0) = 0.0;
+        u(1, 0) = 1.0;
+        EXPECT_NO_THROW(bicop.select(u));
+    }
+    
 }


### PR DESCRIPTION
@bodashtart found a bug in the `Bicop(data)` constructor (issue #171). It was caused by [this line](https://github.com/vinecopulib/vinecopulib/blob/master/src/bicop/class.cpp#L396) in `Bicop::select()` where [`get_c1c2()`](https://github.com/vinecopulib/vinecopulib/blob/master/src/bicop/tools_bicopselect.cpp#L12) is called without `cut_and_rotate()`. In this function, data is passed on to `tools_stats::qnorm()` which gives
> C++ exception with description "Error in function boost::math::erfc_inv<double>(double, double): Overflow Error" thrown in the test body.  

when there are 0s or 1s in the data.

I fixed this by calling `get_c1c2()` with `cut_and_rotate()` and added a unit test to the sanity check section.