### PR TITLE
Check for validity of R-vine matrices

### DIFF
--- a/README.md
+++ b/README.md
@@ -468,6 +468,23 @@ Denoting by `M[i][j]` the matrix entry in row `i` and column `j` (starting at
 2. Jump up to the element in row `t` (second conditioned variable).
 3. Gather all entries further up in column `e` (conditioning set).
 
+A valid R-vine matrix must satisfy several conditions which are checked
+when `RVineMatrix()` is called:
+1. The lower right triangle must only contain zeros.
+2. The upper left triangle can only contain numbers between 1 and d.
+3. The antidiagonal must contain the numbers 1, ..., d.
+4. The antidiagonal entry of a column must not be contained in any 
+   column further to the right.
+5. The entries of a column must be contained in all columns to the left.
+6. The proximity condition must hold: For all t = 1, ..., d - 2 and 
+   e = 0, ..., d - t - 1 there must exist an index j > d, such that 
+   `(M[t, e], {M[0, e], ..., M[t-1, e]})` equals either
+   `(M[d-j-1, j], {M[0, j], ..., M[t-1, j]})` or 
+   `(M[t-1, j], {M[d-j-1, j], M[0, j], ..., M[t-2, j]})`.
+
+Condition 6 already implies conditions 2-5, but is more difficult to
+check by hand.
+
 ### Fit and select a vine copula model
 
 The method `select_all()` performs parameter estimation and automatic

--- a/include/vinecopulib/vinecop/rvine_matrix.hpp
+++ b/include/vinecopulib/vinecop/rvine_matrix.hpp
@@ -57,6 +57,8 @@ namespace vinecopulib
             const Eigen::Matrix<size_t, Eigen::Dynamic, 1>& order);
 
     private:
+        void check_matrix() const;
+        
         size_t d_;
         Eigen::Matrix<size_t, Eigen::Dynamic, Eigen::Dynamic> matrix_;
     };

--- a/include/vinecopulib/vinecop/rvine_matrix.hpp
+++ b/include/vinecopulib/vinecop/rvine_matrix.hpp
@@ -58,6 +58,10 @@ namespace vinecopulib
 
     private:
         void check_matrix() const;
+        void check_lower_tri() const;
+        void check_upper_tri() const;
+        void check_antidiagonal() const;
+        void check_columns() const;
         
         size_t d_;
         Eigen::Matrix<size_t, Eigen::Dynamic, Eigen::Dynamic> matrix_;

--- a/include/vinecopulib/vinecop/rvine_matrix.hpp
+++ b/include/vinecopulib/vinecop/rvine_matrix.hpp
@@ -62,6 +62,7 @@ namespace vinecopulib
         void check_upper_tri() const;
         void check_antidiagonal() const;
         void check_columns() const;
+        void check_proximity_condition() const;
         
         size_t d_;
         Eigen::Matrix<size_t, Eigen::Dynamic, Eigen::Dynamic> matrix_;

--- a/include/vinecopulib/vinecop/rvine_matrix.hpp
+++ b/include/vinecopulib/vinecop/rvine_matrix.hpp
@@ -62,7 +62,10 @@ namespace vinecopulib
     {
     public:
         RVineMatrix() {}
-        RVineMatrix(const Eigen::Matrix<size_t, Eigen::Dynamic, Eigen::Dynamic>& matrix);
+        RVineMatrix(
+            const Eigen::Matrix<size_t, Eigen::Dynamic, Eigen::Dynamic>& matrix,
+            bool check = true
+        );
 
         Eigen::Matrix<size_t, Eigen::Dynamic, Eigen::Dynamic> get_matrix() const;
         Eigen::Matrix<size_t, Eigen::Dynamic, 1> get_order() const;
@@ -71,11 +74,10 @@ namespace vinecopulib
         MatrixXb get_needed_hfunc1() const;
         MatrixXb get_needed_hfunc2() const;
 
-        static Eigen::Matrix<size_t, Eigen::Dynamic, Eigen::Dynamic> construct_d_vine_matrix(
-            const Eigen::Matrix<size_t, Eigen::Dynamic, 1>& order);
+        static Eigen::Matrix<size_t, Eigen::Dynamic, Eigen::Dynamic> 
+        construct_d_vine_matrix(const Eigen::Matrix<size_t, Eigen::Dynamic, 1>& order);
 
     private:
-        void check_matrix() const;
         void check_lower_tri() const;
         void check_upper_tri() const;
         void check_antidiagonal() const;

--- a/include/vinecopulib/vinecop/rvine_matrix.hpp
+++ b/include/vinecopulib/vinecop/rvine_matrix.hpp
@@ -32,14 +32,32 @@ namespace vinecopulib
     //! |      | 1    | `(3, 2; 1)`    |
     //! | 2    | 0    | `(4, 3; 2, 1)` |
     //! ```
-    //! Denoting by `M[i][j]` the matrix entry in row `i` and column `j` (starting at
-    //! 0), the pair-copula index for edge `e` in tree `t` of a `d` dimensional vine is
-    //! `(M[d - 1 - t][e], M[t][e]; M[t - 1][e], ..., M[0][e])`. Less formally,
+    //! Denoting by `M[i][j]` the matrix entry in row `i` and column `j` 
+    //! (starting at 0), the pair-copula index for edge `e` in tree `t` of a 
+    //! `d` dimensional vine is
+    //! `(M[d - 1 - t][e], M[t][e]; M[t - 1][e], ..., M[0][e])`. Less 
+    //! formally,
     //! 1. Start with the counter-diagonal element of column `e` (first conditioned 
     //!    variable).
     //! 2. Jump up to the element in row `t` (second conditioned variable).
     //! 3. Gather all entries further up in column `e` (conditioning set).
     //! 
+    //! A valid R-vine matrix must satisfy several conditions which are checked
+    //! when `RVineMatrix()` is called:
+    //! 1. The lower right triangle must only contain zeros.
+    //! 2. The upper left triangle can only contain numbers between 1 and d.
+    //! 3. The antidiagonal must contain the numbers 1, ..., d.
+    //! 4. The antidiagonal entry of a column must not be contained in any 
+    //!    column further to the right.
+    //! 5. The entries of a column must be contained in all columns to the left.
+    //! 6. The proximity condition must hold: For all t = 1, ..., d - 2 and 
+    //!    e = 0, ..., d - t - 1 there must exist an index j > d, such that 
+    //!    `(M[t, e], {M[0, e], ..., M[t-1, e]})` equals either
+    //!    `(M[d-j-1, j], {M[0, j], ..., M[t-1, j]})` or 
+    //!    `(M[t-1, j], {M[d-j-1, j], M[0, j], ..., M[t-2, j]})`.
+    //! 
+    //! Condition 6 already implies conditions 2-5, but is more difficult to
+    //! check by hand.
     class RVineMatrix
     {
     public:

--- a/src/vinecop/rvine_matrix.cpp
+++ b/src/vinecop/rvine_matrix.cpp
@@ -168,7 +168,7 @@ namespace vinecopulib
     void RVineMatrix::check_antidiagonal() const {    
         std::string problem;
         problem += "the antidiagonal must contain the numbers ";
-        problem += "1, 2, ..., d (the number of variables)";
+        problem += "1, ..., d (the number of variables)";
         auto diag = matrix_.colwise().reverse().diagonal();
         std::vector<size_t> diag_vec(d_);
         Eigen::Matrix<size_t, Eigen::Dynamic, 1>::Map(&diag_vec[0], d_) = diag;
@@ -184,7 +184,7 @@ namespace vinecopulib
         problem += "the antidiagonal entry of a column must not be ";
         problem += "contained in any column further to the right; ";
         problem += "the entries of a column must be contained ";
-        problem += "in all columns left of that column.";
+        problem += "in all columns to the left.";
         
         // In natural order: column j only contains indices 1:(d - j).
         bool ok = true;

--- a/src/vinecop/rvine_matrix.cpp
+++ b/src/vinecop/rvine_matrix.cpp
@@ -129,6 +129,62 @@ namespace vinecopulib
         return needed_hfunc2;
     }
     //! @}
+    
+    void RVineMatrix::check_matrix() const
+    {
+        using namespace tools_stl;
+        std::string not_valid_msg = "not a valid R-vine matrix: ";
+        std::string problem;
+        
+        problem = "the lower right triangle must only contain zeros";
+        size_t sum_lwr = 0;
+        for (size_t j = 1; j < d_; ++j) {
+                sum_lwr += matrix_.block(d_ - j, j, j, 0).array().sum();
+                if (sum_lwr != 0) {
+                    throw std::runtime_error(not_valid_msg + problem);
+                }            
+        }
+        
+        problem = "the upper left triangle can only contain numbers \
+                   between and d (number of variables).";
+        size_t min_upr = d_;
+        size_t max_upr = 0;
+        for (size_t j = 0; j < d_; ++j) {
+            min_upr = std::min(max_upr, matrix_.block(0, j, j, 0).maxCoeff());
+            max_upr = std::max(max_upr, matrix_.block(0, j, j, 0).maxCoeff());
+            if ((max_upr > d_) | (min_upr < 1)) {
+                throw std::runtime_error(not_valid_msg + problem);
+            }
+        }
+        
+        problem = "the antidiagonal must contain the numbers 1, 2, ..., d \
+                   (the number of variables)";
+        auto diag = matrix_.colwise().reverse().diagonal();
+        std::vector<size_t> diag_vec(d_);
+        Eigen::Matrix<size_t, Eigen::Dynamic, 1>::Map(&diag_vec[0], d_) = diag;
+        if (!is_same_set(diag_vec, seq_int(1, d_))) {
+            throw std::runtime_error(not_valid_msg + problem);
+        }
+        
+        
+        auto no_matrix = in_natural_order();
+        problem = "the antidiagonal entry of a column must not be \
+                   contained in any column further to the right; \
+                   all entries of a column must be contained \
+                   in all columns left of that column ";
+        // In natural order: column j only contains indices 0:(d - j).
+        bool ok = true;
+        for (size_t j = 0; j < d_; ++j) {
+            std::vector<size_t> col_vec(d_);
+            Eigen::Matrix<size_t, Eigen::Dynamic, 1>::Map(&col_vec[0], d_) = no_matrix.col(j);
+            ok = ok & is_same_set(col_vec, seq_int(0, d_ - j));
+            if (!ok) {
+                throw std::runtime_error(not_valid_msg + problem);
+            }
+        }
+        
+        // TODO: check for simplifying assumption
+    }
 
     // translates matrix_entry from old to new labels
     size_t relabel_one(size_t x, 

--- a/src/vinecop/rvine_matrix.cpp
+++ b/src/vinecop/rvine_matrix.cpp
@@ -143,10 +143,11 @@ namespace vinecopulib
         std::string problem = "the lower right triangle must only contain zeros";
         size_t sum_lwr = 0;
         for (size_t j = 1; j < d_; ++j) {
-                sum_lwr += matrix_.block(d_ - j, j, j, 0).array().sum();
-                if (sum_lwr != 0) {
-                    throw std::runtime_error("not a valid R-vine matrix: " + problem);
-                }            
+            // std::cout << matrix_.block(d_ - j, j, j, 1) << std::endl << std::endl;
+            sum_lwr += matrix_.block(d_ - j, j, j, 1).array().sum();
+            if (sum_lwr != 0) {
+                throw std::runtime_error("not a valid R-vine matrix: " + problem);
+            }            
         }
     }
     

--- a/src/vinecop/rvine_matrix.cpp
+++ b/src/vinecop/rvine_matrix.cpp
@@ -6,7 +6,7 @@
 
 #include <vinecopulib/vinecop/rvine_matrix.hpp>
 #include <vinecopulib/misc/tools_stl.hpp>
-#include <iostream>
+
 namespace vinecopulib
 {
     //! instantiates an RVineMatrix object.
@@ -143,7 +143,6 @@ namespace vinecopulib
         std::string problem = "the lower right triangle must only contain zeros";
         size_t sum_lwr = 0;
         for (size_t j = 1; j < d_; ++j) {
-            // std::cout << matrix_.block(d_ - j, j, j, 1) << std::endl << std::endl;
             sum_lwr += matrix_.block(d_ - j, j, j, 1).array().sum();
             if (sum_lwr != 0) {
                 throw std::runtime_error("not a valid R-vine matrix: " + problem);
@@ -158,8 +157,8 @@ namespace vinecopulib
         size_t min_upr = d_;
         size_t max_upr = 0;
         for (size_t j = 0; j < d_; ++j) {
-            min_upr = std::min(min_upr, matrix_.block(0, j, j, 0).maxCoeff());
-            max_upr = std::max(max_upr, matrix_.block(0, j, j, 0).maxCoeff());
+            min_upr = std::min(min_upr, matrix_.block(0, j, j + 1, 1).maxCoeff());
+            max_upr = std::max(max_upr, matrix_.block(0, j, j + 1, 1).maxCoeff());
             if ((max_upr > d_) | (min_upr < 1)) {
                 throw std::runtime_error("not a valid R-vine matrix: " + problem);
             }
@@ -192,7 +191,7 @@ namespace vinecopulib
         for (size_t j = 0; j < d_; ++j) {
             std::vector<size_t> col_vec(d_ - j);
             Eigen::Matrix<size_t, Eigen::Dynamic, 1>::Map(&col_vec[0], d_ - j) = 
-                no_matrix.block(0, j, d_ - j, 0);
+                no_matrix.block(0, j, d_ - j, 1);
             ok = ok & is_same_set(col_vec, seq_int(1, d_ - j));
             if (!ok) {
                 throw std::runtime_error("not a valid R-vine matrix: " + problem);

--- a/test/src_test/include/test_rvine_matrix.hpp
+++ b/test/src_test/include/test_rvine_matrix.hpp
@@ -32,7 +32,7 @@ namespace test_rvine_matrix {
         RVineMatrix rvine_matrix(mat);
         EXPECT_EQ(rvine_matrix.in_natural_order(), true_no_matrix);
     }
-
+    
     TEST(rvine_matrix, max_mat_is_correct) {
         Eigen::Matrix<size_t, Eigen::Dynamic, Eigen::Dynamic> mat(7, 7);
         mat << 5, 2, 6, 6, 6, 6, 6,
@@ -53,7 +53,7 @@ namespace test_rvine_matrix {
         RVineMatrix rvine_matrix(mat);
         EXPECT_EQ(rvine_matrix.get_max_matrix(), true_max_matrix);
     }
-
+    
     TEST(rvine_matrix, needed_hfunc1_is_correct) {
         Eigen::Matrix<size_t, Eigen::Dynamic, Eigen::Dynamic> mat(7, 7);
         mat << 5, 2, 6, 6, 6, 6, 6,
@@ -74,7 +74,7 @@ namespace test_rvine_matrix {
         RVineMatrix rvine_matrix(mat);
         EXPECT_EQ(rvine_matrix.get_needed_hfunc1(), true_hfunc1);
     }
-
+    
     TEST(rvine_matrix, needed_hfunc2_is_correct) {
         Eigen::Matrix<size_t, Eigen::Dynamic, Eigen::Dynamic> mat(7, 7);
         mat << 5, 2, 6, 6, 6, 6, 6,
@@ -95,7 +95,7 @@ namespace test_rvine_matrix {
         RVineMatrix rvine_matrix(mat);
         EXPECT_EQ(rvine_matrix.get_needed_hfunc2(), true_hfunc2);
     }
-
+    
     TEST(rvine_matrix, construct_d_vine_matrix_is_correct) {
         Eigen::Matrix<size_t, Eigen::Dynamic, 1> order(7);
         order << 7, 2, 3, 5, 1, 4, 6;
@@ -142,6 +142,12 @@ namespace test_rvine_matrix {
         // all numbers in a column most appear in each column to the left
         wrong_mat = mat;
         wrong_mat(0, 0) = 4;
+        EXPECT_ANY_THROW(rvm = RVineMatrix(wrong_mat));
+        
+        // proximity condition
+        wrong_mat = mat;
+        wrong_mat(3, 1) = 7;
+        wrong_mat(4, 1) = 1;
         EXPECT_ANY_THROW(rvm = RVineMatrix(wrong_mat));
     }
 }

--- a/test/src_test/include/test_rvine_matrix.hpp
+++ b/test/src_test/include/test_rvine_matrix.hpp
@@ -122,27 +122,26 @@ namespace test_rvine_matrix {
         // should pass without errors
         auto rvm = RVineMatrix(mat);
         
-        // // lower tri must contain zeros
-        // auto wrong_mat = mat;
-        // wrong_mat(6, 6) = -1;
-        // rvm = RVineMatrix(wrong_mat);
-        // EXPECT_ANY_THROW(RVineMatrix(wrong_mat));
-        // 
-        // // upper tri must only contain 1, ..., d
-        // wrong_mat = mat;
-        // wrong_mat(0, 0) = 9;
-        // EXPECT_ANY_THROW(RVineMatrix(wrong_mat));
-        // wrong_mat(0, 0) = 0;
-        // EXPECT_ANY_THROW(RVineMatrix(wrong_mat));
-        // 
-        // // diagonal elements cannot appear further to the right
-        // wrong_mat = mat;
-        // wrong_mat(0, 1) = 4;
-        // EXPECT_ANY_THROW(RVineMatrix(wrong_mat));
-        // 
-        // // all numbers in a column most appear in each column to the left
-        // wrong_mat = mat;
-        // wrong_mat(0, 0) = 4;
-        // EXPECT_ANY_THROW(RVineMatrix(wrong_mat));
+        // lower tri must contain zeros
+        auto wrong_mat = mat;
+        wrong_mat(6, 6) = 1;
+        EXPECT_ANY_THROW(rvm = RVineMatrix(wrong_mat));
+        
+        // upper tri must only contain 1, ..., d
+        wrong_mat = mat;
+        wrong_mat(0, 0) = 9;
+        EXPECT_ANY_THROW(rvm = RVineMatrix(wrong_mat));
+        wrong_mat(0, 0) = 0;
+        EXPECT_ANY_THROW(rvm = RVineMatrix(wrong_mat));
+        
+        // diagonal elements cannot appear further to the right
+        wrong_mat = mat;
+        wrong_mat(0, 1) = 4;
+        EXPECT_ANY_THROW(rvm = RVineMatrix(wrong_mat));
+        
+        // all numbers in a column most appear in each column to the left
+        wrong_mat = mat;
+        wrong_mat(0, 0) = 4;
+        EXPECT_ANY_THROW(rvm = RVineMatrix(wrong_mat));
     }
 }

--- a/test/src_test/include/test_rvine_matrix.hpp
+++ b/test/src_test/include/test_rvine_matrix.hpp
@@ -15,20 +15,20 @@ namespace test_rvine_matrix {
     TEST(rvine_matrix, can_convert_to_natural_order) {
         Eigen::Matrix<size_t, Eigen::Dynamic, Eigen::Dynamic> mat(7, 7);
         mat << 5, 2, 6, 6, 6, 6, 6,
-                6, 6, 1, 2, 5, 5, 0,
-                2, 5, 2, 5, 2, 0, 0,
-                1, 1, 5, 1, 0, 0, 0,
-                3, 7, 7, 0, 0, 0, 0,
-                7, 3, 0, 0, 0, 0, 0,
-                4, 0, 0, 0, 0, 0, 0;
+               6, 6, 1, 2, 5, 5, 0,
+               2, 5, 2, 5, 2, 0, 0,
+               1, 1, 5, 1, 0, 0, 0,
+               3, 7, 7, 0, 0, 0, 0,
+               7, 3, 0, 0, 0, 0, 0,
+               4, 0, 0, 0, 0, 0, 0;
         Eigen::Matrix<size_t, Eigen::Dynamic, Eigen::Dynamic> true_no_matrix(7, 7);
         true_no_matrix << 2, 3, 1, 1, 1, 1, 1,
-                1, 1, 4, 3, 2, 2, 0,
-                3, 2, 3, 2, 3, 0, 0,
-                4, 4, 2, 4, 0, 0, 0,
-                6, 5, 5, 0, 0, 0, 0,
-                5, 6, 0, 0, 0, 0, 0,
-                7, 0, 0, 0, 0, 0, 0;
+                          1, 1, 4, 3, 2, 2, 0,
+                          3, 2, 3, 2, 3, 0, 0,
+                          4, 4, 2, 4, 0, 0, 0,
+                          6, 5, 5, 0, 0, 0, 0,
+                          5, 6, 0, 0, 0, 0, 0,
+                          7, 0, 0, 0, 0, 0, 0;
         RVineMatrix rvine_matrix(mat);
         EXPECT_EQ(rvine_matrix.in_natural_order(), true_no_matrix);
     }
@@ -36,20 +36,20 @@ namespace test_rvine_matrix {
     TEST(rvine_matrix, max_mat_is_correct) {
         Eigen::Matrix<size_t, Eigen::Dynamic, Eigen::Dynamic> mat(7, 7);
         mat << 5, 2, 6, 6, 6, 6, 6,
-                6, 6, 1, 2, 5, 5, 0,
-                2, 5, 2, 5, 2, 0, 0,
-                1, 1, 5, 1, 0, 0, 0,
-                3, 7, 7, 0, 0, 0, 0,
-                7, 3, 0, 0, 0, 0, 0,
-                4, 0, 0, 0, 0, 0, 0;
+               6, 6, 1, 2, 5, 5, 0,
+               2, 5, 2, 5, 2, 0, 0,
+               1, 1, 5, 1, 0, 0, 0,
+               3, 7, 7, 0, 0, 0, 0,
+               7, 3, 0, 0, 0, 0, 0,
+               4, 0, 0, 0, 0, 0, 0;
         Eigen::Matrix<size_t, Eigen::Dynamic, Eigen::Dynamic> true_max_matrix(7, 7);
         true_max_matrix << 2, 3, 1, 1, 1, 1, 1,
-                2, 3, 4, 3, 2, 2, 0,
-                3, 3, 4, 3, 3, 0, 0,
-                4, 4, 4, 4, 0, 0, 0,
-                6, 5, 5, 0, 0, 0, 0,
-                6, 6, 0, 0, 0, 0, 0,
-                7, 0, 0, 0, 0, 0, 0;
+                           2, 3, 4, 3, 2, 2, 0,
+                           3, 3, 4, 3, 3, 0, 0,
+                           4, 4, 4, 4, 0, 0, 0,
+                           6, 5, 5, 0, 0, 0, 0,
+                           6, 6, 0, 0, 0, 0, 0,
+                           7, 0, 0, 0, 0, 0, 0;
         RVineMatrix rvine_matrix(mat);
         EXPECT_EQ(rvine_matrix.get_max_matrix(), true_max_matrix);
     }
@@ -57,20 +57,20 @@ namespace test_rvine_matrix {
     TEST(rvine_matrix, needed_hfunc1_is_correct) {
         Eigen::Matrix<size_t, Eigen::Dynamic, Eigen::Dynamic> mat(7, 7);
         mat << 5, 2, 6, 6, 6, 6, 6,
-                6, 6, 1, 2, 5, 5, 0,
-                2, 5, 2, 5, 2, 0, 0,
-                1, 1, 5, 1, 0, 0, 0,
-                3, 7, 7, 0, 0, 0, 0,
-                7, 3, 0, 0, 0, 0, 0,
-                4, 0, 0, 0, 0, 0, 0;
+               6, 6, 1, 2, 5, 5, 0,
+               2, 5, 2, 5, 2, 0, 0,
+               1, 1, 5, 1, 0, 0, 0,
+               3, 7, 7, 0, 0, 0, 0,
+               7, 3, 0, 0, 0, 0, 0,
+               4, 0, 0, 0, 0, 0, 0;
         MatrixXb true_hfunc1(7, 7);
         true_hfunc1 << 0, 0, 0, 0, 0, 0, 0,
-                0, 0, 0, 0, 1, 1, 0,
-                0, 0, 0, 1, 1, 0, 0,
-                0, 0, 0, 1, 0, 0, 0,
-                0, 0, 0, 0, 0, 0, 0,
-                0, 1, 0, 0, 0, 0, 0,
-                0, 0, 0, 0, 0, 0, 0;
+                       0, 0, 0, 0, 1, 1, 0,
+                       0, 0, 0, 1, 1, 0, 0,
+                       0, 0, 0, 1, 0, 0, 0,
+                       0, 0, 0, 0, 0, 0, 0,
+                       0, 1, 0, 0, 0, 0, 0,
+                       0, 0, 0, 0, 0, 0, 0;
         RVineMatrix rvine_matrix(mat);
         EXPECT_EQ(rvine_matrix.get_needed_hfunc1(), true_hfunc1);
     }
@@ -78,20 +78,20 @@ namespace test_rvine_matrix {
     TEST(rvine_matrix, needed_hfunc2_is_correct) {
         Eigen::Matrix<size_t, Eigen::Dynamic, Eigen::Dynamic> mat(7, 7);
         mat << 5, 2, 6, 6, 6, 6, 6,
-                6, 6, 1, 2, 5, 5, 0,
-                2, 5, 2, 5, 2, 0, 0,
-                1, 1, 5, 1, 0, 0, 0,
-                3, 7, 7, 0, 0, 0, 0,
-                7, 3, 0, 0, 0, 0, 0,
-                4, 0, 0, 0, 0, 0, 0;
+               6, 6, 1, 2, 5, 5, 0,
+               2, 5, 2, 5, 2, 0, 0,
+               1, 1, 5, 1, 0, 0, 0,
+               3, 7, 7, 0, 0, 0, 0,
+               7, 3, 0, 0, 0, 0, 0,
+               4, 0, 0, 0, 0, 0, 0;
         MatrixXb true_hfunc2(7, 7);
         true_hfunc2 << 1, 1, 1, 1, 1, 1, 0,
-                1, 1, 1, 1, 1, 1, 0,
-                1, 1, 1, 1, 1, 0, 0,
-                1, 1, 1, 1, 0, 0, 0,
-                1, 1, 1, 0, 0, 0, 0,
-                1, 0, 0, 0, 0, 0, 0,
-                0, 0, 0, 0, 0, 0, 0;
+                       1, 1, 1, 1, 1, 1, 0,
+                       1, 1, 1, 1, 1, 0, 0,
+                       1, 1, 1, 1, 0, 0, 0,
+                       1, 1, 1, 0, 0, 0, 0,
+                       1, 0, 0, 0, 0, 0, 0,
+                       0, 0, 0, 0, 0, 0, 0;
         RVineMatrix rvine_matrix(mat);
         EXPECT_EQ(rvine_matrix.get_needed_hfunc2(), true_hfunc2);
     }
@@ -101,12 +101,48 @@ namespace test_rvine_matrix {
         order << 7, 2, 3, 5, 1, 4, 6;
         Eigen::Matrix<size_t, Eigen::Dynamic, Eigen::Dynamic> true_d_vine_matrix(7, 7);
         true_d_vine_matrix << 4, 1, 5, 3, 2, 7, 7,
-                1, 5, 3, 2, 7, 2, 0,
-                5, 3, 2, 7, 3, 0, 0,
-                3, 2, 7, 5, 0, 0, 0,
-                2, 7, 1, 0, 0, 0, 0,
-                7, 4, 0, 0, 0, 0, 0,
-                6, 0, 0, 0, 0, 0, 0;
+                              1, 5, 3, 2, 7, 2, 0,
+                              5, 3, 2, 7, 3, 0, 0,
+                              3, 2, 7, 5, 0, 0, 0,
+                              2, 7, 1, 0, 0, 0, 0,
+                              7, 4, 0, 0, 0, 0, 0,
+                              6, 0, 0, 0, 0, 0, 0;
         EXPECT_EQ(RVineMatrix::construct_d_vine_matrix(order), true_d_vine_matrix);
+    }
+    
+    TEST(rvine_matrix, rvine_matrix_sanity_checks_work) {
+        Eigen::Matrix<size_t, Eigen::Dynamic, Eigen::Dynamic> mat(7, 7);
+        mat << 5, 2, 6, 6, 6, 6, 6,
+               6, 6, 1, 2, 5, 5, 0,
+               2, 5, 2, 5, 2, 0, 0,
+               1, 1, 5, 1, 0, 0, 0,
+               3, 7, 7, 0, 0, 0, 0,
+               7, 3, 0, 0, 0, 0, 0,
+               4, 0, 0, 0, 0, 0, 0;
+        // should pass without errors
+        auto rvm = RVineMatrix(mat);
+        
+        // // lower tri must contain zeros
+        // auto wrong_mat = mat;
+        // wrong_mat(6, 6) = -1;
+        // rvm = RVineMatrix(wrong_mat);
+        // EXPECT_ANY_THROW(RVineMatrix(wrong_mat));
+        // 
+        // // upper tri must only contain 1, ..., d
+        // wrong_mat = mat;
+        // wrong_mat(0, 0) = 9;
+        // EXPECT_ANY_THROW(RVineMatrix(wrong_mat));
+        // wrong_mat(0, 0) = 0;
+        // EXPECT_ANY_THROW(RVineMatrix(wrong_mat));
+        // 
+        // // diagonal elements cannot appear further to the right
+        // wrong_mat = mat;
+        // wrong_mat(0, 1) = 4;
+        // EXPECT_ANY_THROW(RVineMatrix(wrong_mat));
+        // 
+        // // all numbers in a column most appear in each column to the left
+        // wrong_mat = mat;
+        // wrong_mat(0, 0) = 4;
+        // EXPECT_ANY_THROW(RVineMatrix(wrong_mat));
     }
 }

--- a/test/src_test/include/test_vinecop_class.hpp
+++ b/test/src_test/include/test_vinecop_class.hpp
@@ -91,7 +91,8 @@ namespace test_vinecop_class {
             }
         }
         Eigen::Matrix<size_t, 2, 2> matrix;
-        matrix << 2,0,1,1;
+        matrix << 1, 1,
+                  2, 0;
         Vinecop vinecop(pair_copulas, matrix);
 
         // Test whether the analytic and simulated versions are "close" enough


### PR DESCRIPTION
re #186 

Added checks for several conditions that must be satisfied by an R-vine matrix. The checks are actually redundant, `check_upper_tri()`, `check_antidiagonal`, `check_columns()` are violated whenever `check_proximity_condition()` is, but I kept them to allow for more informative error messages. They could be ommited for sake of performance, which I haven't looked into so far.
