### PR TITLE
Flip + get/set_parameters for kernel bicop

### DIFF
--- a/include/vinecopulib/bicop/abstract.hpp
+++ b/include/vinecopulib/bicop/abstract.hpp
@@ -14,20 +14,6 @@
 
 namespace vinecopulib
 {
-    // Pre-declaration to allow AbtractBicop to befriend the two functions
-    namespace tools_optimization
-    {
-        // the objective function for maximum likelihood estimation
-        double mle_objective(const std::vector<double>& x,
-                             std::vector<double>& grad,
-                             void* data);
-
-        // the objective function for profile maximum likelihood estimation
-        double pmle_objective(const std::vector<double>& x,
-                              std::vector<double> &,
-                              void* data);
-    }
-    
     //! @brief An abstract class for bivariate copula families
     //!
     //! This class is used in the implementation underlying the Bicop class. 
@@ -36,10 +22,6 @@ namespace vinecopulib
     class AbstractBicop
     {
     friend class Bicop;
-    friend double tools_optimization::mle_objective(
-        const std::vector<double>& x, std::vector<double>& grad, void* data);
-    friend double tools_optimization::pmle_objective(
-        const std::vector<double>& x, std::vector<double>& grad, void* data);
     
     protected:
         // Factories
@@ -50,11 +32,9 @@ namespace vinecopulib
         // Getters and setters
         BicopFamily get_family() const;
         std::string get_family_name() const;
-        Eigen::MatrixXd get_parameters() const;
-        Eigen::MatrixXd get_parameters_lower_bounds() const;
-        Eigen::MatrixXd get_parameters_upper_bounds() const;
-        void set_parameters(const Eigen::MatrixXd& parameters);
-        void flip();
+        virtual Eigen::MatrixXd get_parameters() const;
+        virtual void set_parameters(const Eigen::MatrixXd& parameters);
+        virtual void flip();
 
         // Virtual methods
         virtual void fit(const Eigen::Matrix<double, Eigen::Dynamic, 2> &data,
@@ -83,15 +63,6 @@ namespace vinecopulib
 
         // Data members
         BicopFamily family_;
-        Eigen::MatrixXd parameters_;
-        Eigen::MatrixXd parameters_lower_bounds_;
-        Eigen::MatrixXd parameters_upper_bounds_;
-
-    private:
-        void check_parameters(const Eigen::MatrixXd& parameters);
-        void check_parameters_size(const Eigen::MatrixXd& parameters);
-        void check_parameters_upper(const Eigen::MatrixXd& parameters);
-        void check_parameters_lower(const Eigen::MatrixXd& parameters);
     };
     
     //! A shared pointer to an object of class AbstracBicop.

--- a/include/vinecopulib/bicop/abstract.hpp
+++ b/include/vinecopulib/bicop/abstract.hpp
@@ -32,9 +32,9 @@ namespace vinecopulib
         // Getters and setters
         BicopFamily get_family() const;
         std::string get_family_name() const;
-        virtual Eigen::MatrixXd get_parameters() const;
-        virtual void set_parameters(const Eigen::MatrixXd& parameters);
-        virtual void flip();
+        virtual Eigen::MatrixXd get_parameters() const = 0;
+        virtual void set_parameters(const Eigen::MatrixXd& parameters) = 0;
+        virtual void flip() = 0;
 
         // Virtual methods
         virtual void fit(const Eigen::Matrix<double, Eigen::Dynamic, 2> &data,

--- a/include/vinecopulib/bicop/kernel.hpp
+++ b/include/vinecopulib/bicop/kernel.hpp
@@ -53,6 +53,8 @@ namespace vinecopulib
         Eigen::MatrixXd tau_to_parameters(const double& tau);
         double calculate_npars();
 
+        Eigen::MatrixXd get_parameters() const;
+        void set_parameters(const Eigen::MatrixXd& parameters);
         void flip();
 
         tools_interpolation::InterpolationGrid interp_grid_;

--- a/include/vinecopulib/bicop/parametric.hpp
+++ b/include/vinecopulib/bicop/parametric.hpp
@@ -45,7 +45,6 @@ namespace vinecopulib
         void flip();
 
         // Data members
-        BicopFamily family_;
         Eigen::MatrixXd parameters_;
         Eigen::MatrixXd parameters_lower_bounds_;
         Eigen::MatrixXd parameters_upper_bounds_;

--- a/include/vinecopulib/bicop/parametric.hpp
+++ b/include/vinecopulib/bicop/parametric.hpp
@@ -10,6 +10,20 @@
 
 namespace vinecopulib
 {
+    // Pre-declaration to allow ParBicop to befriend the two functions
+    namespace tools_optimization
+    {
+        // the objective function for maximum likelihood estimation
+        double mle_objective(const std::vector<double>& x,
+                             std::vector<double>& grad,
+                             void* data);
+
+        // the objective function for profile maximum likelihood estimation
+        double pmle_objective(const std::vector<double>& x,
+                              std::vector<double> &,
+                              void* data);
+    }
+
     //! @brief An abstract class for parametric copula families
     //!
     //! This class is used in the implementation underlying the Bicop class. 
@@ -17,10 +31,34 @@ namespace vinecopulib
     //! always work with the Bicop interface.
     class ParBicop : public AbstractBicop
     {
+    friend double tools_optimization::mle_objective(
+        const std::vector<double>& x, std::vector<double>& grad, void* data);
+    friend double tools_optimization::pmle_objective(
+        const std::vector<double>& x, std::vector<double>& grad, void* data);
+
+    protected:
+        // Getters and setters
+        Eigen::MatrixXd get_parameters() const;
+        Eigen::MatrixXd get_parameters_lower_bounds() const;
+        Eigen::MatrixXd get_parameters_upper_bounds() const;
+        void set_parameters(const Eigen::MatrixXd& parameters);
+        void flip();
+
+        // Data members
+        BicopFamily family_;
+        Eigen::MatrixXd parameters_;
+        Eigen::MatrixXd parameters_lower_bounds_;
+        Eigen::MatrixXd parameters_upper_bounds_;
+
     private:
         void fit(const Eigen::Matrix<double, Eigen::Dynamic, 2>& data,
              std::string method, double);
         double calculate_npars();
         virtual Eigen::VectorXd get_start_parameters(const double tau) = 0;
+
+        void check_parameters(const Eigen::MatrixXd& parameters);
+        void check_parameters_size(const Eigen::MatrixXd& parameters);
+        void check_parameters_upper(const Eigen::MatrixXd& parameters);
+        void check_parameters_lower(const Eigen::MatrixXd& parameters);
     };
 }

--- a/include/vinecopulib/misc/tools_interpolation.hpp
+++ b/include/vinecopulib/misc/tools_interpolation.hpp
@@ -21,6 +21,8 @@ namespace tools_interpolation {
         InterpolationGrid() {}
         InterpolationGrid(const Eigen::VectorXd& grid_points, const Eigen::MatrixXd& values);
 
+        Eigen::MatrixXd get_values() const;
+        void set_values(const Eigen::MatrixXd& values);
         void flip();
 
         Eigen::VectorXd interpolate(const Eigen::MatrixXd& x);

--- a/src/bicop/abstract.cpp
+++ b/src/bicop/abstract.cpp
@@ -73,7 +73,6 @@ namespace vinecopulib
             case BicopFamily::tll0:
                 new_bicop =  BicopPtr(new Tll0Bicop());
                 break;
-
             default:
                 throw std::runtime_error(std::string("Family not implemented"));
         }
@@ -103,36 +102,8 @@ namespace vinecopulib
     {
         return vinecopulib::get_family_name(family_);
     };
-    
-    Eigen::MatrixXd AbstractBicop::get_parameters() const 
-    {
-        return parameters_;
-    }
-    
-    Eigen::MatrixXd AbstractBicop::get_parameters_lower_bounds() const 
-    {
-        return parameters_lower_bounds_;
-    }
-    
-    Eigen::MatrixXd AbstractBicop::get_parameters_upper_bounds() const 
-    {
-        return parameters_upper_bounds_;
-    }
-
-    void AbstractBicop::set_parameters(const Eigen::MatrixXd& parameters)
-    {
-        check_parameters(parameters);
-        parameters_ = parameters;
-    }
     //! @}
-    
-    //! Adjust the copula to flipped columns
-    void AbstractBicop::flip()
-    {
-        // Most parametric families can be flipped by changing the rotation. 
-        // This is done in Bicop::flip() directly. All other families need to
-        // override this method.
-    }
+
     
 
     //! Numerical inversion of h-functions
@@ -163,73 +134,5 @@ namespace vinecopulib
 
         return tools_eigen::invert_f(u.col(0), h1);
     }
-    //! @}
-
-    
-    //! Sanity checks
-    //! @{
-    void AbstractBicop::check_parameters(const Eigen::MatrixXd& parameters)
-    {
-        check_parameters_size(parameters);
-        check_parameters_lower(parameters);
-        check_parameters_upper(parameters);
-    }
-    
-    
-    void AbstractBicop::check_parameters_size(const Eigen::MatrixXd& parameters)
-    {
-        if (parameters.size() != parameters_.size()) {
-            if (parameters.rows() != parameters_.rows()) {
-                std::stringstream message;
-                message <<
-                    "parameters have has wrong number of rows " << 
-                    "for " << get_family_name() << " copula; " << 
-                    "expected: " << parameters_.rows() << ", " <<
-                    "actual: " << parameters.rows() << std::endl;
-                throw std::runtime_error(message.str().c_str());
-            }
-            if (parameters.cols() != parameters_.cols()) {
-                std::stringstream message;
-                message <<
-                    "parameters have wrong number of columns " << 
-                    "for " << get_family_name() << " copula; " << 
-                    "expected: " << parameters_.cols() << ", " <<
-                    "actual: " << parameters.cols() << std::endl;
-                throw std::runtime_error(message.str().c_str());
-            }
-        }
-    }
-    
-    
-    void AbstractBicop::check_parameters_lower(const Eigen::MatrixXd& parameters)
-    {
-        if (parameters_lower_bounds_.size() > 0) {
-            std::stringstream message;
-            if ((parameters.array() < parameters_lower_bounds_.array()).any()) {
-                message <<
-                    "parameters exceed lower bound " << 
-                    "for " << get_family_name() << " copula; " << std::endl << 
-                    "bound:" << std::endl << parameters_lower_bounds_ << std::endl <<
-                    "actual:" << std::endl << parameters << std::endl;
-                throw std::runtime_error(message.str().c_str());  
-            }
-        }
-    }
-    
-    void AbstractBicop::check_parameters_upper(const Eigen::MatrixXd& parameters)
-    {
-        if (parameters_upper_bounds_.size() > 0) {
-            std::stringstream message;
-            if ((parameters.array() > parameters_upper_bounds_.array()).any()) {
-                message <<
-                    "parameters exceed upper bound " << 
-                    "for " << get_family_name() << " copula; " << std::endl << 
-                    "bound:" << std::endl << parameters_upper_bounds_ << std::endl <<
-                    "actual:" << std::endl << parameters << std::endl;
-                throw std::runtime_error(message.str().c_str());  
-            }
-        }
-    }
-
     //! @}
 }

--- a/src/bicop/abstract.cpp
+++ b/src/bicop/abstract.cpp
@@ -23,7 +23,6 @@
 #include <vinecopulib/bicop/student.hpp>
 #include <vinecopulib/bicop/tll0.hpp>
 
-#include <iostream>
 namespace vinecopulib
 {
     //! Create a bivariate copula using the default contructor
@@ -36,24 +35,18 @@ namespace vinecopulib
     BicopPtr AbstractBicop::create(BicopFamily family,
                                    const Eigen::MatrixXd& parameters)
     {
-        std::cout << "create" << std::endl;
-        //std::cout << vinecopulib::get_family_name(family) << std::endl;
         BicopPtr new_bicop;
         switch (family) {
             case BicopFamily::indep:
-                std::cout << vinecopulib::get_family_name(family) << std::endl;
                 new_bicop = BicopPtr(new IndepBicop());
                 break;
             case BicopFamily::gaussian:
-                std::cout << vinecopulib::get_family_name(family) << std::endl;
                 new_bicop = BicopPtr(new GaussianBicop());
                 break;
             case BicopFamily::student:
-                std::cout << vinecopulib::get_family_name(family) << std::endl;
                 new_bicop = BicopPtr(new StudentBicop());
                 break;
             case BicopFamily::clayton:
-                std::cout << vinecopulib::get_family_name(family) << std::endl;
                 new_bicop = BicopPtr(new ClaytonBicop());
                 break;
             case BicopFamily::gumbel:
@@ -84,9 +77,6 @@ namespace vinecopulib
             default:
                 throw std::runtime_error(std::string("Family not implemented"));
         }
-
-        std::cout << "create2" << std::endl;
-        std::cout << new_bicop->get_family_name() << std::endl;
         
         if (parameters.size() > 0) {
             new_bicop->set_parameters(parameters);

--- a/src/bicop/abstract.cpp
+++ b/src/bicop/abstract.cpp
@@ -23,6 +23,7 @@
 #include <vinecopulib/bicop/student.hpp>
 #include <vinecopulib/bicop/tll0.hpp>
 
+#include <iostream>
 namespace vinecopulib
 {
     //! Create a bivariate copula using the default contructor
@@ -35,18 +36,24 @@ namespace vinecopulib
     BicopPtr AbstractBicop::create(BicopFamily family,
                                    const Eigen::MatrixXd& parameters)
     {
+        std::cout << "create" << std::endl;
+        //std::cout << vinecopulib::get_family_name(family) << std::endl;
         BicopPtr new_bicop;
         switch (family) {
             case BicopFamily::indep:
+                std::cout << vinecopulib::get_family_name(family) << std::endl;
                 new_bicop = BicopPtr(new IndepBicop());
                 break;
             case BicopFamily::gaussian:
+                std::cout << vinecopulib::get_family_name(family) << std::endl;
                 new_bicop = BicopPtr(new GaussianBicop());
                 break;
             case BicopFamily::student:
+                std::cout << vinecopulib::get_family_name(family) << std::endl;
                 new_bicop = BicopPtr(new StudentBicop());
                 break;
             case BicopFamily::clayton:
+                std::cout << vinecopulib::get_family_name(family) << std::endl;
                 new_bicop = BicopPtr(new ClaytonBicop());
                 break;
             case BicopFamily::gumbel:
@@ -73,9 +80,13 @@ namespace vinecopulib
             case BicopFamily::tll0:
                 new_bicop =  BicopPtr(new Tll0Bicop());
                 break;
+
             default:
                 throw std::runtime_error(std::string("Family not implemented"));
         }
+
+        std::cout << "create2" << std::endl;
+        std::cout << new_bicop->get_family_name() << std::endl;
         
         if (parameters.size() > 0) {
             new_bicop->set_parameters(parameters);

--- a/src/bicop/class.cpp
+++ b/src/bicop/class.cpp
@@ -325,7 +325,7 @@ namespace vinecopulib
                 set_rotation(90);
             }
         } else {
-            bicop_->flip();    
+            bicop_->flip();
         }
     }
     

--- a/src/bicop/class.cpp
+++ b/src/bicop/class.cpp
@@ -31,6 +31,8 @@ namespace vinecopulib
     {
         bicop_ = AbstractBicop::create(family, parameters);
         // family must be set before checking the rotation
+        std::cout << "Bicop" << std::endl;
+        std::cout << get_family_name() << std::endl;
         set_rotation(rotation);
     }
     
@@ -528,6 +530,8 @@ namespace vinecopulib
     
     void Bicop::check_rotation(int rotation)
     {
+        std::cout << "check" << std::endl;
+        std::cout << get_family_name() << std::endl;
         using namespace tools_stl;
         std::vector<int> allowed_rotations = {0, 90, 180, 270};
         if (!is_member(rotation, allowed_rotations)) {

--- a/src/bicop/class.cpp
+++ b/src/bicop/class.cpp
@@ -31,11 +31,9 @@ namespace vinecopulib
     {
         bicop_ = AbstractBicop::create(family, parameters);
         // family must be set before checking the rotation
-        std::cout << "Bicop" << std::endl;
-        std::cout << get_family_name() << std::endl;
         set_rotation(rotation);
     }
-    
+
     //! equivalent to `Bicop cop; cop.select(data, controls)`.
     //! @param data see select().
     //! @param controls see select().
@@ -87,7 +85,7 @@ namespace vinecopulib
         }
     }
 
-    //! calculates the first h-function, i.e., 
+    //! calculates the first h-function, i.e.,
     //! \f$ h_1(u_1, u_2) = \int_0^{u_2} c(u_1, s) \f$.
     //! @param u \f$m \times 2\f$ matrix of evaluation points.
     Eigen::VectorXd Bicop::hfunc1(const Eigen::Matrix<double, Eigen::Dynamic, 2>& u)
@@ -112,7 +110,7 @@ namespace vinecopulib
         }
     }
 
-    //! calculates the second h-function, i.e., 
+    //! calculates the second h-function, i.e.,
     //! \f$ h_2(u_1, u_2) = \int_0^{u_1} c(s, u_2) \f$.
     //! @param u \f$m \times 2\f$ matrix of evaluation points.
     Eigen::VectorXd Bicop::hfunc2(const Eigen::Matrix<double, Eigen::Dynamic, 2>& u)
@@ -137,7 +135,7 @@ namespace vinecopulib
         }
     }
 
-    //! calculates the inverse of \f$ h_1 f\f$ (see hfunc1()) w.r.t. the second 
+    //! calculates the inverse of \f$ h_1 f\f$ (see hfunc1()) w.r.t. the second
     //! argument.
     //! @param u \f$m \times 2\f$ matrix of evaluation points.
     Eigen::VectorXd Bicop::hinv1(const Eigen::Matrix<double, Eigen::Dynamic, 2>& u)
@@ -162,7 +160,7 @@ namespace vinecopulib
         }
     }
 
-    //! calculates the inverse of \f$ h_2 f\f$ (see hfunc2()) w.r.t. the first 
+    //! calculates the inverse of \f$ h_2 f\f$ (see hfunc2()) w.r.t. the first
     //! argument.
     //! @param u \f$m \times 2\f$ matrix of evaluation points.
     Eigen::VectorXd Bicop::hinv2(const Eigen::Matrix<double, Eigen::Dynamic, 2>& u)
@@ -188,7 +186,7 @@ namespace vinecopulib
     }
     //! @}
 
-    
+
     //! simulates from a bivariate copula.
     //!
     //! @param n number of observations.
@@ -203,11 +201,11 @@ namespace vinecopulib
     }
 
     //! calculates the log-likelihood.
-    //! 
+    //!
     //! The log-likelihood is defined as
     //! \f[ \mathrm{loglik} = \sum_{i = 1}^n \ln c(U_{1, i}, U_{2, i}), \f]
     //! where \f$ c \f$ is the copula density pdf().
-    //! 
+    //!
     //! @param u \f$n \times 2\f$ matrix of observations.
     double Bicop::loglik(const Eigen::Matrix<double, Eigen::Dynamic, 2>& u)
     {
@@ -215,14 +213,14 @@ namespace vinecopulib
     }
 
     //! calculates the Akaike information criterion (AIC).
-    //! 
+    //!
     //! The AIC is defined as
     //! \f[ \mathrm{AIC} = -2\, \mathrm{loglik} + 2 p, \f]
-    //! where \f$ \mathrm{loglik} \f$ is the log-liklihood and \f$ p \f$ is the 
-    //! (effective) number of parameters of the model, see loglik() and 
-    //! calculate_npars(). The AIC is a consistent model selection criterion 
+    //! where \f$ \mathrm{loglik} \f$ is the log-liklihood and \f$ p \f$ is the
+    //! (effective) number of parameters of the model, see loglik() and
+    //! calculate_npars(). The AIC is a consistent model selection criterion
     //! for nonparametric models.
-    //! 
+    //!
     //! @param u \f$n \times 2\f$ matrix of observations.
     double Bicop::aic(const Eigen::Matrix<double, Eigen::Dynamic, 2>& u)
     {
@@ -230,33 +228,33 @@ namespace vinecopulib
     }
 
     //! calculates the Bayesian information criterion (BIC).
-    //! 
+    //!
     //! The BIC is defined as
     //! \f[ \mathrm{BIC} = -2\, \mathrm{loglik} +  \ln(n) p, \f]
-    //! where \f$ \mathrm{loglik} \f$ is the log-liklihood and \f$ p \f$ is the 
-    //! (effective) number of parameters of the model, see loglik() and 
-    //! calculate_npars(). The BIC is a consistent model selection criterion 
+    //! where \f$ \mathrm{loglik} \f$ is the log-liklihood and \f$ p \f$ is the
+    //! (effective) number of parameters of the model, see loglik() and
+    //! calculate_npars(). The BIC is a consistent model selection criterion
     //! for nonparametric models.
-    //! 
+    //!
     //! @param u \f$n \times 2\f$ matrix of observations.
     double Bicop::bic(const Eigen::Matrix<double, Eigen::Dynamic, 2>& u)
     {
         return -2 * loglik(u) + calculate_npars() * log(u.rows());
     }
-    
+
     //! calculates the effective number of parameters.
-    //! 
-    //! Returns the actual number of parameters for parameteric families. For 
-    //! nonparametric families, there is a conceptually similar definition in 
+    //!
+    //! Returns the actual number of parameters for parameteric families. For
+    //! nonparametric families, there is a conceptually similar definition in
     //! the sense that it can be used in the calculation of fit statistics.
     double Bicop::calculate_npars()
     {
         return bicop_->calculate_npars();
     }
-        
-    //! converts a Kendall's \f$ \tau \f$ to the copula parameters of the 
+
+    //! converts a Kendall's \f$ \tau \f$ to the copula parameters of the
     //! current family (only works for one-parameter families).
-    //! 
+    //!
     //! @param tau a value in \f$ (-1, 1) \f$.
     Eigen::MatrixXd Bicop::tau_to_parameters(const double& tau)
     {
@@ -264,8 +262,8 @@ namespace vinecopulib
     }
 
     //! converts the parameters to the Kendall's \f$ tau \f$ for the current
-    //! family (works for all families but `BicopFamily::tll0`). 
-    //! 
+    //! family (works for all families but `BicopFamily::tll0`).
+    //!
     //! @param parameters the parameters (must be a valid parametrization of
     //!     the current family).
     double Bicop::parameters_to_tau(const Eigen::VectorXd& parameters)
@@ -276,44 +274,44 @@ namespace vinecopulib
         }
         return tau;
     }
-    
+
     //! @name Getters and setters
-    //! 
+    //!
     //! @{
-    BicopFamily Bicop::get_family() const 
+    BicopFamily Bicop::get_family() const
     {
         return bicop_->get_family();
     }
-    
-    std::string Bicop::get_family_name() const 
+
+    std::string Bicop::get_family_name() const
     {
         return bicop_->get_family_name();
     };
-    
+
     int Bicop::get_rotation() const
     {
         return rotation_;
     }
-    
-    Eigen::MatrixXd Bicop::get_parameters() const 
+
+    Eigen::MatrixXd Bicop::get_parameters() const
     {
         return bicop_->get_parameters();
     }
-    
-    //! @param rotation 
+
+    //! @param rotation
     void Bicop::set_rotation(int rotation) {
         check_rotation(rotation);
         rotation_ = rotation;
     }
-    
-    //! @param parameters 
+
+    //! @param parameters
     void Bicop::set_parameters(const Eigen::MatrixXd& parameters)
     {
         bicop_->set_parameters(parameters);
     }
     //! @}
-    
-    
+
+
     //! @name Utilities
     //! @{
     //! adjust's the copula model to a change in the variable order.
@@ -330,7 +328,7 @@ namespace vinecopulib
             bicop_->flip();
         }
     }
-    
+
     //! summarizes the model into a string (can be used for printing).
     std::string Bicop::str()
     {
@@ -347,19 +345,19 @@ namespace vinecopulib
     {
         return bicop_;
     };
-    
-    
+
+
 
     //! fits a bivariate copula (with fixed family) to data.
-    //! 
+    //!
     //! For parametric models, two different methods are available. `"mle"` fits
-    //! the parameters by maximum-likelihood. `"itau"` uses inversion of 
+    //! the parameters by maximum-likelihood. `"itau"` uses inversion of
     //! Kendall's \f$ \tau \f$, but is only available for one-parameter families
-    //! and the Student t copula. For the latter, there is a one-to-one 
+    //! and the Student t copula. For the latter, there is a one-to-one
     //! transformation for the first parameter, the second is found by profile
     //! likelihood optimization (with accuracy of at least 0.5). Nonparametric
     //! families have specialized methods, no specification is required.
-    //! 
+    //!
     //! @param data an \f$ n \times 2 \f$ matrix of observations contained in
     //!     \f$(0, 1)^2 \f$.
     //! @param controls the controls (see FitControlsBicop).
@@ -370,12 +368,12 @@ namespace vinecopulib
         bicop_->fit(cut_and_rotate(data), controls.get_parametric_method(),
                     controls.get_nonparametric_mult());
     }
-    
+
     //! selects the best fitting model.
-    //! 
+    //!
     //! The function calls fit() for all families in `family_set`)  and selects
     //! the best fitting model by either BIC or AIC, see bic() and aic().
-    //! 
+    //!
     //! @param data an \f$ n \times 2 \f$ matrix of observations contained in
     //!     \f$(0, 1)^2 \f$.
     //! @param controls the controls (see FitControlsBicop).
@@ -483,11 +481,11 @@ namespace vinecopulib
                 fitted_rotation = rotation_;
             }
         }
-        
+
         bicop_ = fitted_bicop;
         rotation_ = fitted_rotation;
     }
-    
+
     //! Data manipulations for rotated families
     //!
     //! @param u \f$m \times 2\f$ matrix of data.
@@ -520,18 +518,16 @@ namespace vinecopulib
         }
 
         // truncate to interval [eps, 1 - eps]
-        Eigen::Matrix<double, Eigen::Dynamic, 2> eps = 
+        Eigen::Matrix<double, Eigen::Dynamic, 2> eps =
             Eigen::Matrix<double, Eigen::Dynamic, 2>::Constant(u.rows(), 2, 1e-10);
         u_new = u_new.array().min(1.0 - eps.array());
         u_new = u_new.array().max(eps.array());
 
         return u_new;
     }
-    
+
     void Bicop::check_rotation(int rotation)
     {
-        std::cout << "check" << std::endl;
-        std::cout << get_family_name() << std::endl;
         using namespace tools_stl;
         std::vector<int> allowed_rotations = {0, 90, 180, 270};
         if (!is_member(rotation, allowed_rotations)) {

--- a/src/bicop/kernel.cpp
+++ b/src/bicop/kernel.cpp
@@ -6,7 +6,6 @@
 
 #include <vinecopulib/bicop/kernel.hpp>
 #include <vinecopulib/misc/tools_stats.hpp>
-#include <iostream>
 
 namespace vinecopulib
 {

--- a/src/bicop/kernel.cpp
+++ b/src/bicop/kernel.cpp
@@ -6,6 +6,7 @@
 
 #include <vinecopulib/bicop/kernel.hpp>
 #include <vinecopulib/misc/tools_stats.hpp>
+#include <iostream>
 
 namespace vinecopulib
 {
@@ -18,7 +19,7 @@ namespace vinecopulib
              grid_points(i) = - 3.25 + i * (6.25 / (double) m);
          interp_grid_ = tools_interpolation::InterpolationGrid(
              tools_stats::pnorm(grid_points), 
-             Eigen::MatrixXd::Constant(30, 30, 1.0)  // independence
+             Eigen::MatrixXd::Constant(m, m, 1.0)  // independence
          );
      }
 
@@ -70,6 +71,21 @@ namespace vinecopulib
     double KernelBicop::calculate_npars()
     {
         return npars_;
+    }
+
+    Eigen::MatrixXd KernelBicop::get_parameters() const
+    {
+        return interp_grid_.get_values();
+    }
+
+    void KernelBicop::set_parameters(const Eigen::MatrixXd& parameters)
+    {
+        if (parameters.minCoeff() < 0 ) {
+            std::stringstream message;
+            message << "density should be larger than 0. ";
+            throw std::runtime_error(message.str().c_str());
+        }
+        interp_grid_.set_values(parameters);
     }
 
     void KernelBicop::flip()

--- a/src/bicop/parametric.cpp
+++ b/src/bicop/parametric.cpp
@@ -11,6 +11,34 @@
 
 namespace vinecopulib
 {
+    Eigen::MatrixXd ParBicop::get_parameters() const
+    {
+        return parameters_;
+    }
+
+    Eigen::MatrixXd ParBicop::get_parameters_lower_bounds() const
+    {
+        return parameters_lower_bounds_;
+    }
+
+    Eigen::MatrixXd ParBicop::get_parameters_upper_bounds() const
+    {
+        return parameters_upper_bounds_;
+    }
+
+    void ParBicop::set_parameters(const Eigen::MatrixXd& parameters)
+    {
+        check_parameters(parameters);
+        parameters_ = parameters;
+    }
+
+    void ParBicop::flip()
+    {
+        // Most parametric families can be flipped by changing the rotation.
+        // This is done in Bicop::flip() directly. All other families need to
+        // override this method.
+    }
+    
     // calculate number of parameters
     double ParBicop::calculate_npars() {
         // indepence copula has no parameters
@@ -86,6 +114,73 @@ namespace vinecopulib
             set_parameters(newpar);
         }
     }
+
+    //! Sanity checks
+    //! @{
+    void ParBicop::check_parameters(const Eigen::MatrixXd& parameters)
+    {
+        check_parameters_size(parameters);
+        check_parameters_lower(parameters);
+        check_parameters_upper(parameters);
+    }
+
+
+    void ParBicop::check_parameters_size(const Eigen::MatrixXd& parameters)
+    {
+        if (parameters.size() != parameters_.size()) {
+            if (parameters.rows() != parameters_.rows()) {
+                std::stringstream message;
+                message <<
+                        "parameters have has wrong number of rows " <<
+                        "for " << get_family_name() << " copula; " <<
+                        "expected: " << parameters_.rows() << ", " <<
+                        "actual: " << parameters.rows() << std::endl;
+                throw std::runtime_error(message.str().c_str());
+            }
+            if (parameters.cols() != parameters_.cols()) {
+                std::stringstream message;
+                message <<
+                        "parameters have wrong number of columns " <<
+                        "for " << get_family_name() << " copula; " <<
+                        "expected: " << parameters_.cols() << ", " <<
+                        "actual: " << parameters.cols() << std::endl;
+                throw std::runtime_error(message.str().c_str());
+            }
+        }
+    }
+
+
+    void ParBicop::check_parameters_lower(const Eigen::MatrixXd& parameters)
+    {
+        if (parameters_lower_bounds_.size() > 0) {
+            std::stringstream message;
+            if ((parameters.array() < parameters_lower_bounds_.array()).any()) {
+                message <<
+                        "parameters exceed lower bound " <<
+                        "for " << get_family_name() << " copula; " << std::endl <<
+                        "bound:" << std::endl << parameters_lower_bounds_ << std::endl <<
+                        "actual:" << std::endl << parameters << std::endl;
+                throw std::runtime_error(message.str().c_str());
+            }
+        }
+    }
+
+    void ParBicop::check_parameters_upper(const Eigen::MatrixXd& parameters)
+    {
+        if (parameters_upper_bounds_.size() > 0) {
+            std::stringstream message;
+            if ((parameters.array() > parameters_upper_bounds_.array()).any()) {
+                message <<
+                        "parameters exceed upper bound " <<
+                        "for " << get_family_name() << " copula; " << std::endl <<
+                        "bound:" << std::endl << parameters_upper_bounds_ << std::endl <<
+                        "actual:" << std::endl << parameters << std::endl;
+                throw std::runtime_error(message.str().c_str());
+            }
+        }
+    }
+
+    //! @}
     
 }
 

--- a/src/misc/tools_interpolation.cpp
+++ b/src/misc/tools_interpolation.cpp
@@ -35,6 +35,35 @@ namespace tools_interpolation {
         values_ = values;
     }
 
+    Eigen::MatrixXd InterpolationGrid::get_values() const
+    {
+        return values_;
+    }
+
+    void InterpolationGrid::set_values(const Eigen::MatrixXd& values)
+    {
+        if (values.size() != values_.size()) {
+            if (values.rows() != values_.rows()) {
+                std::stringstream message;
+                message <<
+                        "values have has wrong number of rows; " <<
+                        "expected: " << values_.rows() << ", " <<
+                        "actual: " << values.rows() << std::endl;
+                throw std::runtime_error(message.str().c_str());
+            }
+            if (values.cols() != values_.cols()) {
+                std::stringstream message;
+                message <<
+                        "values have wrong number of columns; " <<
+                        "expected: " << values_.cols() << ", " <<
+                        "actual: " << values.cols() << std::endl;
+                throw std::runtime_error(message.str().c_str());
+            }
+        }
+
+        values_ = values;
+    }
+
     void InterpolationGrid::flip()
     {
         values_.transposeInPlace();

--- a/test/src_test/include/parbicop_test.hpp
+++ b/test/src_test/include/parbicop_test.hpp
@@ -38,10 +38,6 @@ protected:
         if (tools_stl::is_member(family, bicop_families::rotationless)) {
             bicop_ = Bicop(family);
         } else {
-            std::cout << "here" << std::endl;
-            std::cout << get_family_name(family) << std::endl;
-            std::cout << rotation << std::endl;
-            std::cout << "here2" << std::endl;
             bicop_ = Bicop(family, rotation);
         }
 

--- a/test/src_test/include/parbicop_test.hpp
+++ b/test/src_test/include/parbicop_test.hpp
@@ -38,6 +38,10 @@ protected:
         if (tools_stl::is_member(family, bicop_families::rotationless)) {
             bicop_ = Bicop(family);
         } else {
+            std::cout << "here" << std::endl;
+            std::cout << get_family_name(family) << std::endl;
+            std::cout << rotation << std::endl;
+            std::cout << "here2" << std::endl;
             bicop_ = Bicop(family, rotation);
         }
 

--- a/test/src_test/include/test_bicop_kernel.hpp
+++ b/test/src_test/include/test_bicop_kernel.hpp
@@ -11,6 +11,13 @@
 namespace test_bicop_kernel {
     using namespace vinecopulib;
 
+    TEST_F(TrafokernelTest, trafo_kernel_sanity_checks) {
+        auto values = bicop_.get_parameters();
+        EXPECT_ANY_THROW(bicop_.set_parameters(values.block(0,0,30,1)));
+        EXPECT_ANY_THROW(bicop_.set_parameters(values.block(0,0,1,30)));
+        EXPECT_ANY_THROW(bicop_.set_parameters(-1*values));
+    }
+
     TEST_F(TrafokernelTest, trafo_kernel_fit) {
         bicop_.fit(u);
     }


### PR DESCRIPTION
Note: unit tests are coming but I'll finish them tomorrow morning!

Before merging to dev  (and then releasing 0.0.3 to master), we should probably discuss the organization of the documentation.

I noticed that the non-virtual method of AbstractBicop were documented, but the non-virtual methods of derived classes (e.g. ParBicop and KernelBicop) were not. In my opinion, we should either document all of them or none. 

Also, looking at the current documentation (e.g. https://vinecopulib.github.io/vinecopulib/classvinecopulib_1_1_abstract_bicop.html), I think that it's a bit messy (what is documented and what isn't).

