### PR TITLE
Ensure valid starting parameters in Bicop::fit (fixes #209)

### DIFF
--- a/src/bicop/parametric.cpp
+++ b/src/bicop/parametric.cpp
@@ -8,6 +8,7 @@
 #include <vinecopulib/misc/tools_optimization.hpp>
 #include <vinecopulib/misc/tools_stl.hpp>
 #include <vinecopulib/misc/tools_stats.hpp>
+#include <iostream>
 
 namespace vinecopulib
 {
@@ -72,13 +73,6 @@ namespace vinecopulib
 
             auto temp_data = data;
             double tau = tools_stats::pairwise_ktau(temp_data);
-            double sign = 1.0;
-            if (tau < 0) sign = -1.0;
-            if (std::abs(tau) < 0.01) {
-                tau = 0.01 * sign;
-            } else if (std::abs(1.0 - tau) < 0.01) {
-                tau = 0.9 * sign;
-            }
             auto newpar = get_start_parameters(tau);
             if (npars > 0) {
                 // Create optimizer
@@ -87,8 +81,19 @@ namespace vinecopulib
                 // Set bounds and starting values
                 auto lb = get_parameters_lower_bounds();
                 auto ub = get_parameters_upper_bounds();
-                auto initial_parameters = newpar;
-                ParBicopOptData my_data = {temp_data, this, newpar(0), 0};
+                
+                // ensure that starting values are sufficiently separated from 
+                // bounds
+                double sign = 1.0;
+                if (tau < 0) sign = -1.0;
+                if (std::abs(tau) < 0.01) {
+                    tau = 0.01 * sign;
+                } else if (std::abs(tau) > 0.9) {
+                    tau = 0.9 * sign;
+                }
+                auto initial_parameters = get_start_parameters(tau);
+                
+                ParBicopOptData my_data = {temp_data, this, initial_parameters(0), 0};
                 if (method == "itau") {
                       lb.resize(1, 1);
                       lb(0) = get_parameters_lower_bounds()(1);

--- a/src/bicop/parametric.cpp
+++ b/src/bicop/parametric.cpp
@@ -72,12 +72,12 @@ namespace vinecopulib
 
             auto temp_data = data;
             double tau = tools_stats::pairwise_ktau(temp_data);
+            double sign = 1.0;
+            if (tau < 0) sign = -1.0;
             if (std::abs(tau) < 0.01) {
-                tau = 0.01;
-                if (tau < 0) tau *= -1.0;
+                tau = 0.01 * sign;
             } else if (std::abs(1.0 - tau) < 0.01) {
-                tau = 0.9;
-                if (tau < 0) tau *= -1.0;
+                tau = 0.9 * sign;
             }
             auto newpar = get_start_parameters(tau);
             if (npars > 0) {

--- a/src/bicop/parametric.cpp
+++ b/src/bicop/parametric.cpp
@@ -72,6 +72,13 @@ namespace vinecopulib
 
             auto temp_data = data;
             double tau = tools_stats::pairwise_ktau(temp_data);
+            if (std::abs(tau) < 0.01) {
+                tau = 0.01;
+                if (tau < 0) tau *= -1.0;
+            } else if (std::abs(1.0 - tau) < 0.01) {
+                tau = 0.9;
+                if (tau < 0) tau *= -1.0;
+            }
             auto newpar = get_start_parameters(tau);
             if (npars > 0) {
                 // Create optimizer


### PR DESCRIPTION
The absolute Kendall's tau needs to be truncated from above and below for setting the starting parameters.