### PR TITLE
Refactor sparse select fix

### DIFF
--- a/include/vinecopulib/misc/tools_stl.hpp
+++ b/include/vinecopulib/misc/tools_stl.hpp
@@ -52,21 +52,6 @@ namespace tools_stl {
     }
 
     template<class T>
-    vector<T> set_sym_diff(vector<T> x, vector<T> y)
-    {
-        sort(x.begin(), x.end());
-        sort(y.begin(), y.end());
-        vector<T> different;
-        set_symmetric_difference(
-                x.begin(), x.end(),
-                y.begin(), y.end(),
-                back_inserter(different)
-        );
-
-        return different;
-    }
-
-    template<class T>
     size_t find_position(T x, vector<T> vec)
     {
         return distance(vec.begin(), find(vec.begin(), vec.end(), x));
@@ -103,6 +88,14 @@ namespace tools_stl {
         out.reserve(1 + y.size());
         out.insert(out.end(), y.begin(), y.end());
         return out;
+    }
+    
+    template<class T>
+    vector<T> set_sym_diff(vector<T> x, vector<T> y)
+    {
+        vector<T> dxy = set_diff(x, y);
+        auto dyx = set_diff(y, x);
+        return cat(dxy, dyx);
     }
 
     template<class T>

--- a/include/vinecopulib/vinecop/rvine_matrix.hpp
+++ b/include/vinecopulib/vinecop/rvine_matrix.hpp
@@ -76,8 +76,8 @@ namespace vinecopulib
 
         static Eigen::Matrix<size_t, Eigen::Dynamic, Eigen::Dynamic> 
         construct_d_vine_matrix(const Eigen::Matrix<size_t, Eigen::Dynamic, 1>& order);
-        bool belong_to_structure(const std::vector<size_t> conditioned,
-                                 const std::vector<size_t> conditioning);
+        bool belongs_to_structure(const std::vector<size_t> conditioned,
+                                  const std::vector<size_t> conditioning);
 
     private:
         void check_if_quadratic() const;

--- a/include/vinecopulib/vinecop/tools_select.hpp
+++ b/include/vinecopulib/vinecop/tools_select.hpp
@@ -83,7 +83,7 @@ namespace tools_select {
         //! selects tree of vine copula, assuming all previous trees have 
         //! been fit.
         void select_tree(size_t t);
-        void finalize();
+        virtual void finalize() = 0;
 
         double get_loglik_of_tree(size_t t);
         double get_npars_of_tree(size_t t);
@@ -134,6 +134,7 @@ namespace tools_select {
         
     private:
         void add_allowed_edges(VineTree& tree);
+        void finalize();
     };
 
     class FamilySelector : public VinecopSelector
@@ -149,6 +150,7 @@ namespace tools_select {
         void add_allowed_edges(VineTree& tree);
         bool belongs_to_structure(size_t v0, size_t v1, 
                                   const VineTree& vine_tree);
+        void finalize();
     };
     
 }

--- a/include/vinecopulib/vinecop/tools_select.hpp
+++ b/include/vinecopulib/vinecop/tools_select.hpp
@@ -35,6 +35,7 @@ namespace tools_select {
     struct VertexProperties {
         std::vector<size_t> conditioning;
         std::vector<size_t> conditioned;
+        std::vector<size_t> all_indices;
         std::vector<size_t> prev_edge_indices;
         Eigen::VectorXd hfunc1;
         Eigen::VectorXd hfunc2;
@@ -147,9 +148,8 @@ namespace tools_select {
         RVineMatrix vine_matrix_;
         bool v0_;
         void add_allowed_edges(VineTree& tree);
-        bool belong_to_structure(size_t v0, size_t v1,
-                                 const VineTree& vine_tree,
-                                 const RVineMatrix& vine_matrix);
+        bool belong_to_structure(size_t v0, size_t v1, 
+                                 const VineTree& vine_tree);
     };
     
 }

--- a/include/vinecopulib/vinecop/tools_select.hpp
+++ b/include/vinecopulib/vinecop/tools_select.hpp
@@ -147,8 +147,8 @@ namespace tools_select {
     private:
         RVineMatrix vine_matrix_;
         void add_allowed_edges(VineTree& tree);
-        bool belong_to_structure(size_t v0, size_t v1, 
-                                 const VineTree& vine_tree);
+        bool belongs_to_structure(size_t v0, size_t v1, 
+                                  const VineTree& vine_tree);
     };
     
 }

--- a/include/vinecopulib/vinecop/tools_select.hpp
+++ b/include/vinecopulib/vinecop/tools_select.hpp
@@ -146,7 +146,6 @@ namespace tools_select {
 
     private:
         RVineMatrix vine_matrix_;
-        bool v0_;
         void add_allowed_edges(VineTree& tree);
         bool belong_to_structure(size_t v0, size_t v1, 
                                  const VineTree& vine_tree);

--- a/src/vinecop/rvine_matrix.cpp
+++ b/src/vinecop/rvine_matrix.cpp
@@ -97,12 +97,11 @@ namespace vinecopulib
         bool res = false;
         if (tree + 2 <= d_) {
             for (size_t i = 0; i < d_ - tree - 1; ++i) {
-                conditioned_test[0] = matrix_(tree, i);
-                conditioned_test[1] = matrix_(d_ - 1 - i, i);
-                bool conditioned_ok = tools_stl::is_same_set(conditioned,
-                                                             conditioned_test);
+                conditioned_test[0] = matrix_(d_ - 1 - i, i);
+                conditioned_test[1] = matrix_(tree, i);
+                bool conditioned_ok = (conditioned == conditioned_test);
                 if (conditioned_ok) {
-                    auto cond = matrix_.block(0, i, tree, 1);
+                    auto cond = matrix_.col(i).head(tree);
                     Eigen::Matrix<size_t, Eigen::Dynamic, 1>::Map(&conditioning_test[0], tree) = cond;
                     res = tools_stl::is_same_set(conditioning,
                                                  conditioning_test);

--- a/src/vinecop/rvine_matrix.cpp
+++ b/src/vinecop/rvine_matrix.cpp
@@ -85,8 +85,8 @@ namespace vinecopulib
     //!
     //! @param conditioned the conditioned set.
     //! @param conditioning the conditioning set.
-    bool RVineMatrix::belong_to_structure(const std::vector<size_t> conditioned,
-                                          const std::vector<size_t> conditioning) {
+    bool RVineMatrix::belongs_to_structure(const std::vector<size_t> conditioned,
+                                           const std::vector<size_t> conditioning) {
         if (conditioned.size() != 2) {
             throw std::runtime_error("conditioned should have size 2 ");
         }
@@ -103,8 +103,7 @@ namespace vinecopulib
                 if (conditioned_ok) {
                     auto cond = matrix_.col(i).head(tree);
                     Eigen::Matrix<size_t, Eigen::Dynamic, 1>::Map(&conditioning_test[0], tree) = cond;
-                    res = tools_stl::is_same_set(conditioning,
-                                                 conditioning_test);
+                    res = tools_stl::is_same_set(conditioning, conditioning_test);
                 }
 
                 if (res)

--- a/src/vinecop/tools_select.cpp
+++ b/src/vinecop/tools_select.cpp
@@ -347,8 +347,8 @@ namespace tools_select {
         for (auto v0 : boost::vertices(vine_tree)) {
             for (auto v1 : boost::vertices(vine_tree)) {
                 if (v0 == v1) continue;
-                // check proximity condition: common neighbor in previous tree
-                // (-1 means 'no common neighbor')
+                // check whether edege (v0, v1) belongs to the structure
+                // given in rvine_matrix_
                 if (belongs_to_structure(v0, v1, vine_tree)) {
                     Eigen::MatrixXd pc_data;
                     boost::graph_traits<VineTree>::edge_descriptor e;
@@ -369,7 +369,7 @@ namespace tools_select {
     //! @return The pseudo-observations for the pair coula, extracted from
     //!     the h-functions calculated in the previous tree.
     Eigen::MatrixXd VinecopSelector::get_pc_data(size_t v0, size_t v1,
-                                                   const VineTree& tree)
+                                                 const VineTree& tree)
     {
         Eigen::MatrixXd pc_data(tree[v0].hfunc1.size(), 2);
         size_t ei_common = find_common_neighbor(v0, v1, tree);
@@ -438,12 +438,12 @@ namespace tools_select {
             pair_copulas_[t - 1][col] = trees_[t][e0].pair_copula;
     
             // initialize running set with full conditioing set of this edge
-            auto ned_set = trees_[t][e0].conditioning;
+            auto ning_set = trees_[t][e0].conditioning;
     
             // iteratively search for an edge in lower tree that shares all 
             // indices in the conditioned set + diagonal entry
             for (size_t k = 1; k < t; ++k) {
-                auto reduced_set = cat(mat(t, col), ned_set);
+                auto reduced_set = cat(mat(t, col), ning_set);
                 for (auto e : boost::edges(trees_[t - k])) {
                     if (is_same_set(trees_[t - k][e].all_indices, reduced_set)) {
                         // next matrix entry is conditioned variable of new edge
@@ -461,7 +461,7 @@ namespace tools_select {
                         pair_copulas_[t - 1 - k][col] = e_new.pair_copula;
     
                         // start over with conditioned set of next edge
-                        ned_set = e_new.conditioning;
+                        ning_set = e_new.conditioning;
     
                         // remove edge (must not be reused in another column!)
                         size_t v0 = boost::source(e, trees_[t - k]);

--- a/src/vinecop/tools_select.cpp
+++ b/src/vinecop/tools_select.cpp
@@ -585,6 +585,7 @@ namespace tools_select {
             base_tree[e].conditioned.reserve(2);
             base_tree[e].conditioned.push_back(boost::target(e, base_tree));
             base_tree[e].conditioning.reserve(d - 2);
+            base_tree[e].all_indices = base_tree[e].conditioned;
         }
     
         return base_tree;
@@ -612,6 +613,7 @@ namespace tools_select {
             new_tree[i].hfunc2 = prev_tree[e].hfunc2;
             new_tree[i].conditioned = prev_tree[e].conditioned;
             new_tree[i].conditioning = prev_tree[e].conditioning;
+            new_tree[i].all_indices = prev_tree[e].all_indices;
             new_tree[i].prev_edge_indices.reserve(2);
             new_tree[i].prev_edge_indices.push_back(boost::source(e, prev_tree));
             new_tree[i].prev_edge_indices.push_back(boost::target(e, prev_tree));
@@ -669,17 +671,11 @@ namespace tools_select {
         for (auto e : boost::edges(tree)) {
             auto v0 = boost::source(e, tree);
             auto v1 = boost::target(e, tree);
-            tree[e].pc_data = get_pc_data(v0, v1, tree);
-    
-            auto v0_indices = cat(tree[v0].conditioned, tree[v0].conditioning);
-            auto v1_indices = cat(tree[v1].conditioned, tree[v1].conditioning);
-    
-            auto test = intersect(v0_indices, v1_indices);
-            auto d01 = set_diff(v0_indices, v1_indices);
-            auto d10 = set_diff(v1_indices, v0_indices);
-    
-            tree[e].conditioned = cat(d01, d10);
-            tree[e].conditioning = intersect(v0_indices, v1_indices);
+            tree[e].pc_data = get_pc_data(v0, v1, tree);        
+            tree[e].conditioned = set_sym_diff(tree[v0].all_indices,
+                                               tree[v1].all_indices);
+            tree[e].conditioning = intersect(tree[v0].all_indices,
+                                             tree[v1].all_indices);
             tree[e].all_indices = cat(tree[e].conditioned, tree[e].conditioning);
         }
     }

--- a/src/vinecop/tools_select.cpp
+++ b/src/vinecop/tools_select.cpp
@@ -299,8 +299,8 @@ namespace tools_select {
         }
     }
 
-    bool FamilySelector::belong_to_structure(size_t v0, size_t v1,
-                                             const VineTree& vine_tree) {
+    bool FamilySelector::belongs_to_structure(size_t v0, size_t v1,
+                                              const VineTree& vine_tree) {
         
         // -1 means no common neighbor in previous tree
         if (find_common_neighbor(v0, v1, vine_tree) > -1) {
@@ -330,7 +330,7 @@ namespace tools_select {
             add_one(conditioning);
 
             // check whether the edge belongs to the structure
-            return vine_matrix_.belong_to_structure(conditioned, conditioning);
+            return vine_matrix_.belongs_to_structure(conditioned, conditioning);
         }
         
         // there was no common neighbor
@@ -349,7 +349,7 @@ namespace tools_select {
                 if (v0 == v1) continue;
                 // check proximity condition: common neighbor in previous tree
                 // (-1 means 'no common neighbor')
-                if (belong_to_structure(v0, v1, vine_tree)) {
+                if (belongs_to_structure(v0, v1, vine_tree)) {
                     Eigen::MatrixXd pc_data;
                     boost::graph_traits<VineTree>::edge_descriptor e;
                     pc_data = get_pc_data(v0, v1, vine_tree);

--- a/src/vinecop/tools_select.cpp
+++ b/src/vinecop/tools_select.cpp
@@ -371,26 +371,21 @@ namespace tools_select {
 
     bool FamilySelector::belongs_to_structure(size_t v0, size_t v1,
                                               const VineTree& vine_tree) {
-        
         // -1 means no common neighbor in previous tree
         if (find_common_neighbor(v0, v1, vine_tree) > -1) {
-            // conditioned sets
-            auto conditioned0 = vine_tree[v0].conditioned;
-            auto conditioned1 = vine_tree[v1].conditioned;
-
             std::vector<size_t> conditioning;
             std::vector<size_t> conditioned(2);
-            if (conditioned0.size() == 1) {
-                conditioned = {conditioned0[0], conditioned1[0]};
+            if (vine_tree[v0].conditioned.size() == 1) {
+                // first tree
+                conditioned = cat(vine_tree[v0].conditioned,
+                                  vine_tree[v1].conditioned);
                 conditioning = {};
             } else {
-                // add conditioning sets
-                auto all0 = cat(conditioned0, vine_tree[v0].conditioning);
-                auto all1 = cat(conditioned1, vine_tree[v1].conditioning);
-
                 // compute new conditioned/conditioning sets
-                conditioned = set_sym_diff(all0, all1);
-                conditioning = intersect(all0, all1);
+                conditioned = set_sym_diff(vine_tree[v0].all_indices,
+                                           vine_tree[v1].all_indices);
+                conditioning = intersect(vine_tree[v0].all_indices,
+                                         vine_tree[v1].all_indices);
             }
 
             // to convert from vinecop to rvine_matrix indices

--- a/test/src_test/include/test_rvine_matrix.hpp
+++ b/test/src_test/include/test_rvine_matrix.hpp
@@ -110,7 +110,7 @@ namespace test_rvine_matrix {
         EXPECT_EQ(RVineMatrix::construct_d_vine_matrix(order), true_d_vine_matrix);
     }
 
-    TEST(rvine_matrix, belong_to_structure_is_correct) {
+    TEST(rvine_matrix, belongs_to_structure_is_correct) {
 
 
         Eigen::Matrix<size_t, Eigen::Dynamic, Eigen::Dynamic> mat(7, 7);
@@ -126,57 +126,57 @@ namespace test_rvine_matrix {
         // conditioned set size is equal to 2
         std::vector<size_t> conditioning0 = {0,1,2,3};
         std::vector<size_t> conditioned0 = {0,1,2,3};
-        EXPECT_ANY_THROW(rvine_matrix.belong_to_structure(conditioned0,
-                                                          conditioning0));
+        EXPECT_ANY_THROW(rvine_matrix.belongs_to_structure(conditioned0,
+                                                           conditioning0));
         std::vector<size_t> conditioning1 = {};
         std::vector<size_t> conditioned1 = {4, 5};
-        ASSERT_TRUE(rvine_matrix.belong_to_structure(conditioned1,
-                                                     conditioning1));
-        ASSERT_FALSE(rvine_matrix.belong_to_structure(conditioned1,
-                                                      conditioning0));
+        ASSERT_TRUE(rvine_matrix.belongs_to_structure(conditioned1,
+                                                      conditioning1));
+        ASSERT_FALSE(rvine_matrix.belongs_to_structure(conditioned1,
+                                                       conditioning0));
         conditioned1[0] = 5;
         conditioned1[1] = 4;
-        ASSERT_TRUE(rvine_matrix.belong_to_structure(conditioned1,
-                                                     conditioning1));
-        ASSERT_FALSE(rvine_matrix.belong_to_structure(conditioned1,
-                                                      conditioning0));
+        ASSERT_TRUE(rvine_matrix.belongs_to_structure(conditioned1,
+                                                      conditioning1));
+        ASSERT_FALSE(rvine_matrix.belongs_to_structure(conditioned1,
+                                                       conditioning0));
 
         conditioned1[0] = 6;
         conditioned1[1] = 5;
-        ASSERT_TRUE(rvine_matrix.belong_to_structure(conditioned1,
-                                                     conditioning1));
-        ASSERT_FALSE(rvine_matrix.belong_to_structure(conditioned1,
-                                                      conditioning0));
+        ASSERT_TRUE(rvine_matrix.belongs_to_structure(conditioned1,
+                                                      conditioning1));
+        ASSERT_FALSE(rvine_matrix.belongs_to_structure(conditioned1,
+                                                       conditioning0));
 
         std::vector<size_t> conditioning2 = {5};
         std::vector<size_t> conditioned2 = {4, 6};
-        ASSERT_TRUE(rvine_matrix.belong_to_structure(conditioned2,
-                                                     conditioning2));
-        ASSERT_FALSE(rvine_matrix.belong_to_structure(conditioned2,
-                                                      conditioning1));
-        ASSERT_FALSE(rvine_matrix.belong_to_structure(conditioned2,
-                                                      conditioning0));
-        conditioning2[0] = 6;
-        ASSERT_FALSE(rvine_matrix.belong_to_structure(conditioned2,
+        ASSERT_TRUE(rvine_matrix.belongs_to_structure(conditioned2,
                                                       conditioning2));
+        ASSERT_FALSE(rvine_matrix.belongs_to_structure(conditioned2,
+                                                       conditioning1));
+        ASSERT_FALSE(rvine_matrix.belongs_to_structure(conditioned2,
+                                                       conditioning0));
+        conditioning2[0] = 6;
+        ASSERT_FALSE(rvine_matrix.belongs_to_structure(conditioned2,
+                                                       conditioning2));
 
         conditioned2[0] = 5;
         conditioned2[1] = 2;
-        ASSERT_TRUE(rvine_matrix.belong_to_structure(conditioned2,
-                                                     conditioning2));
-        ASSERT_FALSE(rvine_matrix.belong_to_structure(conditioned2,
-                                                      conditioning1));
-        ASSERT_FALSE(rvine_matrix.belong_to_structure(conditioned2,
-                                                      conditioning0));
+        ASSERT_TRUE(rvine_matrix.belongs_to_structure(conditioned2,
+                                                      conditioning2));
+        ASSERT_FALSE(rvine_matrix.belongs_to_structure(conditioned2,
+                                                       conditioning1));
+        ASSERT_FALSE(rvine_matrix.belongs_to_structure(conditioned2,
+                                                       conditioning0));
 
         std::vector<size_t> conditioning3 = {6, 2};
         std::vector<size_t> conditioned3 = {1, 5};
-        ASSERT_TRUE(rvine_matrix.belong_to_structure(conditioned3,
-                                                     conditioning3));
-        ASSERT_FALSE(rvine_matrix.belong_to_structure(conditioned3,
-                                                      conditioning1));
-        ASSERT_FALSE(rvine_matrix.belong_to_structure(conditioned3,
-                                                      conditioning0));
+        ASSERT_TRUE(rvine_matrix.belongs_to_structure(conditioned3,
+                                                      conditioning3));
+        ASSERT_FALSE(rvine_matrix.belongs_to_structure(conditioned3,
+                                                       conditioning1));
+        ASSERT_FALSE(rvine_matrix.belongs_to_structure(conditioned3,
+                                                       conditioning0));
 
     }
     

--- a/test/src_test/include/test_rvine_matrix.hpp
+++ b/test/src_test/include/test_rvine_matrix.hpp
@@ -111,8 +111,6 @@ namespace test_rvine_matrix {
     }
 
     TEST(rvine_matrix, belongs_to_structure_is_correct) {
-
-
         Eigen::Matrix<size_t, Eigen::Dynamic, Eigen::Dynamic> mat(7, 7);
         mat << 5, 2, 6, 6, 6, 6, 6,
                6, 6, 1, 2, 5, 5, 0,
@@ -124,32 +122,33 @@ namespace test_rvine_matrix {
         RVineMatrix rvine_matrix(mat);
 
         // conditioned set size is equal to 2
-        std::vector<size_t> conditioning0 = {0,1,2,3};
         std::vector<size_t> conditioned0 = {0,1,2,3};
+        std::vector<size_t> conditioning0 = {0,1,2,3};
         EXPECT_ANY_THROW(rvine_matrix.belongs_to_structure(conditioned0,
                                                            conditioning0));
-        std::vector<size_t> conditioning1 = {};
         std::vector<size_t> conditioned1 = {4, 5};
+        std::vector<size_t> conditioning1 = {};
         ASSERT_TRUE(rvine_matrix.belongs_to_structure(conditioned1,
                                                       conditioning1));
         ASSERT_FALSE(rvine_matrix.belongs_to_structure(conditioned1,
                                                        conditioning0));
         conditioned1[0] = 5;
         conditioned1[1] = 4;
+        // only allow for correctly ordered conditioned set
+        ASSERT_FALSE(rvine_matrix.belongs_to_structure(conditioned1,
+                                                       conditioning1));
+        ASSERT_FALSE(rvine_matrix.belongs_to_structure(conditioned1,
+                                                       conditioning0));
+
+        conditioned1[0] = 5;
+        conditioned1[1] = 6;
         ASSERT_TRUE(rvine_matrix.belongs_to_structure(conditioned1,
                                                       conditioning1));
         ASSERT_FALSE(rvine_matrix.belongs_to_structure(conditioned1,
                                                        conditioning0));
 
-        conditioned1[0] = 6;
-        conditioned1[1] = 5;
-        ASSERT_TRUE(rvine_matrix.belongs_to_structure(conditioned1,
-                                                      conditioning1));
-        ASSERT_FALSE(rvine_matrix.belongs_to_structure(conditioned1,
-                                                       conditioning0));
-
-        std::vector<size_t> conditioning2 = {5};
         std::vector<size_t> conditioned2 = {4, 6};
+        std::vector<size_t> conditioning2 = {5};
         ASSERT_TRUE(rvine_matrix.belongs_to_structure(conditioned2,
                                                       conditioning2));
         ASSERT_FALSE(rvine_matrix.belongs_to_structure(conditioned2,
@@ -160,8 +159,8 @@ namespace test_rvine_matrix {
         ASSERT_FALSE(rvine_matrix.belongs_to_structure(conditioned2,
                                                        conditioning2));
 
-        conditioned2[0] = 5;
-        conditioned2[1] = 2;
+        conditioned2[0] = 2;
+        conditioned2[1] = 5;
         ASSERT_TRUE(rvine_matrix.belongs_to_structure(conditioned2,
                                                       conditioning2));
         ASSERT_FALSE(rvine_matrix.belongs_to_structure(conditioned2,
@@ -169,8 +168,8 @@ namespace test_rvine_matrix {
         ASSERT_FALSE(rvine_matrix.belongs_to_structure(conditioned2,
                                                        conditioning0));
 
-        std::vector<size_t> conditioning3 = {6, 2};
         std::vector<size_t> conditioned3 = {1, 5};
+        std::vector<size_t> conditioning3 = {6, 2};
         ASSERT_TRUE(rvine_matrix.belongs_to_structure(conditioned3,
                                                       conditioning3));
         ASSERT_FALSE(rvine_matrix.belongs_to_structure(conditioned3,

--- a/test/src_test/include/test_vinecop_class.hpp
+++ b/test/src_test/include/test_vinecop_class.hpp
@@ -145,10 +145,11 @@ namespace test_vinecop_class {
             }
         }
         Vinecop vinecop(pair_copulas, model_matrix);
-        
         auto u = vinecop.simulate(10000);
-        Vinecop fit(u, model_matrix,
-                    FitControlsVinecop({BicopFamily::clayton}, "itau"));
+        
+        auto controls = FitControlsVinecop({BicopFamily::clayton}, "itau");
+        // controls.set_show_trace(true);
+        Vinecop fit(u, model_matrix, controls);
             
         // don't check last two trees to avoid random failures because of
         // estimation uncertainty
@@ -197,9 +198,7 @@ namespace test_vinecop_class {
         EXPECT_EQ(pairs_unequal, 0);
     }
     
-    
     // in what follows, we only check if funs run without error ----------
-    
     TEST_F(VinecopTest, sparse_threshold_selection) {
         FitControlsVinecop controls(bicop_families::itau, "itau");
         controls.set_select_threshold(true);


### PR DESCRIPTION
- Fixed the rotation issue in `FamilySelector`: your `set_sym_diff` "forgot" about the ordering of the sets, which is fixed now. This makes the `v0_` thing superfluous and allows to simplify `belong_to_structure()`.
- Simplified other functions like `add_edge_info()` a bit by storing `all_indices` in vertices as well.
- Simplified `finalize()` for `FamilySelector`: since the matrix is fixed, we need to do a lot less work. `finalize()` is now virtual in `VinecopSelector` and each child class has their own implementation.
- Did all the stylistic changes that I suggested in #217.

We should keep the commits when merging into `refactor-sparse-select` and only squash when merging to `dev`.
