### PR TITLE
safeguard against checking equality of empty sets

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -31,7 +31,7 @@ install:
   - git clone git://github.com/stevengj/nlopt
   - cd nlopt
   - sed -i '26i#define NLOPT_DLL' .\api\nlopt.h
-  - sed -i '27#define NLOPT_DLL_EXPORT' .\api\nlopt.h
+  - sed -i '27i#define NLOPT_DLL_EXPORT' .\api\nlopt.h
   - sed -i '$i\#undef NLOPT_DLL' .\api\nlopt.h
   - sed -i '$i\#undef NLOPT_DLL_EXPORT' .\api\nlopt.h
   - cmake -DCMAKE_GENERATOR_PLATFORM="%CMAKE_GEN_PLAT%" -DCMAKE_INSTALL_PREFIX=C:\projects\nlopt-install -DCMAKE_INSTALL_BINDIR=c:\projects\nlopt-install\lib .

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -30,8 +30,8 @@ install:
   - cd ..
   - git clone git://github.com/stevengj/nlopt
   - cd nlopt
-  - sed -i '1i#define NLOPT_DLL' .\api\nlopt.h
-  - sed -i '2i#define NLOPT_DLL_EXPORT' .\api\nlopt.h
+  - sed -i '26i#define NLOPT_DLL' .\api\nlopt.h
+  - sed -i '27#define NLOPT_DLL_EXPORT' .\api\nlopt.h
   - sed -i '$i\#undef NLOPT_DLL' .\api\nlopt.h
   - sed -i '$i\#undef NLOPT_DLL_EXPORT' .\api\nlopt.h
   - cmake -DCMAKE_GENERATOR_PLATFORM="%CMAKE_GEN_PLAT%" -DCMAKE_INSTALL_PREFIX=C:\projects\nlopt-install -DCMAKE_INSTALL_BINDIR=c:\projects\nlopt-install\lib .

--- a/src/vinecop/rvine_matrix.cpp
+++ b/src/vinecop/rvine_matrix.cpp
@@ -92,26 +92,28 @@ namespace vinecopulib
         }
 
         size_t tree = conditioning.size();
-        std::vector<size_t> conditioning_test(tree);
-        std::vector<size_t> conditioned_test(2);
-        bool res = false;
+        std::vector<size_t> conditioning_mat(tree);
+        std::vector<size_t> conditioned_mat(2);
         if (tree + 2 <= d_) {
             for (size_t i = 0; i < d_ - tree - 1; ++i) {
-                conditioned_test[0] = matrix_(d_ - 1 - i, i);
-                conditioned_test[1] = matrix_(tree, i);
-                bool conditioned_ok = (conditioned == conditioned_test);
-                if (conditioned_ok & (tree > 0)) {
+                conditioned_mat = {matrix_(d_ - 1 - i, i), matrix_(tree, i)};
+                if (conditioned == conditioned_mat) {
+                    if (tree == 0) {
+                        return true;  // conditioning set is empty for tree == 0
+                    }
                     auto cond = matrix_.col(i).head(tree);
-                    Eigen::Matrix<size_t, Eigen::Dynamic, 1>::Map(&conditioning_test[0], tree) = cond;
-                    res = tools_stl::is_same_set(conditioning, conditioning_test);
+                    Eigen::Matrix<size_t, Eigen::Dynamic, 1>::Map(
+                        &conditioning_test[0], tree
+                    ) = cond;
+                    if (tools_stl::is_same_set(conditioning, conditioning_mat)) {
+                        return true;
+                    }
                 }
-
-                if (res)
-                    break;
             }
         }
-
-        return res;
+        
+        // edge is not contained in the structure implied by the matrix
+        return false;
     }
 
 

--- a/src/vinecop/rvine_matrix.cpp
+++ b/src/vinecop/rvine_matrix.cpp
@@ -104,7 +104,7 @@ namespace vinecopulib
                     }
                     auto cond = matrix_.col(i).head(tree);
                     Eigen::Matrix<size_t, Eigen::Dynamic, 1>::Map(
-                        &conditioning_test[0], tree) = cond;
+                        &conditioning_mat[0], tree) = cond;
                     if (tools_stl::is_same_set(conditioning, conditioning_mat)) {
                         return true;
                     }

--- a/src/vinecop/rvine_matrix.cpp
+++ b/src/vinecop/rvine_matrix.cpp
@@ -100,7 +100,7 @@ namespace vinecopulib
                 conditioned_test[0] = matrix_(d_ - 1 - i, i);
                 conditioned_test[1] = matrix_(tree, i);
                 bool conditioned_ok = (conditioned == conditioned_test);
-                if (conditioned_ok) {
+                if (conditioned_ok & (tree > 0)) {
                     auto cond = matrix_.col(i).head(tree);
                     Eigen::Matrix<size_t, Eigen::Dynamic, 1>::Map(&conditioning_test[0], tree) = cond;
                     res = tools_stl::is_same_set(conditioning, conditioning_test);

--- a/src/vinecop/rvine_matrix.cpp
+++ b/src/vinecop/rvine_matrix.cpp
@@ -98,13 +98,13 @@ namespace vinecopulib
             for (size_t i = 0; i < d_ - tree - 1; ++i) {
                 conditioned_mat = {matrix_(d_ - 1 - i, i), matrix_(tree, i)};
                 if (conditioned == conditioned_mat) {
+                    // conditioned sets equal, need to check conditioning set
                     if (tree == 0) {
                         return true;  // conditioning set is empty for tree == 0
                     }
                     auto cond = matrix_.col(i).head(tree);
                     Eigen::Matrix<size_t, Eigen::Dynamic, 1>::Map(
-                        &conditioning_test[0], tree
-                    ) = cond;
+                        &conditioning_test[0], tree) = cond;
                     if (tools_stl::is_same_set(conditioning, conditioning_mat)) {
                         return true;
                     }

--- a/src/vinecop/tools_select.cpp
+++ b/src/vinecop/tools_select.cpp
@@ -379,7 +379,7 @@ namespace tools_select {
                 // first tree
                 conditioned = cat(vine_tree[v0].conditioned,
                                   vine_tree[v1].conditioned);
-                conditioning = {};
+                conditioning = std::vector<size_t>(0);
             } else {
                 // compute new conditioned/conditioning sets
                 conditioned = set_sym_diff(vine_tree[v0].all_indices,

--- a/test/src_test/include/test_rvine_matrix.hpp
+++ b/test/src_test/include/test_rvine_matrix.hpp
@@ -8,6 +8,7 @@
 
 #include "gtest/gtest.h"
 #include <vinecopulib/vinecop/rvine_matrix.hpp>
+#include <iostream>
 
 namespace test_rvine_matrix {
     using namespace vinecopulib;
@@ -120,56 +121,70 @@ namespace test_rvine_matrix {
                7, 3, 0, 0, 0, 0, 0,
                4, 0, 0, 0, 0, 0, 0;
         RVineMatrix rvine_matrix(mat);
-
+        
+        std::cout << "created matrix" << std::endl;
         // conditioned set size is equal to 2
         std::vector<size_t> conditioned0 = {0,1,2,3};
         std::vector<size_t> conditioning0 = {0,1,2,3};
+        std::cout << "created conditioned0" << std::endl;
         EXPECT_ANY_THROW(rvine_matrix.belongs_to_structure(conditioned0,
                                                            conditioning0));
+        std::cout << "checked conditioned0" << std::endl;
         std::vector<size_t> conditioned1 = {4, 5};
         std::vector<size_t> conditioning1 = {};
+        std::cout << "created conditioned1" << std::endl;
         ASSERT_TRUE(rvine_matrix.belongs_to_structure(conditioned1,
                                                       conditioning1));
         ASSERT_FALSE(rvine_matrix.belongs_to_structure(conditioned1,
                                                        conditioning0));
+        std::cout << "checked conditioned1" << std::endl;
         conditioned1[0] = 5;
         conditioned1[1] = 4;
+        std::cout << "modified conditioned1" << std::endl;
         // only allow for correctly ordered conditioned set
         ASSERT_FALSE(rvine_matrix.belongs_to_structure(conditioned1,
                                                        conditioning1));
         ASSERT_FALSE(rvine_matrix.belongs_to_structure(conditioned1,
                                                        conditioning0));
-
+        std::cout << "checked conditioned1" << std::endl;
         conditioned1[0] = 5;
         conditioned1[1] = 6;
+        std::cout << "modified conditioned1" << std::endl;
         ASSERT_TRUE(rvine_matrix.belongs_to_structure(conditioned1,
                                                       conditioning1));
         ASSERT_FALSE(rvine_matrix.belongs_to_structure(conditioned1,
                                                        conditioning0));
-
+        std::cout << "checked conditioned1" << std::endl;
+        
         std::vector<size_t> conditioned2 = {4, 6};
         std::vector<size_t> conditioning2 = {5};
+        std::cout << "created conditioned2" << std::endl;
         ASSERT_TRUE(rvine_matrix.belongs_to_structure(conditioned2,
                                                       conditioning2));
         ASSERT_FALSE(rvine_matrix.belongs_to_structure(conditioned2,
                                                        conditioning1));
         ASSERT_FALSE(rvine_matrix.belongs_to_structure(conditioned2,
                                                        conditioning0));
+        std::cout << "checked conditioned2" << std::endl;
         conditioning2[0] = 6;
+        std::cout << "modified conditioned2" << std::endl;
         ASSERT_FALSE(rvine_matrix.belongs_to_structure(conditioned2,
                                                        conditioning2));
-
+        std::cout << "checked conditioned2" << std::endl;
         conditioned2[0] = 2;
         conditioned2[1] = 5;
+        std::cout << "modified conditioned2" << std::endl;
         ASSERT_TRUE(rvine_matrix.belongs_to_structure(conditioned2,
                                                       conditioning2));
         ASSERT_FALSE(rvine_matrix.belongs_to_structure(conditioned2,
                                                        conditioning1));
         ASSERT_FALSE(rvine_matrix.belongs_to_structure(conditioned2,
                                                        conditioning0));
-
+        std::cout << "checked conditioned2" << std::endl;
+        
         std::vector<size_t> conditioned3 = {1, 5};
         std::vector<size_t> conditioning3 = {6, 2};
+        std::cout << "created conditioned3" << std::endl;
         ASSERT_TRUE(rvine_matrix.belongs_to_structure(conditioned3,
                                                       conditioning3));
         ASSERT_FALSE(rvine_matrix.belongs_to_structure(conditioned3,

--- a/test/src_test/include/test_rvine_matrix.hpp
+++ b/test/src_test/include/test_rvine_matrix.hpp
@@ -122,69 +122,54 @@ namespace test_rvine_matrix {
                4, 0, 0, 0, 0, 0, 0;
         RVineMatrix rvine_matrix(mat);
         
-        std::cout << "created matrix" << std::endl;
         // conditioned set size is equal to 2
         std::vector<size_t> conditioned0 = {0,1,2,3};
         std::vector<size_t> conditioning0 = {0,1,2,3};
-        std::cout << "created conditioned0" << std::endl;
         EXPECT_ANY_THROW(rvine_matrix.belongs_to_structure(conditioned0,
                                                            conditioning0));
-        std::cout << "checked conditioned0" << std::endl;
+        
         std::vector<size_t> conditioned1 = {4, 5};
         std::vector<size_t> conditioning1(0);
-        std::cout << "created conditioned1" << std::endl;
         ASSERT_TRUE(rvine_matrix.belongs_to_structure(conditioned1,
                                                       conditioning1));
         ASSERT_FALSE(rvine_matrix.belongs_to_structure(conditioned1,
                                                        conditioning0));
-        std::cout << "checked conditioned1" << std::endl;
         conditioned1[0] = 5;
         conditioned1[1] = 4;
-        std::cout << "modified conditioned1" << std::endl;
         // only allow for correctly ordered conditioned set
         ASSERT_FALSE(rvine_matrix.belongs_to_structure(conditioned1,
                                                        conditioning1));
         ASSERT_FALSE(rvine_matrix.belongs_to_structure(conditioned1,
                                                        conditioning0));
-        std::cout << "checked conditioned1" << std::endl;
         conditioned1[0] = 5;
         conditioned1[1] = 6;
-        std::cout << "modified conditioned1" << std::endl;
         ASSERT_TRUE(rvine_matrix.belongs_to_structure(conditioned1,
                                                       conditioning1));
         ASSERT_FALSE(rvine_matrix.belongs_to_structure(conditioned1,
                                                        conditioning0));
-        std::cout << "checked conditioned1" << std::endl;
         
         std::vector<size_t> conditioned2 = {4, 6};
         std::vector<size_t> conditioning2 = {5};
-        std::cout << "created conditioned2" << std::endl;
         ASSERT_TRUE(rvine_matrix.belongs_to_structure(conditioned2,
                                                       conditioning2));
         ASSERT_FALSE(rvine_matrix.belongs_to_structure(conditioned2,
                                                        conditioning1));
         ASSERT_FALSE(rvine_matrix.belongs_to_structure(conditioned2,
                                                        conditioning0));
-        std::cout << "checked conditioned2" << std::endl;
         conditioning2[0] = 6;
-        std::cout << "modified conditioned2" << std::endl;
         ASSERT_FALSE(rvine_matrix.belongs_to_structure(conditioned2,
                                                        conditioning2));
-        std::cout << "checked conditioned2" << std::endl;
         conditioned2[0] = 2;
         conditioned2[1] = 5;
-        std::cout << "modified conditioned2" << std::endl;
         ASSERT_TRUE(rvine_matrix.belongs_to_structure(conditioned2,
                                                       conditioning2));
         ASSERT_FALSE(rvine_matrix.belongs_to_structure(conditioned2,
                                                        conditioning1));
         ASSERT_FALSE(rvine_matrix.belongs_to_structure(conditioned2,
                                                        conditioning0));
-        std::cout << "checked conditioned2" << std::endl;
         
         std::vector<size_t> conditioned3 = {1, 5};
         std::vector<size_t> conditioning3 = {6, 2};
-        std::cout << "created conditioned3" << std::endl;
         ASSERT_TRUE(rvine_matrix.belongs_to_structure(conditioned3,
                                                       conditioning3));
         ASSERT_FALSE(rvine_matrix.belongs_to_structure(conditioned3,

--- a/test/src_test/include/test_rvine_matrix.hpp
+++ b/test/src_test/include/test_rvine_matrix.hpp
@@ -131,7 +131,7 @@ namespace test_rvine_matrix {
                                                            conditioning0));
         std::cout << "checked conditioned0" << std::endl;
         std::vector<size_t> conditioned1 = {4, 5};
-        std::vector<size_t> conditioning1 = {};
+        std::vector<size_t> conditioning1(0);
         std::cout << "created conditioned1" << std::endl;
         ASSERT_TRUE(rvine_matrix.belongs_to_structure(conditioned1,
                                                       conditioning1));

--- a/test/test_all.cpp
+++ b/test/test_all.cpp
@@ -4,23 +4,23 @@
 // the MIT license. For a copy, see the LICENSE file in the root directory of
 // vinecopulib or https://vinecopulib.github.io/vinecopulib/.
 
-// #include "src_test/include/test_bicop_sanity_checks.hpp"
-// #include "src_test/include/test_bicop_parametric.hpp"
-// #include "src_test/include/test_bicop_kernel.hpp"
+#include "src_test/include/test_bicop_sanity_checks.hpp"
+#include "src_test/include/test_bicop_parametric.hpp"
+#include "src_test/include/test_bicop_kernel.hpp"
 #include "src_test/include/test_rvine_matrix.hpp"
-// #include "src_test/include/test_serialization.hpp"
-// #include "src_test/include/test_tools_stats.hpp"
-// #include "src_test/include/test_vinecop_class.hpp"
-// #include "src_test/include/test_vinecop_sanity_checks.hpp"
+#include "src_test/include/test_serialization.hpp"
+#include "src_test/include/test_tools_stats.hpp"
+#include "src_test/include/test_vinecop_class.hpp"
+#include "src_test/include/test_vinecop_sanity_checks.hpp"
 
-// using namespace test_bicop_sanity_checks;
-// using namespace test_bicop_parametric;
-// using namespace test_bicop_kernel;
+using namespace test_bicop_sanity_checks;
+using namespace test_bicop_parametric;
+using namespace test_bicop_kernel;
 using namespace test_rvine_matrix;
-// using namespace test_serialization;
-// using namespace test_tools_stats;
-// using namespace test_vinecop_class;
-// using namespace test_vinecop_sanity_checks;
+using namespace test_serialization;
+using namespace test_tools_stats;
+using namespace test_vinecop_class;
+using namespace test_vinecop_sanity_checks;
 
 int main(int argc, char **argv) {
     ::testing::InitGoogleTest(&argc, argv);

--- a/test/test_all.cpp
+++ b/test/test_all.cpp
@@ -4,23 +4,23 @@
 // the MIT license. For a copy, see the LICENSE file in the root directory of
 // vinecopulib or https://vinecopulib.github.io/vinecopulib/.
 
-#include "src_test/include/test_bicop_sanity_checks.hpp"
-#include "src_test/include/test_bicop_parametric.hpp"
-#include "src_test/include/test_bicop_kernel.hpp"
+// #include "src_test/include/test_bicop_sanity_checks.hpp"
+// #include "src_test/include/test_bicop_parametric.hpp"
+// #include "src_test/include/test_bicop_kernel.hpp"
 #include "src_test/include/test_rvine_matrix.hpp"
-#include "src_test/include/test_serialization.hpp"
-#include "src_test/include/test_tools_stats.hpp"
-#include "src_test/include/test_vinecop_class.hpp"
-#include "src_test/include/test_vinecop_sanity_checks.hpp"
+// #include "src_test/include/test_serialization.hpp"
+// #include "src_test/include/test_tools_stats.hpp"
+// #include "src_test/include/test_vinecop_class.hpp"
+// #include "src_test/include/test_vinecop_sanity_checks.hpp"
 
-using namespace test_bicop_sanity_checks;
-using namespace test_bicop_parametric;
-using namespace test_bicop_kernel;
+// using namespace test_bicop_sanity_checks;
+// using namespace test_bicop_parametric;
+// using namespace test_bicop_kernel;
 using namespace test_rvine_matrix;
-using namespace test_serialization;
-using namespace test_tools_stats;
-using namespace test_vinecop_class;
-using namespace test_vinecop_sanity_checks;
+// using namespace test_serialization;
+// using namespace test_tools_stats;
+// using namespace test_vinecop_class;
+// using namespace test_vinecop_sanity_checks;
 
 int main(int argc, char **argv) {
     ::testing::InitGoogleTest(&argc, argv);


### PR DESCRIPTION
Didn't like `is_same_set()` with an empty set as argument.