### PR TITLE
stabilize quadratic tll estimator near zero

### DIFF
--- a/src/bicop/tll.cpp
+++ b/src/bicop/tll.cpp
@@ -115,6 +115,11 @@ namespace vinecopulib
                     res(k) *= std::sqrt(S.determinant()) / det_irB;
                 }
                 res(k) *= std::exp(- 0.5 * double(b.transpose() * S * b));
+                if (std::isnan(res(k)) | std::isinf(res(k))) {
+                    // inverse operation might go wrong due to rounding when
+                    // true value is equal or close to zero
+                    res(k) = 0.0;
+                }
             }
             res(k, 0) *= f0;
             res(k, 1) = calculate_infl(n, f0, b, B, det_irB, S, method);


### PR DESCRIPTION
When data are strongly dependent, S becomes close to the zero matrix in regions where there's no observations. That caused the estimated to return `nan` or `inf` where it should be zero. 

My "solution" is actually a rather dirty workaround, but it does the job. I tried more elegant ways to fix it (like using more stable linear solvers to calculate S^{-1} * b), but without success.