### PR TITLE
simplify output of Bicop.str() / print

### DIFF
--- a/src/bicop/class.cpp
+++ b/src/bicop/class.cpp
@@ -386,9 +386,13 @@ namespace vinecopulib
     std::string Bicop::str() const
     {
         std::stringstream bicop_str;
-        bicop_str << "family = "    << get_family_name() <<
-                  ", rotation = "   << get_rotation() <<
-                  ", parameters = " << get_parameters();
+        bicop_str << get_family_name();
+        if (get_rotation() != 0) {
+            bicop_str << " " << get_rotation() << "°";
+        }
+        if (get_family() != BicopFamily::indep) {
+            bicop_str << ", parameters = " << get_parameters();
+        }
 
         return bicop_str.str().c_str();
     }


### PR DESCRIPTION
Should wait for windows checks, just to make sure that the degree sign doesn't blow up the system (yeah windows).