### PR TITLE
Fix familyselector

### DIFF
--- a/include/vinecopulib/vinecop/implementation/tools_select.ipp
+++ b/include/vinecopulib/vinecop/implementation/tools_select.ipp
@@ -497,13 +497,23 @@ inline void FamilySelector::finalize(size_t trunc_lvl)
 {
     pair_copulas_ = make_pair_copula_store(d_, trunc_lvl);
     for (size_t tree = 0; tree < pair_copulas_.size(); tree++) {
-        int edge = 0;
-        // trees_[0] is base tree, vine copula starts at trees_[1]
         for (auto e : boost::edges(trees_[tree + 1])) {
+            // check in which column of the matrix the pair-copula e is
+            size_t edge = find_column_in_matrix(trees_[tree + 1][e].conditioned);
+            // trees_[0] is base tree, vine copula starts at trees_[1]
             pair_copulas_[tree][edge] = trees_[tree + 1][e].pair_copula;
             edge++;
         }
     }
+}
+
+inline size_t FamilySelector::find_column_in_matrix(
+    const std::vector<size_t>& conditioned)
+{
+    Eigen::Matrix<size_t, Eigen::Dynamic, 1> inds =
+        vine_matrix_.get_order().reverse();
+    std::vector<size_t> vinds(inds.data(), inds.data() + inds.rows());
+    return tools_stl::find_position(conditioned[0] + 1, vinds);
 }
 
 

--- a/include/vinecopulib/vinecop/tools_select.hpp
+++ b/include/vinecopulib/vinecop/tools_select.hpp
@@ -190,6 +190,9 @@ private:
                               const VineTree &vine_tree);
 
     void finalize(size_t trunc_lvl);
+    
+    size_t find_column_in_matrix(const std::vector<size_t>& conditioned);
+
 };
 
 }

--- a/test/src_test/include/test_vinecop_class.hpp
+++ b/test/src_test/include/test_vinecop_class.hpp
@@ -161,6 +161,26 @@ TEST_F(VinecopTest, family_select_finds_true_rotations) {
     EXPECT_EQ(true_rots, fitd_rots);
 }
 
+TEST_F(VinecopTest, family_select_returns_pcs_in_right_order) {
+
+    auto pair_copulas = Vinecop::make_pair_copula_store(7);
+    auto par = Eigen::VectorXd::Constant(1, 3.0);
+    for (auto &tree : pair_copulas) {
+        for (auto &pc : tree) {
+            pc = Bicop(BicopFamily::clayton, 270, par);
+        }
+    }
+    Vinecop vinecop(pair_copulas, model_matrix);
+    auto data = vinecop.simulate(10000);
+
+    auto controls = FitControlsVinecop(bicop_families::itau, "itau");
+    // controls.set_show_trace(true);
+    Vinecop fit_struct(data, controls);
+    Vinecop fit_fam(data, fit_struct.get_matrix(), controls);
+
+    EXPECT_EQ(fit_struct.get_all_parameters(), fit_fam.get_all_parameters());
+}
+
 TEST_F(VinecopTest, works_multi_threaded) {
     FitControlsVinecop controls(bicop_families::itau, "itau");
     controls.set_select_truncation_level(true);


### PR DESCRIPTION
The pair copulas were stored in an order that did not correspond to the R-vine matrix.