### PR TITLE
Numerical stability

### DIFF
--- a/include/vinecopulib/bicop/abstract.hpp
+++ b/include/vinecopulib/bicop/abstract.hpp
@@ -56,7 +56,9 @@ protected:
 
     virtual double parameters_to_tau(const Eigen::MatrixXd &parameters) = 0;
 
-    virtual Eigen::VectorXd pdf(
+    Eigen::VectorXd pdf(const Eigen::Matrix<double, Eigen::Dynamic, 2> &u);
+
+    virtual Eigen::VectorXd pdf_raw(
         const Eigen::Matrix<double, Eigen::Dynamic, 2> &u) = 0;
 
     virtual Eigen::VectorXd cdf(

--- a/include/vinecopulib/bicop/bb1.hpp
+++ b/include/vinecopulib/bicop/bb1.hpp
@@ -34,7 +34,7 @@ private:
     double generator_derivative2(const double &u);
 
     // pdf
-    Eigen::VectorXd pdf(const Eigen::Matrix<double, Eigen::Dynamic, 2> &u);
+    Eigen::VectorXd pdf_raw(const Eigen::Matrix<double, Eigen::Dynamic, 2> &u);
 
     // link between Kendall's tau and the par_bicop parameter
     double parameters_to_tau(const Eigen::MatrixXd &par);

--- a/include/vinecopulib/bicop/bb6.hpp
+++ b/include/vinecopulib/bicop/bb6.hpp
@@ -34,7 +34,7 @@ private:
     double generator_derivative2(const double &u);
 
     // pdf
-    Eigen::VectorXd pdf(const Eigen::Matrix<double, Eigen::Dynamic, 2> &u);
+    Eigen::VectorXd pdf_raw(const Eigen::Matrix<double, Eigen::Dynamic, 2> &u);
 
     // link between Kendall's tau and the par_bicop parameter
     double parameters_to_tau(const Eigen::MatrixXd &par);

--- a/include/vinecopulib/bicop/bb7.hpp
+++ b/include/vinecopulib/bicop/bb7.hpp
@@ -34,7 +34,7 @@ private:
     double generator_derivative2(const double &u);
 
     // pdf
-    Eigen::VectorXd pdf(const Eigen::Matrix<double, Eigen::Dynamic, 2> &u);
+    Eigen::VectorXd pdf_raw(const Eigen::Matrix<double, Eigen::Dynamic, 2> &u);
 
     // link between Kendall's tau and the par_bicop parameter
     double parameters_to_tau(const Eigen::MatrixXd &par);

--- a/include/vinecopulib/bicop/bb8.hpp
+++ b/include/vinecopulib/bicop/bb8.hpp
@@ -34,7 +34,7 @@ private:
     double generator_derivative2(const double &u);
 
     // pdf
-    Eigen::VectorXd pdf(const Eigen::Matrix<double, Eigen::Dynamic, 2> &u);
+    Eigen::VectorXd pdf_raw(const Eigen::Matrix<double, Eigen::Dynamic, 2> &u);
 
     // link between Kendall's tau and the par_bicop parameter
     double parameters_to_tau(const Eigen::MatrixXd &par);

--- a/include/vinecopulib/bicop/clayton.hpp
+++ b/include/vinecopulib/bicop/clayton.hpp
@@ -34,7 +34,7 @@ private:
     double generator_derivative2(const double &u);
 
     // pdf
-    Eigen::VectorXd pdf(const Eigen::Matrix<double, Eigen::Dynamic, 2> &u);
+    Eigen::VectorXd pdf_raw(const Eigen::Matrix<double, Eigen::Dynamic, 2> &u);
 
     // inverse hfunction
     Eigen::VectorXd hinv1(

--- a/include/vinecopulib/bicop/frank.hpp
+++ b/include/vinecopulib/bicop/frank.hpp
@@ -34,7 +34,7 @@ private:
     double generator_derivative2(const double &u);
 
     // pdf
-    Eigen::VectorXd pdf(const Eigen::Matrix<double, Eigen::Dynamic, 2> &u);
+    Eigen::VectorXd pdf_raw(const Eigen::Matrix<double, Eigen::Dynamic, 2> &u);
 
     // link between Kendall's tau and the par_bicop parameter
     Eigen::MatrixXd tau_to_parameters(const double &tau);

--- a/include/vinecopulib/bicop/gaussian.hpp
+++ b/include/vinecopulib/bicop/gaussian.hpp
@@ -25,7 +25,7 @@ public:
 
 private:
     // PDF
-    Eigen::VectorXd pdf(
+    Eigen::VectorXd pdf_raw(
         const Eigen::Matrix<double, Eigen::Dynamic, 2> &u
     );
 

--- a/include/vinecopulib/bicop/gumbel.hpp
+++ b/include/vinecopulib/bicop/gumbel.hpp
@@ -34,7 +34,7 @@ private:
     double generator_derivative2(const double &u);
 
     // pdf
-    Eigen::VectorXd pdf(const Eigen::Matrix<double, Eigen::Dynamic, 2> &u);
+    Eigen::VectorXd pdf_raw(const Eigen::Matrix<double, Eigen::Dynamic, 2> &u);
 
     // inverse hfunction
     Eigen::VectorXd hinv1(

--- a/include/vinecopulib/bicop/implementation/abstract.ipp
+++ b/include/vinecopulib/bicop/implementation/abstract.ipp
@@ -124,7 +124,10 @@ inline void AbstractBicop::set_loglik(const double loglik)
 inline Eigen::VectorXd AbstractBicop::pdf(
     const Eigen::Matrix<double, Eigen::Dynamic, 2> &u)
 {
-    return pdf_raw(u).array().min(DBL_MAX).max(DBL_MIN);
+    auto trim = [] (const double &x) {
+        return std::min(DBL_MAX, std::max(x, DBL_MIN));
+    };
+    return tools_eigen::unaryExpr_or_nan(pdf_raw(u), trim);
 }
 
 //! Numerical inversion of h-functions

--- a/include/vinecopulib/bicop/implementation/abstract.ipp
+++ b/include/vinecopulib/bicop/implementation/abstract.ipp
@@ -119,6 +119,13 @@ inline void AbstractBicop::set_loglik(const double loglik)
 //! @}
 
 
+//! evaluates the pdf, but truncates it's value by DBL_MIN and DBL_MAX.
+//! @param u matrix of evaluation points.
+inline Eigen::VectorXd AbstractBicop::pdf(
+    const Eigen::Matrix<double, Eigen::Dynamic, 2> &u)
+{
+    return pdf_raw(u).array().min(DBL_MAX).max(DBL_MIN);
+}
 
 //! Numerical inversion of h-functions
 //!

--- a/include/vinecopulib/bicop/implementation/bb1.ipp
+++ b/include/vinecopulib/bicop/implementation/bb1.ipp
@@ -45,7 +45,7 @@ inline double Bb1Bicop::generator_derivative2(const double &u)
     return res * (1 + delta * theta - (1 + theta) * std::pow(u, theta));
 }
 
-inline Eigen::VectorXd Bb1Bicop::pdf(
+inline Eigen::VectorXd Bb1Bicop::pdf_raw(
     const Eigen::Matrix<double, Eigen::Dynamic, 2> &u
 )
 {

--- a/include/vinecopulib/bicop/implementation/bb6.ipp
+++ b/include/vinecopulib/bicop/implementation/bb6.ipp
@@ -5,9 +5,7 @@
 // vinecopulib or https://vinecopulib.github.io/vinecopulib/.
 
 #include <vinecopulib/misc/tools_integration.hpp>
-
-#include <boost/math/special_functions/expm1.hpp>
-#include <boost/math/special_functions/log1p.hpp>
+#include <vinecopulib/misc/tools_stl.hpp>
 
 namespace vinecopulib {
 inline Bb6Bicop::Bb6Bicop()
@@ -23,13 +21,13 @@ inline Bb6Bicop::Bb6Bicop()
 
 inline double Bb6Bicop::generator(const double &u)
 {
-    double res = boost::math::log1p(-std::pow(1 - u, parameters_(0)));
+    double res = tools_stl::log1p(-std::pow(1 - u, parameters_(0)));
     return std::pow((-1) * res, parameters_(1));
 }
 
 inline double Bb6Bicop::generator_inv(const double &u)
 {
-    double res = boost::math::expm1(-std::pow(u, 1 / parameters_(1)));
+    double res = std::expm1(-std::pow(u, 1 / parameters_(1)));
     return 1 - std::pow(-res, 1 / parameters_(0));
 }
 
@@ -37,7 +35,7 @@ inline double Bb6Bicop::generator_derivative(const double &u)
 {
     double theta = double(parameters_(0));
     double delta = double(parameters_(1));
-    double res = boost::math::log1p(-std::pow(1 - u, theta));
+    double res = tools_stl::log1p(-std::pow(1 - u, theta));
     res = delta * theta * std::pow((-1) * res, delta - 1);
     return res * std::pow(1 - u, theta - 1) / (std::pow(1 - u, theta) - 1);
 }
@@ -47,7 +45,7 @@ inline double Bb6Bicop::generator_derivative2(const double &u)
     double theta = double(parameters_(0));
     double delta = double(parameters_(1));
     double tmp = std::pow(1 - u, theta);
-    double tmp2 = boost::math::log1p(-tmp);
+    double tmp2 = tools_stl::log1p(-tmp);
     double res = std::pow((-1) * tmp2, delta - 2);
     res *= ((delta - 1) * theta * tmp - (tmp + theta - 1) * tmp2);
     return res * delta * theta * std::pow(1 - u, theta - 2) /
@@ -123,7 +121,7 @@ inline double Bb6Bicop::parameters_to_tau(const Eigen::MatrixXd &parameters)
         double res = -4 * (1 - v - std::pow(1 - v, -theta) +
                            std::pow(1 - v, -theta) * v);
         return 1 / (delta * theta) *
-               boost::math::log1p(-std::pow(1 - v, theta)) * res;
+               tools_stl::log1p(-std::pow(1 - v, theta)) * res;
     };
     return 1 + tools_integration::integrate_zero_to_one(f);
 }

--- a/include/vinecopulib/bicop/implementation/bb6.ipp
+++ b/include/vinecopulib/bicop/implementation/bb6.ipp
@@ -52,7 +52,7 @@ inline double Bb6Bicop::generator_derivative2(const double &u)
            std::pow(tmp - 1, 2);
 }
 
-inline Eigen::VectorXd Bb6Bicop::pdf(
+inline Eigen::VectorXd Bb6Bicop::pdf_raw(
     const Eigen::Matrix<double, Eigen::Dynamic, 2> &u
 )
 {

--- a/include/vinecopulib/bicop/implementation/bb7.ipp
+++ b/include/vinecopulib/bicop/implementation/bb7.ipp
@@ -52,7 +52,7 @@ inline double Bb7Bicop::generator_derivative2(const double &u)
 }
 
 
-inline Eigen::VectorXd Bb7Bicop::pdf(
+inline Eigen::VectorXd Bb7Bicop::pdf_raw(
     const Eigen::Matrix<double, Eigen::Dynamic, 2> &u
 )
 {

--- a/include/vinecopulib/bicop/implementation/bb8.ipp
+++ b/include/vinecopulib/bicop/implementation/bb8.ipp
@@ -52,7 +52,7 @@ inline double Bb8Bicop::generator_derivative2(const double &u)
     return res * (theta - 1 + tmp) / std::pow(tmp - 1, 2);
 }
 
-inline Eigen::VectorXd Bb8Bicop::pdf(
+inline Eigen::VectorXd Bb8Bicop::pdf_raw(
     const Eigen::Matrix<double, Eigen::Dynamic, 2> &u
 )
 {

--- a/include/vinecopulib/bicop/implementation/class.ipp
+++ b/include/vinecopulib/bicop/implementation/class.ipp
@@ -103,10 +103,7 @@ Bicop::pdf(const Eigen::Matrix<double, Eigen::Dynamic, 2> &u)
 const
 {
     tools_eigen::check_if_in_unit_cube(u);
-    Eigen::VectorXd f = bicop_->pdf(cut_and_rotate(u));
-    return tools_eigen::unaryExpr_or_nan(f, [](const double& x) { 
-        return std::max(DBL_MIN, std::min(x, DBL_MAX));
-    });
+    return bicop_->pdf(cut_and_rotate(u));
 }
 
 //! evaluates the copula distribution.

--- a/include/vinecopulib/bicop/implementation/clayton.ipp
+++ b/include/vinecopulib/bicop/implementation/clayton.ipp
@@ -42,7 +42,7 @@ inline double ClaytonBicop::generator_derivative2(const double &u)
     return (1 + theta) * std::pow(u, -2 - theta);
 }
 
-inline Eigen::VectorXd ClaytonBicop::pdf(
+inline Eigen::VectorXd ClaytonBicop::pdf_raw(
     const Eigen::Matrix<double, Eigen::Dynamic, 2> &u
 )
 {

--- a/include/vinecopulib/bicop/implementation/frank.ipp
+++ b/include/vinecopulib/bicop/implementation/frank.ipp
@@ -45,7 +45,7 @@ inline double FrankBicop::generator_derivative2(const double &u)
            std::pow(boost::math::expm1(theta * u) * std::exp(-theta * u / 2), 2);
 }
 
-inline Eigen::VectorXd FrankBicop::pdf(
+inline Eigen::VectorXd FrankBicop::pdf_raw(
     const Eigen::Matrix<double, Eigen::Dynamic, 2> &u
 )
 {

--- a/include/vinecopulib/bicop/implementation/gaussian.ipp
+++ b/include/vinecopulib/bicop/implementation/gaussian.ipp
@@ -19,7 +19,7 @@ inline GaussianBicop::GaussianBicop()
     parameters_upper_bounds_ << 1;
 }
 
-inline Eigen::VectorXd GaussianBicop::pdf(
+inline Eigen::VectorXd GaussianBicop::pdf_raw(
     const Eigen::Matrix<double, Eigen::Dynamic, 2> &u
 )
 {

--- a/include/vinecopulib/bicop/implementation/gumbel.ipp
+++ b/include/vinecopulib/bicop/implementation/gumbel.ipp
@@ -44,7 +44,7 @@ inline double GumbelBicop::generator_derivative2(const double &u)
            (theta / std::pow(u, 2));
 }
 
-inline Eigen::VectorXd GumbelBicop::pdf(
+inline Eigen::VectorXd GumbelBicop::pdf_raw(
     const Eigen::Matrix<double, Eigen::Dynamic, 2> &u
 )
 {

--- a/include/vinecopulib/bicop/implementation/indep.ipp
+++ b/include/vinecopulib/bicop/implementation/indep.ipp
@@ -11,7 +11,7 @@ inline IndepBicop::IndepBicop()
     parameters_ = Eigen::MatrixXd();
 }
 
-inline Eigen::VectorXd IndepBicop::pdf(
+inline Eigen::VectorXd IndepBicop::pdf_raw(
     const Eigen::Matrix<double, Eigen::Dynamic, 2> &u
 )
 {

--- a/include/vinecopulib/bicop/implementation/joe.ipp
+++ b/include/vinecopulib/bicop/implementation/joe.ipp
@@ -54,9 +54,10 @@ inline Eigen::VectorXd JoeBicop::pdf(
     auto f = [theta](const double &u1, const double &u2) {
         double t1 = std::pow(1-u1,theta);
         double t2 = std::pow(1-u2,theta);
-        return std::pow(t1 + t2 - t1 * t2,1/theta-2)
+        double res = std::pow(t1 + t2 - t1 * t2,1/theta-2)
                * std::pow(1-u1,theta-1)*std::pow(1-u2,theta-1)
                * (theta-1 + t1 + t2 - t1 * t2);
+        return std::max(DBL_MIN, std::min(res, DBL_MAX));
     };
     return tools_eigen::binaryExpr_or_nan(u, f);
 }

--- a/include/vinecopulib/bicop/implementation/joe.ipp
+++ b/include/vinecopulib/bicop/implementation/joe.ipp
@@ -46,7 +46,7 @@ inline double JoeBicop::generator_derivative2(const double &u)
            std::pow(-1 + std::pow(1 - u, theta), 2);
 }
 
-inline Eigen::VectorXd JoeBicop::pdf(
+inline Eigen::VectorXd JoeBicop::pdf_raw(
     const Eigen::Matrix<double, Eigen::Dynamic, 2> &u
 )
 {
@@ -54,10 +54,9 @@ inline Eigen::VectorXd JoeBicop::pdf(
     auto f = [theta](const double &u1, const double &u2) {
         double t1 = std::pow(1-u1,theta);
         double t2 = std::pow(1-u2,theta);
-        double res = std::pow(t1 + t2 - t1 * t2,1/theta-2)
+        return std::pow(t1 + t2 - t1 * t2,1/theta-2)
                * std::pow(1-u1,theta-1)*std::pow(1-u2,theta-1)
                * (theta-1 + t1 + t2 - t1 * t2);
-        return std::max(DBL_MIN, std::min(res, DBL_MAX));
     };
     return tools_eigen::binaryExpr_or_nan(u, f);
 }

--- a/include/vinecopulib/bicop/implementation/kernel.ipp
+++ b/include/vinecopulib/bicop/implementation/kernel.ipp
@@ -21,7 +21,7 @@ inline KernelBicop::KernelBicop()
     );
 }
 
-inline Eigen::VectorXd KernelBicop::pdf(
+inline Eigen::VectorXd KernelBicop::pdf_raw(
     const Eigen::Matrix<double, Eigen::Dynamic, 2> &u
 )
 {

--- a/include/vinecopulib/bicop/implementation/student.ipp
+++ b/include/vinecopulib/bicop/implementation/student.ipp
@@ -19,7 +19,7 @@ inline StudentBicop::StudentBicop()
     parameters_upper_bounds_ << 1, 50;
 }
 
-inline Eigen::VectorXd StudentBicop::pdf(
+inline Eigen::VectorXd StudentBicop::pdf_raw(
     const Eigen::Matrix<double, Eigen::Dynamic, 2> &u
 )
 {

--- a/include/vinecopulib/bicop/indep.hpp
+++ b/include/vinecopulib/bicop/indep.hpp
@@ -25,7 +25,7 @@ public:
 
 private:
     // PDF
-    Eigen::VectorXd pdf(
+    Eigen::VectorXd pdf_raw(
         const Eigen::Matrix<double, Eigen::Dynamic, 2> &u
     );
 

--- a/include/vinecopulib/bicop/joe.hpp
+++ b/include/vinecopulib/bicop/joe.hpp
@@ -34,7 +34,7 @@ private:
     double generator_derivative2(const double &u);
 
     // pdf
-    Eigen::VectorXd pdf(const Eigen::Matrix<double, Eigen::Dynamic, 2> &u);
+    Eigen::VectorXd pdf_raw(const Eigen::Matrix<double, Eigen::Dynamic, 2> &u);
 
     // inverse hfunction
     Eigen::VectorXd hinv1(

--- a/include/vinecopulib/bicop/kernel.hpp
+++ b/include/vinecopulib/bicop/kernel.hpp
@@ -29,7 +29,7 @@ public:
     KernelBicop();
 
 protected:
-    Eigen::VectorXd pdf(
+    Eigen::VectorXd pdf_raw(
         const Eigen::Matrix<double, Eigen::Dynamic, 2> &u
     );
 

--- a/include/vinecopulib/bicop/student.hpp
+++ b/include/vinecopulib/bicop/student.hpp
@@ -25,7 +25,7 @@ public:
 
 private:
     // PDF
-    Eigen::VectorXd pdf(
+    Eigen::VectorXd pdf_raw(
         const Eigen::Matrix<double, Eigen::Dynamic, 2> &u
     );
 

--- a/include/vinecopulib/misc/implementation/tools_interpolation.ipp
+++ b/include/vinecopulib/misc/implementation/tools_interpolation.ipp
@@ -190,7 +190,7 @@ InterpolationGrid::intergrate_1d(const Eigen::MatrixXd &u,
             tmpgrid.col(0) = grid_points_;
             tmpgrid.col(1) = Eigen::VectorXd::Constant(m, u2);
         }
-        tmpvals = interpolate(tmpgrid);
+        tmpvals = interpolate(tmpgrid).array().max(1e-4);
         tmpint = int_on_grid(upr, tmpvals, grid_points_);
         int1 = int_on_grid(1.0, tmpvals, grid_points_);
 

--- a/include/vinecopulib/misc/tools_stl.hpp
+++ b/include/vinecopulib/misc/tools_stl.hpp
@@ -147,6 +147,17 @@ inline vector <size_t> seq_int(size_t from, size_t length)
     iota(seq.begin(), seq.end(), from);
     return seq;
 }
+
+// safer version of log1p that avoids rounding errors if x ~ -1
+inline double log1p(const double& x)
+{
+    if (x < -0.5) {
+        return std::log(1.0 + x);
+    } else {
+        return std::log1p(x);
+    }
+}
+
 }
 
 }


### PR DESCRIPTION
* fixes #337 using a custom `log1p()`
* makes sure that the loglik used in fitting is the same as `pdf(u).log().sum()` by truncating in `AbstractBicop::pdf()` instad of `Bicop::pdf()`