### PR TITLE
use trunc_lvl of vine_struct in select_families

### DIFF
--- a/include/vinecopulib/vinecop/implementation/tools_select.ipp
+++ b/include/vinecopulib/vinecop/implementation/tools_select.ipp
@@ -320,6 +320,9 @@ inline FamilySelector::FamilySelector(const Eigen::MatrixXd &data,
     d_ = data.cols();
     trees_.resize(1);
     controls_ = controls;
+    if (vine_struct.get_trunc_lvl() < controls.get_trunc_lvl()) {
+        controls_.set_trunc_lvl(vine_struct.get_trunc_lvl());
+    }
     vine_struct_ = vine_struct;
     threshold_ = controls.get_threshold();
     psi0_ = controls.get_psi0();

--- a/test/src_test/include/test_vinecop_class.hpp
+++ b/test/src_test/include/test_vinecop_class.hpp
@@ -341,7 +341,6 @@ TEST_F(VinecopTest, select_finds_right_structure) {
     EXPECT_EQ(pairs_unequal, 0);
 }
 
-// in what follows, we only check if funs run without error ----------
 TEST_F(VinecopTest, fixed_truncation) {
     FitControlsVinecop controls({BicopFamily::indep});
     controls.set_trunc_lvl(2);
@@ -349,6 +348,18 @@ TEST_F(VinecopTest, fixed_truncation) {
     Vinecop fit(7);
     fit.select_all(u, controls);
     fit.select_families(u, controls);
+    
+    TriangularArray<size_t> my_rvm(7);
+    my_rvm[0] = {2, 1, 3, 4, 6, 5};
+    my_rvm[1] = {3, 1, 2, 4, 5};
+    my_rvm[2] = {1, 4, 3, 2};
+    my_rvm[3] = {1, 3, 2};
+    my_rvm[4] = {1, 2};
+    my_rvm[5] = {1};
+    RVineStructure my_struct({1, 2, 3, 4, 5, 6, 7}, my_rvm);
+    my_struct.truncate(2);
+    Vinecop fit2(u, my_struct);
+    EXPECT_EQ(fit2.get_all_pair_copulas().size(), 2);
 }
 
 TEST_F(VinecopTest, sparse_threshold_selection) {


### PR DESCRIPTION
Fixes https://github.com/vinecopulib/rvinecopulib/issues/152