### PR TITLE
speed up unit tests for kernel estimator

### DIFF
--- a/test/src_test/kernel_test.cpp
+++ b/test/src_test/kernel_test.cpp
@@ -12,5 +12,5 @@ TrafokernelTest::TrafokernelTest() {
     controls = FitControlsBicop({vinecopulib::BicopFamily::tll},
                                 "mle",
                                 GetParam());
-    u = tools_stats::simulate_uniform(2000, 2);
+    u = tools_stats::simulate_uniform(20, 2, {1});
 }


### PR DESCRIPTION
They took way to long considering how little they do.