### PR TITLE
Triangular arrays: row major storage

### DIFF
--- a/include/vinecopulib/misc/tools_serialization.hpp
+++ b/include/vinecopulib/misc/tools_serialization.hpp
@@ -52,14 +52,14 @@ triangular_array_to_ptree(TriangularArray<T> matrix)
   boost::property_tree::ptree output;
   size_t d = matrix.get_dim();
   size_t trunc_lvl = matrix.get_trunc_lvl();
-  for (size_t i = 0; i < d - 1; i++) {
-    boost::property_tree::ptree col;
-    for (size_t j = 0; j < std::min(d - i - 1, trunc_lvl); j++) {
+  for (size_t i = 0; i < std::min(d - -1, trunc_lvl); i++) {
+    boost::property_tree::ptree row;
+    for (size_t j = 0; j < d - 1 - i; j++) {
       boost::property_tree::ptree cell;
-      cell.put_value(matrix(j, i));
-      col.push_back(std::make_pair("", cell));
+      cell.put_value(matrix(i, j));
+      row.push_back(std::make_pair("", cell));
     }
-    output.push_back(std::make_pair("", col));
+    output.push_back(std::make_pair("", row));
   }
 
   return output;
@@ -134,19 +134,13 @@ ptree_to_triangular_array(const boost::property_tree::ptree input)
 
   std::vector<std::vector<T>> vec(input.size());
   size_t trunc_lvl = 0;
-  size_t d = 0;
-  for (boost::property_tree::ptree::value_type col : input) {
-    std::vector<T> col_vec(col.second.size());
+  for (boost::property_tree::ptree::value_type row : input) {
+    std::vector<T> row_vec(row.second.size());
     size_t count = 0;
-    for (boost::property_tree::ptree::value_type cell : col.second) {
-      col_vec[count] = cell.second.get_value<T>();
-      if (d == 0) {
-        trunc_lvl++;
-      }
-      count++;
+    for (boost::property_tree::ptree::value_type cell : row.second) {
+      row_vec[count++] = cell.second.get_value<T>();
     }
-    vec[d] = col_vec;
-    d++;
+    vec[trunc_lvl++] = row_vec;
   }
   return TriangularArray<T>(vec);
 }

--- a/include/vinecopulib/misc/tools_serialization.hpp
+++ b/include/vinecopulib/misc/tools_serialization.hpp
@@ -148,12 +148,7 @@ ptree_to_triangular_array(const boost::property_tree::ptree input)
     vec[d] = col_vec;
     d++;
   }
-
-  TriangularArray<T> matrix(d + 1, trunc_lvl);
-  for (size_t i = 0; i < d; i++)
-    matrix[i] = vec[i];
-
-  return matrix;
+  return TriangularArray<T>(vec);
 }
 
 //! conversion from boost::property_tree::ptree to std::vector

--- a/include/vinecopulib/misc/triangular_array.hpp
+++ b/include/vinecopulib/misc/triangular_array.hpp
@@ -23,9 +23,9 @@ namespace vinecopulib {
 //! x
 //! ```
 //! and all other elements omitted. This structure appears naturally in the
-//! representation of a vine copula model and related algorithms. Each tree
-//! corresponds to one row in the vine, starting from the top. In each tree
-//! (= row), each column represents an edge.
+//! representation of a vine copula model and related algorithms. Each row
+//! corresponds to one tree in the vine, starting from the top. In each tree
+//! (=row), each column represents an edge.
 //!
 //! For truncated vine models the last few trees are omitted. For example, a
 //! 3-truncated version of the above array contains the elements

--- a/include/vinecopulib/misc/triangular_array.hpp
+++ b/include/vinecopulib/misc/triangular_array.hpp
@@ -92,18 +92,26 @@ TriangularArray<T>::TriangularArray(size_t d, size_t trunc_lvl)
 
 //! @brief construct a truncated triangular array from nested vector.
 //!
-//! @param d the dimension of the vine.
+//! An arrax of dimension `d` has `d-1` columns and `min(trunc_lvl, d-1)` 
+//! rows.
 //! @param rows a vector of rows; the length of the first row defines
 //! the dimension of the triangular array. The number of rows defines
 //! the truncation level.
 template<typename T>
 TriangularArray<T>::TriangularArray(const std::vector<std::vector<T>>& rows)
-  : d_(rows[0].size())
+  : d_(rows[0].size() + 1)
   , trunc_lvl_(rows.size())
 {
-  if (trunc_lvl_ > d_)
-    throw std::runtime_error(
-      "Input does not define a triangular array: more rows than columns.");
+  std::string problem = "Not a triangular array: ";
+  if (trunc_lvl_ > d_) {
+    throw std::runtime_error(problem + "more rows than columns.");
+  }
+  for (size_t i = 0; i < trunc_lvl_; i++) {
+    if (rows[i].size() != d_ - 1 - i) {
+        throw std::runtime_error(problem + "row i must have d - 1 - i entries.");
+    }
+  }
+  
   arr_ = rows;
 }
 
@@ -155,8 +163,10 @@ TriangularArray<T>::operator==(const TriangularArray<T>& rhs) const
     return false;
 
   for (size_t i = 0; i < trunc_lvl_; i++) {
-    if (arr_[i] != rhs[i])
-      return false;
+    for (size_t j = 0; j < d_ - 1 - i; j++) {
+      if ((*this)(i, j) != rhs(i, j))
+        return false;
+    }
   }
   return true;
 }
@@ -185,7 +195,7 @@ TriangularArray<T>::str() const
 {
   std::stringstream str;
   for (size_t i = 0; i < trunc_lvl_; i++) {
-    for (size_t j = 0; j < d_ - i - 1; j++) {
+    for (size_t j = 0; j < d_ - 1 - i; j++) {
       str << arr_[i][j] << " ";
     }
     str << std::endl;

--- a/include/vinecopulib/misc/triangular_array.hpp
+++ b/include/vinecopulib/misc/triangular_array.hpp
@@ -23,11 +23,11 @@ namespace vinecopulib {
 //! x
 //! ```
 //! and all other elements omitted. This structure appears naturally in the
-//! representation of a vine copula model and related algorithms. Each row
-//! corresponds to one tree in the vine, starting from the top. In each row
-//! (= tree), each column represents an edge in this tree.
+//! representation of a vine copula model and related algorithms. Each tree
+//! corresponds to one row in the vine, starting from the top. In each tree
+//! (= row), each column represents an edge.
 //!
-//! For truncated vine models the last few rows are omitted. For example, a
+//! For truncated vine models the last few trees are omitted. For example, a
 //! 3-truncated version of the above array contains the elements
 //! ```
 //! x x x x x
@@ -46,10 +46,10 @@ public:
   TriangularArray(size_t d);
   TriangularArray(size_t d, size_t trunc_lvl);
 
-  T& operator()(size_t tree, size_t edge);
-  T operator()(size_t tree, size_t edge) const;
-  std::vector<T>& operator[](size_t column);
-  std::vector<T> operator[](size_t column) const;
+  T& operator()(size_t row, size_t column);
+  T operator()(size_t row, size_t column) const;
+  std::vector<T>& operator[](size_t row);
+  std::vector<T> operator[](size_t row) const;
   bool operator==(const TriangularArray<T>& rhs) const;
 
   void set_column(size_t column, const std::vector<size_t>& new_column);
@@ -63,7 +63,7 @@ public:
 private:
   size_t d_;
   size_t trunc_lvl_;
-  std::vector<std::vector<T>> mat_;
+  std::vector<std::vector<T>> arr_;
 };
 
 //! @brief construct a triangular array of dimension `d`.
@@ -77,7 +77,7 @@ TriangularArray<T>::TriangularArray(size_t d)
 
 //! @brief construct a truncated triangular array
 //!
-//! The array has `d-1` columns and `min(trunv_lvl, d-1)` rows.
+//! The array has `d-1` columns and `min(trunc_lvl, d-1)` rows.
 //! @param d the dimension of the vine.
 //! @param trunc_lvl the truncation level.
 template<typename T>
@@ -88,74 +88,51 @@ TriangularArray<T>::TriangularArray(size_t d, size_t trunc_lvl)
   if (d < 2)
     throw std::runtime_error("d should be greater than 1");
 
-  mat_ = std::vector<std::vector<T>>(d - 1);
-  for (size_t i = 0; i < d - 1; i++)
-    mat_[i] = std::vector<T>(std::min(d - i - 1, trunc_lvl));
+  arr_ = std::vector<std::vector<T>>(trunc_lvl_);
+  for (size_t i = 0; i < trunc_lvl_; i++)
+    arr_[i] = std::vector<T>(d_ - i);
 }
 
 //! @brief access one element of the trapezoid (writable).
-//! @param tree the tree level.
-//! @param edge the edge in this tree.
+//! @param row the row level.
+//! @param column the column in this row.
 template<typename T>
 T&
-TriangularArray<T>::operator()(size_t tree, size_t edge)
+TriangularArray<T>::operator()(size_t row, size_t column)
 {
-  assert(tree < trunc_lvl_);
-  assert(edge < d_ - 1 - tree);
-  return mat_[edge][tree];
+  assert(row < trunc_lvl_);
+  assert(column < d_ - 1 - row);
+  return arr_[row][column];
 }
 
 //! @brief access one element of the trapezoid (non-writable).
-//! @param tree the tree level.
-//! @param edge the edge in this tree.
+//! @param row the row level.
+//! @param column the column in this row.
 template<typename T>
 T
-TriangularArray<T>::operator()(size_t tree, size_t edge) const
+TriangularArray<T>::operator()(size_t row, size_t column) const
 {
-  assert(tree < trunc_lvl_);
-  assert(edge < d_ - 1 - tree);
-  return mat_[edge][tree];
+  assert(row < trunc_lvl_);
+  assert(column < d_ - 1 - row);
+  return arr_[row][column];
 }
 
-//! @brief access one column of the trapezoid (writable).
-//! @param column which column to extract.
+//! @brief access one row of the trapezoid (writable).
+//! @param row which row to extract.
 template<typename T>
-std::vector<T>& TriangularArray<T>::operator[](size_t column)
+std::vector<T>& TriangularArray<T>::operator[](size_t row)
 {
-  assert(column < d_ - 1);
-  return mat_[column];
+  assert(row < trunc_lvl_);
+  return arr_[row];
 }
 
-//! @brief access one column of the trapezoid (non-writable).
-//! @param column which column to extract.
+//! @brief access one row of the trapezoid (non-writable).
+//! @param row which row to extract.
 template<typename T>
-std::vector<T> TriangularArray<T>::operator[](size_t column) const
+std::vector<T> TriangularArray<T>::operator[](size_t row) const
 {
-  assert(column < d_ - 1);
-  return mat_[column];
-}
-
-//! @brief set one column of the trapezoid.
-//! @param column which column to set.
-//! @param new_column the column column to set.
-template<typename T>
-void
-TriangularArray<T>::set_column(size_t column,
-                               const std::vector<size_t>& new_column)
-{
-  if (column >= d_ - 1) {
-    std::stringstream problem;
-    problem << "column should be smaller than " << d_ - 1 << ".";
-    throw std::runtime_error(problem.str());
-  }
-  if (new_column.size() != mat_[column].size()) {
-    std::stringstream problem;
-    problem << "column " << column << " should have size "
-            << mat_[column].size() << ".";
-    throw std::runtime_error(problem.str());
-  }
-
-  mat_[column] = new_column;
+  assert(row < trunc_lvl_);
+  return arr_[row];
 }
 
 //! @brief truncates the trapezoid.
@@ -166,11 +143,9 @@ template<typename T>
 void
 TriangularArray<T>::truncate(size_t trunc_lvl)
 {
-  if (trunc_lvl < this->get_trunc_lvl()) {
+  if (trunc_lvl < trunc_lvl_) {
     trunc_lvl_ = trunc_lvl;
-    for (size_t column = 0; column < d_ - 1 - trunc_lvl; column++) {
-      mat_[column].resize(trunc_lvl);
-    }
+    arr_.resize(trunc_lvl);
   }
 }
 
@@ -183,8 +158,8 @@ TriangularArray<T>::operator==(const TriangularArray<T>& rhs) const
   if ((d_ != rhs.get_dim()) | (trunc_lvl_ != rhs.get_trunc_lvl()))
     return false;
 
-  for (size_t i = 0; i < d_ - 1; i++) {
-    if (!((*this)[i] == rhs[i]))
+  for (size_t i = 0; i < trunc_lvl_; i++) {
+    if (arr_[i] != rhs[i])
       return false;
   }
   return true;
@@ -207,22 +182,22 @@ TriangularArray<T>::get_dim() const
   return d_;
 }
 
-//! represent RightTrapezoid as a string.
+//! represent triangular array as a string.
 template<typename T>
 std::string
 TriangularArray<T>::str() const
 {
   std::stringstream str;
-  for (size_t i = 0; i < std::min(d_ - 1, trunc_lvl_); i++) {
+  for (size_t i = 0; i < trunc_lvl_; i++) {
     for (size_t j = 0; j < d_ - i - 1; j++) {
-      str << (*this)(i, j) << " ";
+      str << arr_[i][j] << " ";
     }
     str << std::endl;
   }
   return str.str();
 }
 
-//! @brief ostream method for RightTrapezoid, to be used with `std::cout`
+//! @brief ostream method for TriangularArray, to be used with `std::cout`
 //! @param os an output stream.
 //! @param tri_array n triangular array.
 template<typename T>

--- a/include/vinecopulib/misc/triangular_array.hpp
+++ b/include/vinecopulib/misc/triangular_array.hpp
@@ -45,14 +45,11 @@ public:
   TriangularArray() = default;
   TriangularArray(size_t d);
   TriangularArray(size_t d, size_t trunc_lvl);
+  TriangularArray(const std::vector<std::vector<T>>& rows);
 
   T& operator()(size_t row, size_t column);
   T operator()(size_t row, size_t column) const;
-  std::vector<T>& operator[](size_t row);
-  std::vector<T> operator[](size_t row) const;
   bool operator==(const TriangularArray<T>& rhs) const;
-
-  void set_column(size_t column, const std::vector<size_t>& new_column);
   void truncate(size_t trunc_lvl);
 
   size_t get_trunc_lvl() const;
@@ -93,6 +90,23 @@ TriangularArray<T>::TriangularArray(size_t d, size_t trunc_lvl)
     arr_[i] = std::vector<T>(d_ - i);
 }
 
+//! @brief construct a truncated triangular array from nested vector.
+//!
+//! @param d the dimension of the vine.
+//! @param rows a vector of rows; the length of the first row defines
+//! the dimension of the triangular array. The number of rows defines
+//! the truncation level.
+template<typename T>
+TriangularArray<T>::TriangularArray(const std::vector<std::vector<T>>& rows)
+  : d_(rows[0].size())
+  , trunc_lvl_(rows.size())
+{
+  if (trunc_lvl_ > d_)
+    throw std::runtime_error(
+      "Input does not define a triangular array: more rows than columns.");
+  arr_ = rows;
+}
+
 //! @brief access one element of the trapezoid (writable).
 //! @param row the row level.
 //! @param column the column in this row.
@@ -115,24 +129,6 @@ TriangularArray<T>::operator()(size_t row, size_t column) const
   assert(row < trunc_lvl_);
   assert(column < d_ - 1 - row);
   return arr_[row][column];
-}
-
-//! @brief access one row of the trapezoid (writable).
-//! @param row which row to extract.
-template<typename T>
-std::vector<T>& TriangularArray<T>::operator[](size_t row)
-{
-  assert(row < trunc_lvl_);
-  return arr_[row];
-}
-
-//! @brief access one row of the trapezoid (non-writable).
-//! @param row which row to extract.
-template<typename T>
-std::vector<T> TriangularArray<T>::operator[](size_t row) const
-{
-  assert(row < trunc_lvl_);
-  return arr_[row];
 }
 
 //! @brief truncates the trapezoid.

--- a/include/vinecopulib/vinecop/implementation/rvine_structure.ipp
+++ b/include/vinecopulib/vinecop/implementation/rvine_structure.ipp
@@ -550,7 +550,7 @@ RVineStructure::check_columns() const
 
     size_t unique_in_col = std::unique(col.begin(), col.end()) - col.begin();
     if (unique_in_col != col.size()) {
-      problem = "columns must not contain duplicate entries.";
+      problem = "a column must not contain duplicate entries.";
     }
     if (problem != "") {
         throw std::runtime_error("not a valid R-vine array: " + problem);

--- a/test/src_test/include/test_rvine_structure.hpp
+++ b/test/src_test/include/test_rvine_structure.hpp
@@ -35,6 +35,13 @@ TEST(rvine_structure, triangular_array_works)
                                                     { 4, 4, 2 },
                                                     { 6, 5 },
                                                     { 5, 2 /* TOO MANY*/ } }));
+  EXPECT_ANY_THROW(TriangularArray<size_t> my_rvm({ { 2, 3, 1, 1, 1, 1 },
+                                                    { 1, 1, 4, 3, 2 },
+                                                    { 3, 2, 3, 2 },
+                                                    { 4, 4, 2 },
+                                                    { 6, 5 },
+                                                    { 5 },
+                                                    { 5 }  /* TOO MANY*/ }));
   EXPECT_NO_THROW(TriangularArray<size_t> my_rvm(
                     { { 2, 3, 1, 1, 1, 1 }, { 1, 1, 4, 3, 2 } }));
   my_rvm.truncate(2);

--- a/test/src_test/include/test_rvine_structure.hpp
+++ b/test/src_test/include/test_rvine_structure.hpp
@@ -15,14 +15,12 @@ using namespace vinecopulib;
 
 TEST(rvine_structure, triangular_array_works)
 {
-
-  TriangularArray<size_t> my_rvm(7);
-  my_rvm[0] = { 2, 1, 3, 4, 6, 5 };
-  my_rvm[1] = { 3, 1, 2, 4, 5 };
-  my_rvm[2] = { 1, 4, 3, 2 };
-  my_rvm[3] = { 1, 3, 2 };
-  my_rvm[4] = { 1, 2 };
-  my_rvm[5] = { 1 };
+  TriangularArray<size_t> my_rvm({ { 2, 3, 1, 1, 1, 1 },
+                                   { 1, 1, 4, 3, 2 },
+                                   { 3, 2, 3, 2 },
+                                   { 4, 4, 2 },
+                                   { 6, 5 },
+                                   { 5 } });
 
   EXPECT_NO_THROW(my_rvm.str());
 
@@ -31,32 +29,38 @@ TEST(rvine_structure, triangular_array_works)
   EXPECT_EQ(oss.str(), my_rvm.str());
 
   std::vector<size_t> myvec = { 1, 2 };
-  EXPECT_NO_THROW(my_rvm.set_column(4, myvec));
-  EXPECT_ANY_THROW(my_rvm.set_column(6, myvec));
-  EXPECT_ANY_THROW(my_rvm.set_column(3, myvec));
-
+  EXPECT_ANY_THROW(TriangularArray<size_t> my_rvm({ { 2, 3, 1, 1, 1, 1 },
+                                                    { 1, 1, 4, 3, 2 },
+                                                    { 3, 2, 3, 2 },
+                                                    { 4, 4, 2 },
+                                                    { 6, 5 },
+                                                    { 5, 2 /* TOO MANY*/ } }));
+  EXPECT_NO_THROW(TriangularArray<size_t> my_rvm(
+                    { { 2, 3, 1, 1, 1, 1 }, { 1, 1, 4, 3, 2 } }));
   my_rvm.truncate(2);
   EXPECT_EQ(my_rvm.get_trunc_lvl(), 2);
-  EXPECT_EQ(my_rvm[0].size(), 2);
 }
 
 TEST(rvine_structure, rvine_structure_print)
 {
-
   Eigen::Matrix<size_t, Eigen::Dynamic, Eigen::Dynamic> mat(7, 7);
-  mat << 5, 2, 6, 6, 6, 6, 6, 6, 6, 1, 2, 5, 5, 0, 2, 5, 2, 5, 2, 0, 0, 1, 1, 5,
-    1, 0, 0, 0, 3, 7, 7, 0, 0, 0, 0, 7, 3, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0;
+  mat << 5, 2, 6, 6, 6, 6, 6,
+         6, 6, 1, 2, 5, 5, 0,
+         2, 5, 2, 5, 2, 0, 0,
+         1, 1, 5, 1, 0, 0, 0,
+         3, 7, 7, 0, 0, 0, 0,
+         7, 3, 0, 0, 0, 0, 0,
+         4, 0, 0, 0, 0, 0, 0;
   RVineStructure rvine_structure(mat);
   EXPECT_NO_THROW(rvine_structure.str());
 
-  TriangularArray<size_t> my_rvm(8);
-  my_rvm[0] = { 5, 6, 2, 1, 3, 7, 4 };
-  my_rvm[1] = { 2, 6, 5, 1, 7, 3 };
-  my_rvm[2] = { 6, 1, 2, 5, 7 };
-  my_rvm[3] = { 6, 2, 5, 1 };
-  my_rvm[4] = { 6, 5, 2 };
-  my_rvm[5] = { 6, 5 };
-  my_rvm[6] = { 6 };
+  TriangularArray<size_t> my_rvm({ { 5, 2, 6, 6, 6, 6, 6 },
+                                   { 6, 6, 1, 2, 5, 5 },
+                                   { 2, 5, 2, 5, 2 },
+                                   { 1, 1, 5, 1 },
+                                   { 3, 7, 7 },
+                                   { 7, 3 },
+                                   { 4 } });
 
   std::ostringstream oss;
   oss << rvine_structure;
@@ -66,16 +70,20 @@ TEST(rvine_structure, rvine_structure_print)
 TEST(rvine_structure, can_convert_to_natural_order)
 {
   Eigen::Matrix<size_t, Eigen::Dynamic, Eigen::Dynamic> mat(7, 7);
-  mat << 5, 2, 6, 6, 6, 6, 6, 6, 6, 1, 2, 5, 5, 0, 2, 5, 2, 5, 2, 0, 0, 1, 1, 5,
-    1, 0, 0, 0, 3, 7, 7, 0, 0, 0, 0, 7, 3, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0;
+  mat << 5, 2, 6, 6, 6, 6, 6,
+         6, 6, 1, 2, 5, 5, 0,
+         2, 5, 2, 5, 2, 0, 0,
+         1, 1, 5, 1, 0, 0, 0,
+         3, 7, 7, 0, 0, 0, 0,
+         7, 3, 0, 0, 0, 0, 0,
+         4, 0, 0, 0, 0, 0, 0;
 
-  TriangularArray<size_t> true_no_array(7);
-  true_no_array[0] = { 6, 7, 5, 4, 2, 3 };
-  true_no_array[1] = { 5, 7, 6, 4, 3 };
-  true_no_array[2] = { 7, 4, 5, 6 };
-  true_no_array[3] = { 7, 5, 6 };
-  true_no_array[4] = { 7, 6 };
-  true_no_array[5] = { 7 };
+  TriangularArray<size_t> true_no_array({ { 6, 5, 7, 7, 7, 7 },
+                                          { 7, 7, 4, 5, 6 },
+                                          { 5, 6, 5, 6 },
+                                          { 4, 4, 6 },
+                                          { 2, 3 },
+                                          { 3 } });
 
   RVineStructure rvine_structure(mat);
   EXPECT_EQ(rvine_structure.get_struct_array(), true_no_array);
@@ -84,86 +92,105 @@ TEST(rvine_structure, can_convert_to_natural_order)
 TEST(rvine_structure, min_array_is_correct)
 {
   Eigen::Matrix<size_t, Eigen::Dynamic, Eigen::Dynamic> mat(7, 7);
-  mat << 5, 2, 6, 6, 6, 6, 6, 6, 6, 1, 2, 5, 5, 0, 2, 5, 2, 5, 2, 0, 0, 1, 1, 5,
-    1, 0, 0, 0, 3, 7, 7, 0, 0, 0, 0, 7, 3, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0;
+  mat << 5, 2, 6, 6, 6, 6, 6,
+         6, 6, 1, 2, 5, 5, 0,
+         2, 5, 2, 5, 2, 0, 0,
+         1, 1, 5, 1, 0, 0, 0,
+         3, 7, 7, 0, 0, 0, 0,
+         7, 3, 0, 0, 0, 0, 0,
+         4, 0, 0, 0, 0, 0, 0;
 
-  TriangularArray<size_t> true_min_array(7);
-  true_min_array[0] = { 6, 6, 5, 4, 2, 2 };
-  true_min_array[1] = { 5, 5, 5, 4, 3 };
-  true_min_array[2] = { 7, 4, 4, 4 };
-  true_min_array[3] = { 7, 5, 5 };
-  true_min_array[4] = { 7, 6 };
-  true_min_array[5] = { 7 };
-
+  TriangularArray<size_t> true_min_array({ { 6, 5, 7, 7, 7, 7 },
+                                           { 6, 5, 4, 5, 6 },
+                                           { 5, 5, 4, 5 },
+                                           { 4, 4, 4 },
+                                           { 2, 3 },
+                                           { 2 } });
   RVineStructure rvine_structure(mat);
   EXPECT_EQ(rvine_structure.get_min_array(), true_min_array);
 
   rvine_structure.truncate(2);
   EXPECT_EQ(rvine_structure.get_trunc_lvl(), 2);
-  EXPECT_EQ(rvine_structure.get_min_array()[0].size(), 2);
+  EXPECT_EQ(rvine_structure.get_min_array().get_trunc_lvl(), 2);
 }
 
 TEST(rvine_structure, needed_hfunc1_is_correct)
 {
   Eigen::Matrix<size_t, Eigen::Dynamic, Eigen::Dynamic> mat(7, 7);
-  mat << 5, 2, 6, 6, 6, 6, 6, 6, 6, 1, 2, 5, 5, 0, 2, 5, 2, 5, 2, 0, 0, 1, 1, 5,
-    1, 0, 0, 0, 3, 7, 7, 0, 0, 0, 0, 7, 3, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0;
+  mat << 5, 2, 6, 6, 6, 6, 6,
+         6, 6, 1, 2, 5, 5, 0,
+         2, 5, 2, 5, 2, 0, 0,
+         1, 1, 5, 1, 0, 0, 0,
+         3, 7, 7, 0, 0, 0, 0,
+         7, 3, 0, 0, 0, 0, 0,
+         4, 0, 0, 0, 0, 0, 0;
 
-  TriangularArray<size_t> true_hfunc1(7);
-  true_hfunc1[0] = { 0, 0, 0, 0, 0, 0 };
-  true_hfunc1[1] = { 0, 0, 0, 0, 1 };
-  true_hfunc1[2] = { 0, 0, 0, 0 };
-  true_hfunc1[3] = { 0, 1, 1 };
-  true_hfunc1[4] = { 1, 1 };
-  true_hfunc1[5] = { 1 };
+  TriangularArray<size_t> true_hfunc1({ { 0, 0, 0, 0, 1, 1 },
+                                        { 0, 0, 0, 1, 1 },
+                                        { 0, 0, 0, 1 },
+                                        { 0, 0, 0 },
+                                        { 0, 1 },
+                                        { 0 } });
 
   RVineStructure rvine_structure(mat);
   EXPECT_EQ(rvine_structure.get_needed_hfunc1(), true_hfunc1);
 
   rvine_structure.truncate(2);
-  EXPECT_EQ(rvine_structure.get_needed_hfunc1()[0].size(), 2);
+  EXPECT_EQ(rvine_structure.get_needed_hfunc1().get_trunc_lvl(), 2);
 }
 
 TEST(rvine_structure, needed_hfunc2_is_correct)
 {
   Eigen::Matrix<size_t, Eigen::Dynamic, Eigen::Dynamic> mat(7, 7);
-  mat << 5, 2, 6, 6, 6, 6, 6, 6, 6, 1, 2, 5, 5, 0, 2, 5, 2, 5, 2, 0, 0, 1, 1, 5,
-    1, 0, 0, 0, 3, 7, 7, 0, 0, 0, 0, 7, 3, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0;
+  mat << 5, 2, 6, 6, 6, 6, 6,
+         6, 6, 1, 2, 5, 5, 0,
+         2, 5, 2, 5, 2, 0, 0,
+         1, 1, 5, 1, 0, 0, 0,
+         3, 7, 7, 0, 0, 0, 0,
+         7, 3, 0, 0, 0, 0, 0,
+         4, 0, 0, 0, 0, 0, 0;
 
-  TriangularArray<size_t> true_hfunc2(7);
-  true_hfunc2[0] = { 1, 1, 1, 1, 1, 0 };
-  true_hfunc2[1] = { 1, 1, 1, 1, 0 };
-  true_hfunc2[2] = { 1, 1, 1, 1 };
-  true_hfunc2[3] = { 1, 1, 1 };
-  true_hfunc2[4] = { 1, 1 };
-  true_hfunc2[5] = { 1 };
+  TriangularArray<size_t> true_hfunc2({ { 1, 1, 1, 1, 1, 1 },
+                                        { 1, 1, 1, 1, 1 },
+                                        { 1, 1, 1, 1 },
+                                        { 1, 1, 1 },
+                                        { 1, 0 },
+                                        { 0 } });
 
   RVineStructure rvine_structure(mat);
   EXPECT_EQ(rvine_structure.get_needed_hfunc2(), true_hfunc2);
 
   rvine_structure.truncate(2);
-  EXPECT_EQ(rvine_structure.get_needed_hfunc2()[0].size(), 2);
+  EXPECT_EQ(rvine_structure.get_needed_hfunc2().get_trunc_lvl(), 2);
 }
 
 TEST(rvine_structure, construct_d_vine_struct_is_correct)
 {
 
-  Eigen::Matrix<size_t, Eigen::Dynamic, Eigen::Dynamic> true_d_vine_matrix(7,
-                                                                           7);
-  true_d_vine_matrix << 4, 1, 5, 3, 2, 7, 7, 1, 5, 3, 2, 7, 2, 0, 5, 3, 2, 7, 3,
-    0, 0, 3, 2, 7, 5, 0, 0, 0, 2, 7, 1, 0, 0, 0, 0, 7, 4, 0, 0, 0, 0, 0, 6, 0,
-    0, 0, 0, 0, 0;
+  Eigen::Matrix<size_t, Eigen::Dynamic, Eigen::Dynamic> d_vine_mat(7, 7);
+  d_vine_mat << 4, 1, 5, 3, 2, 7, 7,
+                1, 5, 3, 2, 7, 2, 0,
+                5, 3, 2, 7, 3, 0, 0,
+                3, 2, 7, 5, 0, 0, 0,
+                2, 7, 1, 0, 0, 0, 0,
+                7, 4, 0, 0, 0, 0, 0,
+                6, 0, 0, 0, 0, 0, 0;
 
   std::vector<size_t> order = { 6, 4, 1, 5, 3, 2, 7 };
   RVineStructure rvine_structure(order);
-  EXPECT_EQ(rvine_structure.get_matrix(), true_d_vine_matrix);
+  EXPECT_EQ(rvine_structure.get_matrix(), d_vine_mat);
 }
 
 TEST(rvine_structure, rvine_struct_sanity_checks_work)
 {
   Eigen::Matrix<size_t, Eigen::Dynamic, Eigen::Dynamic> mat(7, 7);
-  mat << 5, 2, 6, 6, 6, 6, 6, 6, 6, 1, 2, 5, 5, 0, 2, 5, 2, 5, 2, 0, 0, 1, 1, 5,
-    1, 0, 0, 0, 3, 7, 7, 0, 0, 0, 0, 7, 3, 0, 0, 0, 0, 0, 4, 0, 0, 0, 0, 0, 0;
+  mat << 5, 2, 6, 6, 6, 6, 6,
+         6, 6, 1, 2, 5, 5, 0,
+         2, 5, 2, 5, 2, 0, 0,
+         1, 1, 5, 1, 0, 0, 0,
+         3, 7, 7, 0, 0, 0, 0,
+         7, 3, 0, 0, 0, 0, 0,
+         4, 0, 0, 0, 0, 0, 0;
 
   // should pass without errors
   auto rvm = RVineStructure(mat);

--- a/test/src_test/include/test_vinecop_class.hpp
+++ b/test/src_test/include/test_vinecop_class.hpp
@@ -363,14 +363,12 @@ TEST_F(VinecopTest, fixed_truncation)
   Vinecop fit(7);
   fit.select_all(u, controls);
   fit.select_families(u, controls);
-
-  TriangularArray<size_t> my_rvm(7);
-  my_rvm[0] = { 2, 1, 3, 4, 6, 5 };
-  my_rvm[1] = { 3, 1, 2, 4, 5 };
-  my_rvm[2] = { 1, 4, 3, 2 };
-  my_rvm[3] = { 1, 3, 2 };
-  my_rvm[4] = { 1, 2 };
-  my_rvm[5] = { 1 };
+  TriangularArray<size_t> my_rvm({ { 2, 3, 1, 1, 1, 1 },
+                                   { 1, 1, 4, 3, 2 },
+                                   { 3, 2, 3, 2 },
+                                   { 4, 4, 2 },
+                                   { 6, 5 },
+                                   { 5 } });
   RVineStructure my_struct({ 7, 6, 5, 4, 3, 2, 1 }, my_rvm);
   my_struct.truncate(2);
   Vinecop fit2(u, my_struct);


### PR DESCRIPTION
#### BREAKING CHANGE

- use row-major format to store values internally in `TriangularArray`
- remove `[]` accessors because they were unsafe
- add ctor expecting `std::vector<std::vector<T>>`
- change serialization format to row major as well

#### Reasons

- Row major is more intuitive (1 row = 1 tree)
- Code becomes simpler
- Interfaces become simpler