### PR TITLE
Ensure consistency in manually created TLL Bicop (fixes #440)

### DIFF
--- a/include/vinecopulib/bicop/implementation/kernel.ipp
+++ b/include/vinecopulib/bicop/implementation/kernel.ipp
@@ -16,8 +16,14 @@ inline KernelBicop::KernelBicop()
   Eigen::VectorXd grid_points(m);
   for (size_t i = 0; i < m; ++i)
     grid_points(i) = -3.25 + i * (6.5 / static_cast<double>(m - 1));
+  grid_points = tools_stats::pnorm(grid_points);
+  
+  // move boundary points to 0/1, so we don't have to extrapolate
+  grid_points(0) = 0.0;
+  grid_points(m - 1) = 1.0;
+  
   interp_grid_ = std::make_shared<tools_interpolation::InterpolationGrid>(
-    tools_stats::pnorm(grid_points),
+    grid_points,
     Eigen::MatrixXd::Constant(m, m, 1.0) // independence
   );
 }

--- a/include/vinecopulib/bicop/implementation/kernel.ipp
+++ b/include/vinecopulib/bicop/implementation/kernel.ipp
@@ -67,12 +67,14 @@ KernelBicop::hinv2(const Eigen::Matrix<double, Eigen::Dynamic, 2>& u)
 inline double
 KernelBicop::parameters_to_tau(const Eigen::MatrixXd& parameters)
 {
-  set_parameters(parameters);
+  auto oldpars = this->get_parameters();
+  this->set_parameters(parameters);
   std::vector<int> seeds = {
     204967043, 733593603, 184618802, 399707801, 290266245
   };
   auto u = tools_stats::ghalton(1000, 2, seeds);
   u.col(1) = hinv1(u);
+  this->set_parameters(oldpars);
   return wdm::wdm(u, "tau")(0, 1);
 }
 
@@ -108,7 +110,8 @@ KernelBicop::set_parameters(const Eigen::MatrixXd& parameters)
     message << "density should be larger than 0. ";
     throw std::runtime_error(message.str().c_str());
   }
-  interp_grid_->set_values(parameters);
+  // don't normalize again!
+  interp_grid_->set_values(parameters, 0);
 }
 
 inline void

--- a/test/src_test/include/test_bicop_kernel.hpp
+++ b/test/src_test/include/test_bicop_kernel.hpp
@@ -83,6 +83,16 @@ TEST_P(TrafokernelTest, tau)
   EXPECT_LE(tau, 1.0);
 }
 
+TEST_P(TrafokernelTest, reset)
+{
+  // this is essentially what we do when converting between C++ and R objects
+  auto cop = Bicop(u, controls);
+  auto cop_new = Bicop(BicopFamily::tll, 0, cop.get_parameters());
+  EXPECT_EQ(cop.get_parameters(), cop_new.get_parameters());
+  EXPECT_EQ(cop.get_family(), cop_new.get_family());
+  EXPECT_EQ(cop.get_rotation(), cop_new.get_rotation());
+  EXPECT_EQ(cop.loglik(u), cop_new.loglik(u));
+}
 
 INSTANTIATE_TEST_SUITE_P(TrafokernelTest,
                          TrafokernelTest,

--- a/test/src_test/include/test_bicop_kernel.hpp
+++ b/test/src_test/include/test_bicop_kernel.hpp
@@ -11,7 +11,7 @@
 namespace test_bicop_kernel {
 using namespace vinecopulib;
 
-TEST_P(TrafokernelTest, trafo_kernel_sanity_checks)
+TEST_P(TrafokernelTest, sanity_checks)
 {
   auto values = bicop_.get_parameters();
   EXPECT_ANY_THROW(bicop_.set_parameters(values.block(0, 0, 30, 1)));
@@ -19,12 +19,12 @@ TEST_P(TrafokernelTest, trafo_kernel_sanity_checks)
   EXPECT_ANY_THROW(bicop_.set_parameters(-1 * values));
 }
 
-TEST_P(TrafokernelTest, trafo_kernel_fit)
+TEST_P(TrafokernelTest, fit)
 {
   bicop_.fit(u, controls);
 }
 
-TEST_P(TrafokernelTest, trafo_kernel_eval_funcs)
+TEST_P(TrafokernelTest, eval_funcs)
 {
   bicop_.fit(u, controls);
 
@@ -60,14 +60,14 @@ TEST_P(TrafokernelTest, trafo_kernel_eval_funcs)
   EXPECT_NO_THROW(bicop_.loglik(u.block(0, 0, 10, 2)));
 }
 
-TEST_P(TrafokernelTest, trafo_kernel_select)
+TEST_P(TrafokernelTest, select)
 {
   auto newcop = Bicop(u, controls);
   EXPECT_EQ(newcop.loglik(u), newcop.get_loglik());
   EXPECT_EQ(newcop.get_family(), BicopFamily::tll);
 }
 
-TEST_P(TrafokernelTest, trafo_kernel_flip)
+TEST_P(TrafokernelTest, flip)
 {
   auto pdf = bicop_.pdf(u);
   u.col(0).swap(u.col(1));
@@ -76,12 +76,13 @@ TEST_P(TrafokernelTest, trafo_kernel_flip)
   EXPECT_TRUE(pdf.isApprox(pdf_flipped, 1e-10));
 }
 
-TEST_P(TrafokernelTest, trafo_kernel_tau)
+TEST_P(TrafokernelTest, tau)
 {
   double tau = bicop_.parameters_to_tau(bicop_.get_parameters());
   EXPECT_GE(tau, -1.0);
   EXPECT_LE(tau, 1.0);
 }
+
 
 INSTANTIATE_TEST_SUITE_P(TrafokernelTest,
                          TrafokernelTest,


### PR DESCRIPTION
Ensures that `cop == cop_new`, where
``` cpp

auto cop = Bicop(u, FitControlsBicop({BicopFamily::tll}});
auto cop_new = Bicop(BicopFamily::tll, 0, cop.get_parameters());
```
This is what we do when converting R and C++ objects. 