### PR TITLE
discrete variables with reduced matrix input

### DIFF
--- a/include/vinecopulib/bicop/class.hpp
+++ b/include/vinecopulib/bicop/class.hpp
@@ -118,7 +118,7 @@ public:
   Bicop as_continuous() const;
 
 private:
-  Eigen::MatrixXd extend_data(const Eigen::MatrixXd& u) const;
+  Eigen::MatrixXd format_data(const Eigen::MatrixXd& u) const;
 
   Eigen::MatrixXd clip_data(const Eigen::MatrixXd& u) const;
 

--- a/include/vinecopulib/bicop/class.hpp
+++ b/include/vinecopulib/bicop/class.hpp
@@ -118,7 +118,13 @@ public:
   Bicop as_continuous() const;
 
 private:
-  Eigen::MatrixXd cut_and_rotate(const Eigen::MatrixXd& u) const;
+  Eigen::MatrixXd extend_data(const Eigen::MatrixXd& u) const;
+
+  Eigen::MatrixXd clip_data(const Eigen::MatrixXd& u) const;
+
+  Eigen::MatrixXd rotate_data(const Eigen::MatrixXd& u) const;
+
+  Eigen::MatrixXd prep_for_abstract(const Eigen::MatrixXd& u) const;
 
   void check_rotation(int rotation) const;
 
@@ -132,6 +138,8 @@ private:
                           const Eigen::MatrixXd& data) const;
 
   void check_fitted() const;
+
+  int get_n_discrete() const;
 
   double compute_mbic_penalty(const size_t nobs, const double psi0) const;
 

--- a/include/vinecopulib/bicop/implementation/abstract.ipp
+++ b/include/vinecopulib/bicop/implementation/abstract.ipp
@@ -196,7 +196,7 @@ AbstractBicop::hfunc1(const Eigen::MatrixXd& u)
             (uu.col(0) - uu.col(2)).array())
       .abs();
   } else {
-    return hfunc1_raw(u);
+    return hfunc1_raw(u.leftCols(2));
   }
 }
 
@@ -210,7 +210,7 @@ AbstractBicop::hfunc2(const Eigen::MatrixXd& u)
             (uu.col(1) - uu.col(3)).array())
       .abs();
   } else {
-    return hfunc2_raw(u);
+    return hfunc2_raw(u.leftCols(2));
   }
 }
 
@@ -218,7 +218,7 @@ inline Eigen::VectorXd
 AbstractBicop::hinv1(const Eigen::MatrixXd& u)
 {
   if (var_types_[0] == "c") {
-    return hinv1_raw(u);
+    return hinv1_raw(u.leftCols(2));
   } else {
     return hinv1_num(u);
   }
@@ -228,7 +228,7 @@ inline Eigen::VectorXd
 AbstractBicop::hinv2(const Eigen::MatrixXd& u)
 {
   if (var_types_[1] == "c") {
-    return hinv2_raw(u);
+    return hinv2_raw(u.leftCols(2));
   } else {
     return hinv2_num(u);
   }

--- a/include/vinecopulib/bicop/implementation/abstract.ipp
+++ b/include/vinecopulib/bicop/implementation/abstract.ipp
@@ -148,7 +148,7 @@ AbstractBicop::pdf(const Eigen::MatrixXd& u)
 
   Eigen::VectorXd pdf(u.rows());
   if (var_types_ == std::vector<std::string>{ "c", "c" }) {
-    pdf = pdf_raw(u);
+    pdf = pdf_raw(u.leftCols(2));
   } else if (var_types_ == std::vector<std::string>{ "d", "d" }) {
     pdf = pdf_d_d(u);
   } else {

--- a/include/vinecopulib/bicop/implementation/class.ipp
+++ b/include/vinecopulib/bicop/implementation/class.ipp
@@ -795,7 +795,10 @@ Bicop::extend_data(const Eigen::MatrixXd& u) const
 inline Eigen::MatrixXd
 Bicop::clip_data(const Eigen::MatrixXd& u) const
 {
-  return u.cwiseMax(1e-10).cwiseMin(1 - 1e-10);
+  auto clip = [] (const double& x) {
+    return std::min(std::max(x, 1e-10), 1 - 1e-10);
+  };
+  return tools_eigen::unaryExpr_or_nan(u, clip);
 }
 
 //! rotates the data corresponding to the models rotation.

--- a/include/vinecopulib/bicop/implementation/class.ipp
+++ b/include/vinecopulib/bicop/implementation/class.ipp
@@ -772,15 +772,14 @@ Bicop::select(const Eigen::MatrixXd& data, FitControlsBicop controls)
   }
 }
 
-
+//! adds an additional column if there's only one discrete variable. 
+//! (continuous models only require two columns, discrete models always four)
 inline Eigen::MatrixXd
 Bicop::extend_data(const Eigen::MatrixXd& u) const
 {
   if (get_n_discrete() != 1) {
     return u;
   }
-  // only one discrete variable, need to duplicate the continuous variable for
-  // u_min
   Eigen::MatrixXd u_new(u.cols(), 4);
   u_new.leftCols(2) = u;
   int disc_col = (var_types_[1] == "d");
@@ -790,12 +789,14 @@ Bicop::extend_data(const Eigen::MatrixXd& u) const
   return u_new;
 }
 
+//! clisp the data to the interval [1e-10, 1 - 1e-10] for numerical stability.
 inline Eigen::MatrixXd
 Bicop::clip_data(const Eigen::MatrixXd& u) const
 {
   return u.cwiseMax(1e-10).cwiseMin(1 - 1e-10);
 }
 
+//! rotates the data corresponding to the models rotation.
 inline Eigen::MatrixXd
 Bicop::rotate_data(const Eigen::MatrixXd& u) const
 {
@@ -823,6 +824,10 @@ Bicop::rotate_data(const Eigen::MatrixXd& u) const
   return u_new;
 }
 
+//! prepares data for use with the `AbstractBicop` class:
+//! - add an additional column if there's only one discrete variable.
+//! - clip the data to the interval [1e-10, 1 - 1e-10] for numerical stability.
+//! - rotate the data appropriately (`AbstractBicop` is always 0deg-rotation).
 inline Eigen::MatrixXd
 Bicop::prep_for_abstract(const Eigen::MatrixXd& u) const
 {
@@ -833,6 +838,7 @@ Bicop::prep_for_abstract(const Eigen::MatrixXd& u) const
   return u_new;
 }
 
+//! checks whether the supplied rotation is valid (only 0, 90, 180, 270 allowd).
 inline void
 Bicop::check_rotation(int rotation) const
 {
@@ -849,6 +855,7 @@ Bicop::check_rotation(int rotation) const
   }
 }
 
+//! checks whether weights and data have matching sizes.
 inline void
 Bicop::check_weights_size(const Eigen::VectorXd& weights,
                           const Eigen::MatrixXd& data) const
@@ -858,6 +865,7 @@ Bicop::check_weights_size(const Eigen::VectorXd& weights,
   }
 }
 
+//! checks whether the Bicop object was fitted to data.
 inline void
 Bicop::check_fitted() const
 {
@@ -867,6 +875,7 @@ Bicop::check_fitted() const
   }
 }
 
+//! returns the number of discrete variables.
 inline int
 Bicop::get_n_discrete() const
 {

--- a/include/vinecopulib/bicop/implementation/class.ipp
+++ b/include/vinecopulib/bicop/implementation/class.ipp
@@ -129,7 +129,7 @@ inline Eigen::VectorXd
 Bicop::cdf(const Eigen::MatrixXd& u) const
 {
   check_data(u);
-  Eigen::VectorXd p = bicop_->cdf(prep_for_abstract(u.leftCols(2)));
+  Eigen::VectorXd p = bicop_->cdf(prep_for_abstract(u).leftCols(2));
   switch (rotation_) {
     default:
       return p;
@@ -712,7 +712,7 @@ Bicop::select(const Eigen::MatrixXd& data, FitControlsBicop controls)
   rotation_ = 0;
   bicop_->set_loglik(0.0);
   if (data_no_nan.rows() >= 10) {
-    data_no_nan = clip_data(data_no_nan);
+    data_no_nan = prep_for_abstract(data_no_nan);
     std::vector<Bicop> bicops = create_candidate_bicops(data_no_nan, controls);
     for (auto& bc : bicops) {
       bc.set_var_types(var_types_);
@@ -780,8 +780,8 @@ Bicop::extend_data(const Eigen::MatrixXd& u) const
   if (get_n_discrete() != 1) {
     return u;
   }
-  Eigen::MatrixXd u_new(u.cols(), 4);
-  u_new.leftCols(2) = u;
+  Eigen::MatrixXd u_new(u.rows(), 4);
+  u_new.leftCols(2) = u.leftCols(2);
   int disc_col = (var_types_[1] == "d");
   int cont_col = 1 - disc_col;
   u_new.col(2 + disc_col) = u.col(2);
@@ -835,7 +835,9 @@ Bicop::prep_for_abstract(const Eigen::MatrixXd& u) const
   auto u_new = extend_data(u);
   u_new = clip_data(u_new);
   u_new.leftCols(2) = rotate_data(u_new.leftCols(2));
-  u_new.rightCols(2) = rotate_data(u_new.rightCols(2));
+  if (u_new.cols() > 2) {
+    u_new.rightCols(2) = rotate_data(u_new.rightCols(2));
+  }
   return u_new;
 }
 

--- a/include/vinecopulib/bicop/implementation/class.ipp
+++ b/include/vinecopulib/bicop/implementation/class.ipp
@@ -110,8 +110,8 @@ Bicop::to_json(const std::string filename) const
 
 //! @brief evaluates the copula density.
 //!
-//! @param u \f$ n \times 2 \f$ matrix of evaluation points for continuous
-//!    models; \f$ n \times 4 \f$ for discrete models.
+//! @param data an \f$ n \times (2 + k) \f$ matrix of observations contained in
+//!   \f$(0, 1)^2 \f$, where \f$ k \f$ is the number of discrete variables.
 //! @return The copula density evaluated at \c u.
 inline Eigen::VectorXd
 Bicop::pdf(const Eigen::MatrixXd& u) const
@@ -122,8 +122,8 @@ Bicop::pdf(const Eigen::MatrixXd& u) const
 
 //! @brief evaluates the copula distribution.
 //!
-//! @param u \f$ n \times 2 \f$ matrix of evaluation points for continuous
-//!    models; \f$ n \times 4 \f$ for discrete models.
+//! @param data an \f$ n \times (2 + k) \f$ matrix of observations contained in
+//!   \f$(0, 1)^2 \f$, where \f$ k \f$ is the number of discrete variables.
 //! @return The copula distribution evaluated at \c u.
 inline Eigen::VectorXd
 Bicop::cdf(const Eigen::MatrixXd& u) const
@@ -148,9 +148,9 @@ Bicop::cdf(const Eigen::MatrixXd& u) const
 //! @brief calculates the first h-function.
 //!
 //! The first h-function is
-//! \f$ h_1(u_1, u_2) = \int_0^{u_2} c(u_1, s) \f$.
-//! @param u \f$ n \times 2 \f$ matrix of evaluation points for continuous
-//!    models; \f$ n \times 4 \f$ for discrete models.
+//! \f$ h_1(u_1, u_2) = P(U_2 \le u_2 | U_1 = u_1) \f$.
+//! @param data an \f$ n \times (2 + k) \f$ matrix of observations contained in
+//!   \f$(0, 1)^2 \f$, where \f$ k \f$ is the number of discrete variables.
 inline Eigen::VectorXd
 Bicop::hfunc1(const Eigen::MatrixXd& u) const
 {
@@ -173,9 +173,9 @@ Bicop::hfunc1(const Eigen::MatrixXd& u) const
 //! @brief calculates the second h-function.
 //!
 //! The second h-function is
-//! \f$ h_2(u_1, u_2) = \int_0^{u_1} c(s, u_2) \f$.
-//! @param u \f$ n \times 2 \f$ matrix of evaluation points for continuous
-//!    models; \f$ n \times 4 \f$ for discrete models.
+//! \f$ h_2(u_1, u_2) = P(U_1 \le u_1 | U_2 = u_2)  \f$.
+//! @param data an \f$ n \times (2 + k) \f$ matrix of observations contained in
+//!   \f$(0, 1)^2 \f$, where \f$ k \f$ is the number of discrete variables.
 inline Eigen::VectorXd
 Bicop::hfunc2(const Eigen::MatrixXd& u) const
 {
@@ -197,8 +197,8 @@ Bicop::hfunc2(const Eigen::MatrixXd& u) const
 
 //! @brief calculates the inverse of \f$ h_1 \f$ (see hfunc1()) w.r.t. the
 //! second argument.
-//! @param u \f$ n \times 2 \f$ matrix of evaluation points for continuous
-//!    models; \f$ n \times 4 \f$ for discrete models.
+//! @param data an \f$ n \times (2 + k) \f$ matrix of observations contained in
+//!   \f$(0, 1)^2 \f$, where \f$ k \f$ is the number of discrete variables.
 inline Eigen::VectorXd
 Bicop::hinv1(const Eigen::MatrixXd& u) const
 {
@@ -220,8 +220,8 @@ Bicop::hinv1(const Eigen::MatrixXd& u) const
 
 //! @brief calculates the inverse of \f$ h_2 \f$ (see hfunc2()) w.r.t. the first
 //! argument.
-//! @param u \f$ n \times 2 \f$ matrix of evaluation points for continuous
-//!    models; \f$ n \times 4 \f$ for discrete models.
+//! @param data an \f$ n \times (2 + k) \f$ matrix of observations contained in
+//!   \f$(0, 1)^2 \f$, where \f$ k \f$ is the number of discrete variables.
 inline Eigen::VectorXd
 Bicop::hinv2(const Eigen::MatrixXd& u) const
 {
@@ -268,8 +268,8 @@ Bicop::simulate(const size_t& n,
 //! \f[ \mathrm{loglik} = \sum_{i = 1}^n \ln c(U_{1, i}, U_{2, i}), \f]
 //! where \f$ c \f$ is the copula density pdf().
 //!
-//! @param u \f$ n \times 2 \f$ matrix of observations for continuous
-//!    models; \f$ n \times 4 \f$ for discrete models.
+//! @param data an \f$ n \times (2 + k) \f$ matrix of observations contained in
+//!   \f$(0, 1)^2 \f$, where \f$ k \f$ is the number of discrete variables.
 inline double
 Bicop::loglik(const Eigen::MatrixXd& u) const
 {
@@ -290,8 +290,8 @@ Bicop::loglik(const Eigen::MatrixXd& u) const
 //! get_npars(). The AIC is a consistent model selection criterion
 //! for nonparametric models.
 //!
-//! @param u \f$ n \times 2 \f$ matrix of observations for continuous
-//!    models; \f$ n \times 4 \f$ for discrete models.
+//! @param data an \f$ n \times (2 + k) \f$ matrix of observations contained in
+//!   \f$(0, 1)^2 \f$, where \f$ k \f$ is the number of discrete variables.
 inline double
 Bicop::aic(const Eigen::MatrixXd& u) const
 {
@@ -307,8 +307,8 @@ Bicop::aic(const Eigen::MatrixXd& u) const
 //! get_npars(). The BIC is a consistent model selection criterion
 //! for parametric models.
 //!
-//! @param u \f$ n \times 2 \f$ matrix of observations for continuous
-//!    models; \f$ n \times 4 \f$ for discrete models.
+//! @param data an \f$ n \times (2 + k) \f$ matrix of observations contained in
+//!   \f$(0, 1)^2 \f$, where \f$ k \f$ is the number of discrete variables.
 inline double
 Bicop::bic(const Eigen::MatrixXd& u) const
 {
@@ -332,8 +332,8 @@ Bicop::bic(const Eigen::MatrixXd& u) const
 //! indicator for the family being non-independence; see loglik() and
 //! get_npars().
 //!
-//! @param u \f$ n \times 2 \f$ matrix of observations for continuous
-//!    models; \f$ n \times 4 \f$ for discrete models.
+//! @param data an \f$ n \times (2 + k) \f$ matrix of observations contained in
+//!   \f$(0, 1)^2 \f$, where \f$ k \f$ is the number of discrete variables.
 //! @param psi0 prior probability of a non-independence copula.
 inline double
 Bicop::mbic(const Eigen::MatrixXd& u, const double psi0) const
@@ -642,15 +642,15 @@ Bicop::as_continuous() const
 //!
 //! @details When at least one variable is discrete, two types of "observations"
 //! are required: the first \f$ n \times 2 \f$ block contains realizations of
-//! \f$ F_Y(Y), F_X(X) \f$; the second \f$ n \times 2 \f$ block contains
-//! realizations of \f$ F_Y(Y^-), F_X(X^-) \f$. The minus indicates a left-sided
-//! limit of the cdf. For continuous variables the left limit and the cdf itself
-//! coincide. For, e.g., an integer-valued variable, it holds \f$ F_Y(Y^-) =
-//! F_Y(Y - 1) \f$.
+//! \f$ F_{X_1}(X_1), F_{X_2}(X_2) \f$. Let \f$ k \f$ denote the number of
+//! discrete variables (either one or two). Then the second \f$ n \times k \f$
+//! block contains realizations of \f$ F_{X_k}(X_k^-) \f$. The minus indicates a
+//! left-sided limit of the cdf. For continuous variables the left limit and the
+//! cdf itself coincide. For, e.g., an integer-valued variable, it holds \f$
+//! F_{X_k}(X_k^-) = F_{X_k}(X_k - 1) \f$.
 //!
-//! @param data an \f$ n \times 2 \f$ matrix of observations contained in
-//!   \f$(0, 1)^2 \f$ for continuous models; \f$ n \times 4 \f$ for discrete
-//!   models.
+//! @param data an \f$ n \times (2 + k) \f$ matrix of observations contained in
+//!   \f$(0, 1)^2 \f$, where \f$ k \f$ is the number of discrete variables.
 //! @param controls the controls (see FitControlsBicop).
 inline void
 Bicop::fit(const Eigen::MatrixXd& data, const FitControlsBicop& controls)
@@ -673,25 +673,25 @@ Bicop::fit(const Eigen::MatrixXd& data, const FitControlsBicop& controls)
   nobs_ = data_no_nan.rows();
 }
 
-// 
+//
 
 //! @brief selects the best fitting model.
 //!
 //! The function calls fit() for all families in
 //! `family_set` and selecting the best fitting model by either BIC or AIC,
 //! see bic() and aic().
-//! 
+//!
 //! @details When at least one variable is discrete, two types of "observations"
 //! are required: the first \f$ n \times 2 \f$ block contains realizations of
-//! \f$ F_Y(Y), F_X(X) \f$; the second \f$ n \times 2 \f$ block contains
-//! realizations of \f$ F_Y(Y^-), F_X(X^-) \f$. The minus indicates a left-sided
-//! limit of the cdf. For continuous variables the left limit and the cdf itself
-//! coincide. For, e.g., an integer-valued variable, it holds \f$ F_Y(Y^-) =
-//! F_Y(Y - 1) \f$.
+//! \f$ F_{X_1}(X_1), F_{X_2}(X_2) \f$. Let \f$ k \f$ denote the number of
+//! discrete variables (either one or two). Then the second \f$ n \times k \f$
+//! block contains realizations of \f$ F_{X_k}(X_k^-) \f$. The minus indicates a
+//! left-sided limit of the cdf. For continuous variables the left limit and the
+//! cdf itself coincide. For, e.g., an integer-valued variable, it holds \f$
+//! F_{X_k}(X_k^-) = F_{X_k}(X_k - 1) \f$.
 //!
-//! @param data an \f$ n \times 2 \f$ matrix of observations contained in
-//!   \f$(0, 1)^2 \f$ for continuous models; \f$ n \times 4 \f$ for discrete
-//!   models.
+//! @param data an \f$ n \times (2 + k) \f$ matrix of observations contained in
+//!   \f$(0, 1)^2 \f$, where \f$ k \f$ is the number of discrete variables.
 //! @param controls the controls (see FitControlsBicop).
 inline void
 Bicop::select(const Eigen::MatrixXd& data, FitControlsBicop controls)
@@ -797,6 +797,7 @@ Bicop::clip_data(const Eigen::MatrixXd& u) const
 }
 
 //! rotates the data corresponding to the models rotation.
+//! @param u an `n x 2` matrix.
 inline Eigen::MatrixXd
 Bicop::rotate_data(const Eigen::MatrixXd& u) const
 {

--- a/include/vinecopulib/bicop/implementation/class.ipp
+++ b/include/vinecopulib/bicop/implementation/class.ipp
@@ -774,12 +774,16 @@ Bicop::select(const Eigen::MatrixXd& data, FitControlsBicop controls)
   }
 }
 
-//! adds an additional column if there's only one discrete variable. 
+//! adds an additional column if there's only one discrete variable;
+//! removes superfluous columns for continuous variables. 
 //! (continuous models only require two columns, discrete models always four)
 inline Eigen::MatrixXd
-Bicop::extend_data(const Eigen::MatrixXd& u) const
+Bicop::format_data(const Eigen::MatrixXd& u) const
 {
-  if ((get_n_discrete() != 1) | (u.cols() == 4)) {
+  int n_disc = get_n_discrete();
+  if (n_disc == 0) {
+    return u.leftCols(2);
+  } else if ((get_n_discrete() != 1) | (u.cols() == 4)) {
     return u;
   }
   Eigen::MatrixXd u_new(u.rows(), 4);
@@ -837,10 +841,10 @@ Bicop::rotate_data(const Eigen::MatrixXd& u) const
 inline Eigen::MatrixXd
 Bicop::prep_for_abstract(const Eigen::MatrixXd& u) const
 {
-  auto u_new = extend_data(u);
+  auto u_new = format_data(u);
   u_new = clip_data(u_new);
   u_new.leftCols(2) = rotate_data(u_new.leftCols(2));
-  if (u_new.cols() > 2) {
+  if (u_new.cols() == 4) {
     u_new.rightCols(2) = rotate_data(u_new.rightCols(2));
   }
   return u_new;

--- a/include/vinecopulib/bicop/implementation/class.ipp
+++ b/include/vinecopulib/bicop/implementation/class.ipp
@@ -504,7 +504,7 @@ Bicop::check_data_dim(const Eigen::MatrixXd& u) const
     std::stringstream msg;
     msg << "data has wrong number of columns; "
         << "expected: " << n_cols_exp << ", actual: " << n_cols 
-        << "; (model contains ";
+        << " (model contains ";
     if (n_cols_exp == 2) {
       msg << "no ";
     } else {
@@ -712,7 +712,7 @@ Bicop::select(const Eigen::MatrixXd& data, FitControlsBicop controls)
   rotation_ = 0;
   bicop_->set_loglik(0.0);
   if (data_no_nan.rows() >= 10) {
-    data_no_nan = prep_for_abstract(data_no_nan);
+    data_no_nan = clip_data(data_no_nan);
     std::vector<Bicop> bicops = create_candidate_bicops(data_no_nan, controls);
     for (auto& bc : bicops) {
       bc.set_var_types(var_types_);

--- a/include/vinecopulib/bicop/implementation/class.ipp
+++ b/include/vinecopulib/bicop/implementation/class.ipp
@@ -500,10 +500,10 @@ Bicop::check_data_dim(const Eigen::MatrixXd& u) const
 {
   size_t n_cols = u.cols();
   size_t n_cols_exp = 2 + get_n_discrete();
-  if (n_cols != n_cols_exp) {
+  if ((n_cols != n_cols_exp) & (n_cols != 4)) {
     std::stringstream msg;
     msg << "data has wrong number of columns; "
-        << "expected: " << n_cols_exp << ", actual: " << n_cols 
+        << "expected: " << n_cols_exp << " or 4, actual: " << n_cols 
         << " (model contains ";
     if (n_cols_exp == 2) {
       msg << "no ";
@@ -668,8 +668,10 @@ Bicop::fit(const Eigen::MatrixXd& data, const FitControlsBicop& controls)
   check_weights_size(w, data);
   tools_eigen::remove_nans(data_no_nan, w);
 
-  bicop_->fit(
-    prep_for_abstract(data_no_nan), method, controls.get_nonparametric_mult(), w);
+  bicop_->fit(prep_for_abstract(data_no_nan),
+              method,
+              controls.get_nonparametric_mult(),
+              w);
   nobs_ = data_no_nan.rows();
 }
 
@@ -777,7 +779,7 @@ Bicop::select(const Eigen::MatrixXd& data, FitControlsBicop controls)
 inline Eigen::MatrixXd
 Bicop::extend_data(const Eigen::MatrixXd& u) const
 {
-  if (get_n_discrete() != 1) {
+  if ((get_n_discrete() != 1) | (u.cols() == 4)) {
     return u;
   }
   Eigen::MatrixXd u_new(u.rows(), 4);

--- a/include/vinecopulib/bicop/implementation/tools_select.ipp
+++ b/include/vinecopulib/bicop/implementation/tools_select.ipp
@@ -43,7 +43,7 @@ create_candidate_bicops(const Eigen::MatrixXd& data,
   // remove combinations based on symmetry characteristics
   if (controls.get_preselect_families()) {
     preselect_candidates(new_bicops,
-                         (data.leftCols(2) + data.rightCols(2)).array() / 2,
+                         data.leftCols(2),
                          tau,
                          controls.get_weights());
   }

--- a/include/vinecopulib/vinecop/class.hpp
+++ b/include/vinecopulib/vinecop/class.hpp
@@ -188,7 +188,7 @@ protected:
   size_t nobs_{0};
   mutable std::vector<std::string> var_types_;
 
-  void check_data_dim(const Eigen::MatrixXd& data) const;
+  void check_data_dim(const Eigen::MatrixXd& data, bool discrete = true) const;
   void check_pair_copulas_rvine_structure(
     const std::vector<std::vector<Bicop>>& pair_copulas) const;
   double calculate_mbicv_penalty(const size_t nobs, const double psi0) const;
@@ -198,6 +198,7 @@ protected:
   void check_enough_data(const Eigen::MatrixXd& data) const;
   void check_fitted() const;
   void set_continuous_var_types();
+  int get_n_discrete() const;
 };
 }
 

--- a/include/vinecopulib/vinecop/class.hpp
+++ b/include/vinecopulib/vinecop/class.hpp
@@ -132,7 +132,7 @@ public:
   double get_mbicv(const double psi0 = 0.9) const;
 
   // Stats methods
-  Eigen::VectorXd pdf(const Eigen::MatrixXd& u,
+  Eigen::VectorXd pdf(Eigen::MatrixXd u,
                       const size_t num_threads = 1) const;
 
   Eigen::VectorXd cdf(const Eigen::MatrixXd& u,
@@ -188,7 +188,7 @@ protected:
   size_t nobs_{0};
   mutable std::vector<std::string> var_types_;
 
-  void check_data_dim(const Eigen::MatrixXd& data, bool discrete = true) const;
+  void check_data_dim(const Eigen::MatrixXd& data) const;
   void check_pair_copulas_rvine_structure(
     const std::vector<std::vector<Bicop>>& pair_copulas) const;
   double calculate_mbicv_penalty(const size_t nobs, const double psi0) const;
@@ -197,9 +197,11 @@ protected:
                           const Eigen::MatrixXd& data) const;
   void check_enough_data(const Eigen::MatrixXd& data) const;
   void check_fitted() const;
-  void set_continuous_var_types();
+  void set_continuous_var_types() const;
   int get_n_discrete() const;
+  Eigen::MatrixXd collapse_data(const Eigen::MatrixXd& u) const;
 };
+
 }
 
 #include <vinecopulib/vinecop/implementation/class.ipp>

--- a/include/vinecopulib/vinecop/class.hpp
+++ b/include/vinecopulib/vinecop/class.hpp
@@ -81,11 +81,11 @@ public:
   void to_json(const std::string filename) const;
 
   // Methods modifying structure and/or families and parameters
-  void select_all(const Eigen::MatrixXd& data,
+  void select_all(Eigen::MatrixXd data,
                   const FitControlsVinecop& controls = FitControlsVinecop());
 
   void select_families(
-    const Eigen::MatrixXd& data,
+    Eigen::MatrixXd data,
     const FitControlsVinecop& controls = FitControlsVinecop());
 
   // Getters for a single pair copula

--- a/include/vinecopulib/vinecop/class.hpp
+++ b/include/vinecopulib/vinecop/class.hpp
@@ -189,6 +189,7 @@ protected:
   mutable std::vector<std::string> var_types_;
 
   void check_data_dim(const Eigen::MatrixXd& data) const;
+  void check_data(const Eigen::MatrixXd& data) const;
   void check_pair_copulas_rvine_structure(
     const std::vector<std::vector<Bicop>>& pair_copulas) const;
   double calculate_mbicv_penalty(const size_t nobs, const double psi0) const;

--- a/include/vinecopulib/vinecop/implementation/class.ipp
+++ b/include/vinecopulib/vinecop/implementation/class.ipp
@@ -171,7 +171,7 @@ inline Vinecop::Vinecop(const Eigen::MatrixXd& data,
                              "incompatible dimensions.");
   }
   check_weights_size(controls.get_weights(), data);
-  select_families(data, controls);
+  select_families(collapse_data(data), controls);
 }
 
 //! @brief constructs a vine copula model from data by creating a model and
@@ -222,7 +222,7 @@ inline Vinecop::Vinecop(const Eigen::MatrixXd& data,
   nobs_ = data.rows();
   check_enough_data(data);
   check_weights_size(controls.get_weights(), data);
-  select_all(data, controls);
+  select_all(collapse_data(data), controls);
 }
 
 //! @brief converts the copula into a boost::property_tree::ptree object.
@@ -298,10 +298,11 @@ Vinecop::make_pair_copula_store(const size_t d, const size_t trunc_lvl)
 //! realizations of \f$ F_Y(Y^-), F_X(X^-), ... \f$. The minus indicates a
 //! left-sided limit of the cdf. For continuous variables the left limit and the
 //! cdf itself coincide. For, e.g., an integer-valued variable, it holds \f$
-//! F_Y(Y^-) = F_Y(Y - 1) \f$.
+//! F_Y(Y^-) = F_Y(Y - 1) \f$. Continuous variables in the second block can
+//! be omitted.
 //!
-//! @param data \f$ n \times d \f$ matrix of observations for continuous
-//!    models; \f$ n \times 2d \f$ for discrete models.
+//! @param data \f$ n \times (d + k) \f$ or \f$ n \times 2d \f$ matrix of
+//!   observations, where \f$ k \f$ is the number of discrete variables.
 //! @param controls the controls to the algorithm (see FitControlsVinecop).
 inline void
 Vinecop::select_all(const Eigen::MatrixXd& data,
@@ -329,10 +330,11 @@ Vinecop::select_all(const Eigen::MatrixXd& data,
 //! realizations of \f$ F_Y(Y^-), F_X(X^-), ... \f$. The minus indicates a
 //! left-sided limit of the cdf. For continuous variables the left limit and the
 //! cdf itself coincide. For, e.g., an integer-valued variable, it holds \f$
-//! F_Y(Y^-) = F_Y(Y - 1) \f$.
+//! F_Y(Y^-) = F_Y(Y - 1) \f$. Continuous variables in the second block can
+//! be omitted.
 //!
-//! @param data \f$ n \times d \f$ matrix of observations for continuous
-//!    models; \f$ n \times 2d \f$ for discrete models.
+//! @param data \f$ n \times (d + k) \f$ or \f$ n \times 2d \f$ matrix of
+//!   observations, where \f$ k \f$ is the number of discrete variables.
 //! @param controls the controls to the algorithm (see FitControlsVinecop).
 inline void
 Vinecop::select_families(const Eigen::MatrixXd& data,
@@ -704,16 +706,19 @@ Vinecop::get_var_types() const
 
 //! @brief calculates the density function of the vine copula model.
 //!
-//! @param u \f$ n \times d \f$ matrix of evaluation points for continuous
-//!    models; \f$ n \times 2d \f$ for discrete models.
+//! @param data \f$ n \times (d + k) \f$ or \f$ n \times 2d \f$ matrix of
+//!   evaluation points, where \f$ k \f$ is the number of discrete variables
+//!   (see `Vinecop::select_all()`).
 //! @param num_threads the number of threads to use for computations; if greater
 //!   than 1, the function will be applied concurrently to `num_threads` batches
 //!   of `u`.
 inline Eigen::VectorXd
-Vinecop::pdf(const Eigen::MatrixXd& u, const size_t num_threads) const
+Vinecop::pdf(Eigen::MatrixXd u, const size_t num_threads) const
 {
   tools_eigen::check_if_in_unit_cube(u);
   check_data_dim(u);
+  u = collapse_data(u);
+
   size_t d = d_;
   size_t n = u.rows();
 
@@ -728,6 +733,7 @@ Vinecop::pdf(const Eigen::MatrixXd& u, const size_t num_threads) const
     needed_hfunc1 = vine_struct_.get_needed_hfunc1();
     needed_hfunc2 = vine_struct_.get_needed_hfunc2();
   }
+  auto disc_cols = tools_select::get_disc_cols(var_types_);
 
   // initial value must be 1.0 for multiplication
   Eigen::VectorXd pdf = Eigen::VectorXd::Constant(u.rows(), 1.0);
@@ -738,26 +744,24 @@ Vinecop::pdf(const Eigen::MatrixXd& u, const size_t num_threads) const
     Eigen::MatrixXd hfunc2(b.size, d);
     Eigen::MatrixXd hfunc1_sub(b.size, d);
     Eigen::MatrixXd hfunc2_sub(b.size, d);
+    Eigen::MatrixXd u_e(b.size, 4);
+    Eigen::MatrixXd u_sub(b.size, 4);
 
     // fill first row of hfunc2 matrix with evaluation points;
     // points have to be reordered to correspond to natural order
+
     for (size_t j = 0; j < d; ++j) {
       hfunc2.col(j) = u.block(b.begin, order[j] - 1, b.size, 1);
-      hfunc2_sub.col(j) = u.block(b.begin, d_ + order[j] - 1, b.size, 1);
+      hfunc2_sub.col(j) =
+        u.block(b.begin, d_ + disc_cols[order[j] - 1], b.size, 1);
     }
 
     for (size_t tree = 0; tree < trunc_lvl; ++tree) {
       tools_interface::check_user_interrupt(n * d > 1e5);
       for (size_t edge = 0; edge < d - tree - 1; ++edge) {
         tools_interface::check_user_interrupt(edge % 100 == 0);
-
-        Bicop edge_copula = get_pair_copula(tree, edge);
-        auto var_types = edge_copula.get_var_types();
-        int n_disc = (var_types[0] == "d") + (var_types[1] == "d");
-
         // extract evaluation point from hfunction matrices (have been
         // computed in previous tree level)
-        Eigen::MatrixXd u_e(b.size, 4);
         u_e.col(0) = hfunc2.col(edge);
         u_e.col(2) = hfunc2_sub.col(edge);
         size_t m = min_array(tree, edge);
@@ -768,27 +772,24 @@ Vinecop::pdf(const Eigen::MatrixXd& u, const size_t num_threads) const
           u_e.col(1) = hfunc1.col(m - 1);
           u_e.col(3) = hfunc1_sub.col(m - 1);
         }
-        if ((n_disc == 1) & (var_types[0] == "c")) {
-          u_e.col(2).swap(u_e.col(3));
-        }
-        u_e.conservativeResize(b.size, 2 + n_disc);
 
+        Bicop edge_copula = get_pair_copula(tree, edge);
         pdf.segment(b.begin, b.size) =
           pdf.segment(b.begin, b.size).cwiseProduct(edge_copula.pdf(u_e));
 
         // h-functions are only evaluated if needed in next step
+        auto var_types = edge_copula.get_var_types();
+        u_sub = u_e;
         if (needed_hfunc1(tree, edge)) {
           hfunc1.col(edge) = edge_copula.hfunc1(u_e);
           if (var_types[1] == "d") {
-            auto u_sub = u_e;
-            u_sub.col(1) = u_sub.col(1 + n_disc);
+            u_sub.col(1) = u_sub.col(3);
             hfunc1_sub.col(edge) = edge_copula.hfunc1(u_sub);
           }
         }
         if (needed_hfunc2(tree, edge)) {
           hfunc2.col(edge) = edge_copula.hfunc2(u_e);
           if (var_types[0] == "d") {
-            auto u_sub = u_e;
             u_sub.col(0) = u_sub.col(2);
             hfunc2_sub.col(edge) = edge_copula.hfunc2(u_sub);
           }
@@ -808,8 +809,9 @@ Vinecop::pdf(const Eigen::MatrixXd& u, const size_t num_threads) const
 
 //! @brief calculates the cumulative distribution of the vine copula model.
 //!
-//! @param u \f$ n \times d \f$ matrix of evaluation points for continuous
-//!    models; \f$ n \times 2d \f$ for discrete models.
+//! @param data \f$ n \times (d + k) \f$ or \f$ n \times 2d \f$ matrix of
+//!   evaluation points, where \f$ k \f$ is the number of discrete variables
+//!   (see `Vinecop::select_all()`).
 //! @param N integer for the number of quasi-random numbers to draw
 //! to evaluate the distribution (default: 1e4).
 //! @param num_threads the number of threads to use for computations; if greater
@@ -834,8 +836,7 @@ Vinecop::cdf(const Eigen::MatrixXd& u,
   check_data_dim(u);
 
   // Simulate N quasi-random numbers from the vine model
-  auto u_sim = tools_stats::simulate_uniform(N, d_, true, seeds);
-  u_sim = inverse_rosenblatt(u_sim, num_threads);
+  auto u_sim = simulate(N, true, num_threads, seeds);
 
   size_t n = u.rows();
   Eigen::VectorXd vine_distribution(n);
@@ -852,6 +853,8 @@ Vinecop::cdf(const Eigen::MatrixXd& u,
 
 //! @brief simulates from a vine copula model, see inverse_rosenblatt().
 //!
+//! @details Simulated data is always a continous \f$ n \times d \f$ matrix.
+//!
 //! @param n number of observations.
 //! @param qrng set to true for quasi-random numbers.
 //! @param num_threads the number of threads to use for computations; if greater
@@ -867,7 +870,12 @@ Vinecop::simulate(const size_t n,
                   const std::vector<int>& seeds) const
 {
   auto u = tools_stats::simulate_uniform(n, d_, qrng, seeds);
-  return inverse_rosenblatt(u, num_threads);
+  // inverse_rosenblatt() only works for continous models
+  auto actual_types = var_types_;
+  set_continuous_var_types();
+  u = inverse_rosenblatt(u, num_threads); 
+  var_types_ = actual_types;
+  return u;
 }
 
 //! @brief calculates the log-likelihood.
@@ -876,8 +884,9 @@ Vinecop::simulate(const size_t n,
 //! \f[ \mathrm{loglik} = \sum_{i = 1}^n \ln c(U_{1, i}, ..., U_{d, i}), \f]
 //! where \f$ c \f$ is the copula density pdf().
 //!
-//! @param u \f$ n \times d \f$ matrix of observations for continuous
-//!    models; \f$ n \times 2d \f$ for discrete models.
+//! @param data \f$ n \times (d + k) \f$ or \f$ n \times 2d \f$ matrix of
+//!   evaluation points, where \f$ k \f$ is the number of discrete variables
+//!   (see `Vinecop::select_all()`).
 //! @param num_threads the number of threads to use for computations; if greater
 //!   than 1, the function will be applied concurrently to `num_threads` batches
 //!   of `u`.
@@ -900,8 +909,9 @@ Vinecop::loglik(const Eigen::MatrixXd& u, const size_t num_threads) const
 //! get_npars(). The AIC is a consistent model selection criterion
 //! for nonparametric models.
 //!
-//! @param u \f$ n \times d \f$ matrix of observations for continuous
-//!    models; \f$ n \times 2d \f$ for discrete models.
+//! @param data \f$ n \times (d + k) \f$ or \f$ n \times 2d \f$ matrix of
+//!   evaluation points, where \f$ k \f$ is the number of discrete variables
+//!   (see `Vinecop::select_all()`).
 //! @param num_threads the number of threads to use for computations; if greater
 //!   than 1, the function will be applied concurrently to `num_threads` batches
 //!   of `u`.
@@ -920,8 +930,9 @@ Vinecop::aic(const Eigen::MatrixXd& u, const size_t num_threads) const
 //! get_npars(). The BIC is a consistent model selection criterion
 //! for nonparametric models.
 //!
-//! @param u \f$ n \times d \f$ matrix of observations for continuous
-//!    models; \f$ n \times 2d \f$ for discrete models.
+//! @param data \f$ n \times (d + k) \f$ or \f$ n \times 2d \f$ matrix of
+//!   evaluation points, where \f$ k \f$ is the number of discrete variables
+//!   (see `Vinecop::select_all()`).
 //! @param num_threads the number of threads to use for computations; if greater
 //!   than 1, the function will be applied concurrently to `num_threads` batches
 //!   of `u`.
@@ -945,8 +956,9 @@ Vinecop::bic(const Eigen::MatrixXd& u, const size_t num_threads) const
 //! in tree \f$ t \f$; The vBIC is a consistent model selection criterion for
 //! parametric sparse vine copula models when \f$ d = o(\sqrt{n \ln n})\f$.
 //!
-//! @param u \f$ n \times d \f$ matrix of observations for continuous
-//!    models; \f$ n \times 2d \f$ for discrete models.
+//! @param data \f$ n \times (d + k) \f$ or \f$ n \times 2d \f$ matrix of
+//!   evaluation points, where \f$ k \f$ is the number of discrete variables
+//!   (see `Vinecop::select_all()`).
 //! @param psi0 baseline prior probability of a non-independence copula.
 //! @param num_threads the number of threads to use for computations; if greater
 //!   than 1, the function will be applied concurrently to `num_threads` batches
@@ -979,18 +991,21 @@ Vinecop::get_npars() const
 //! @brief calculates the Rosenblatt transform for a vine copula model.
 //!
 //! The Rosenblatt transform converts data from this model into independent
-//! uniform variates.
+//! uniform variates. Only works for continuous data.
 //!
-//! @param u \f$ n \times d \f$ matrix of evaluation points for continuous
-//!    models; \f$ n \times 2d \f$ for discrete models.
+//! @param data \f$ n \times d \f$ or \f$ n \times 2d \f$ matrix of
+//!   evaluation points.
 //! @param num_threads the number of threads to use for computations; if greater
 //!   than 1, the function will be applied concurrently to `num_threads` batches
 //!   of `u`.
 inline Eigen::MatrixXd
 Vinecop::rosenblatt(const Eigen::MatrixXd& u, const size_t num_threads) const
 {
+  if (get_n_discrete() > 0) {
+    throw std::runtime_error("rosenblatt() only works for continuous models.");
+  }
   tools_eigen::check_if_in_unit_cube(u);
-  check_data_dim(u, false);
+  check_data_dim(u);
   size_t d = u.cols();
   size_t n = u.rows();
 
@@ -1066,9 +1081,10 @@ Vinecop::rosenblatt(const Eigen::MatrixXd& u, const size_t num_threads) const
 //! "Too large" means that the required memory will exceed 1 GB. An
 //! examplary configuration requiring less than 1 GB is \f$ n = 1000 \f$,
 //! \f$d = 200\f$.
+//! 
+//! Only works for continous models.
 //!
-//! @param u \f$ n \times d \f$ matrix of evaluation points for continuous
-//!    models; \f$ n \times 2d \f$ for discrete models.
+//! @param u \f$ n \times d \f$ matrix of evaluation points..
 //! @param num_threads the number of threads to use for computations; if greater
 //!   than 1, the function will be applied concurrently to `num_threads` batches
 //!   of `u`.
@@ -1076,8 +1092,12 @@ inline Eigen::MatrixXd
 Vinecop::inverse_rosenblatt(const Eigen::MatrixXd& u,
                             const size_t num_threads) const
 {
+  if (get_n_discrete() > 0) {
+    throw std::runtime_error(
+      "inverse_rosenblatt() only works for continuous models.");
+  }
   tools_eigen::check_if_in_unit_cube(u);
-  check_data_dim(u, false);
+  check_data_dim(u);
   size_t n = u.rows();
   if (n < 1) {
     throw std::runtime_error("n must be at least one");
@@ -1171,14 +1191,14 @@ Vinecop::inverse_rosenblatt(const Eigen::MatrixXd& u,
 
 //! checks if dimension d of the data matches the dimension of the vine.
 inline void
-Vinecop::check_data_dim(const Eigen::MatrixXd& data, bool discrete) const
+Vinecop::check_data_dim(const Eigen::MatrixXd& data) const
 {
   size_t d_data = data.cols();
-  size_t d_exp = d_ + discrete * get_n_discrete();
-  if (d_data != d_exp) {
+  size_t d_exp = d_ + get_n_discrete();
+  if ((d_data != d_exp) & (d_data != 2 * d_)) {
     std::stringstream msg;
     msg << "data has wrong number of columns; "
-        << "expected: " << d_exp << ", actual: " << d_data
+        << "expected: " << d_exp << " or " << 2 * d_ << ", actual: " << d_data
         << " (model contains ";
     if (d_exp == d_) {
       msg << "no ";
@@ -1266,8 +1286,9 @@ Vinecop::truncate(size_t trunc_lvl)
 }
 
 //! set all variable types to continuous.
+//! the function can be const, because var_types_ is mutable.
 inline void
-Vinecop::set_continuous_var_types()
+Vinecop::set_continuous_var_types() const
 {
   var_types_ = std::vector<std::string>(d_);
   for (auto& t : var_types_)
@@ -1283,6 +1304,21 @@ Vinecop::get_n_discrete() const
     n_discrete += (t == "d");
   }
   return n_discrete;
+}
+
+//! removes superfluous columns for continuous data.
+inline Eigen::MatrixXd
+Vinecop::collapse_data(const Eigen::MatrixXd& u) const
+{
+  Eigen::MatrixXd u_new(u.rows(), d_ + get_n_discrete());
+  u_new.leftCols(d_) = u.leftCols(d_);
+  size_t disc_count = 0;
+  for (size_t i = 0; i < d_; ++i) {
+    if (var_types_[i] == "d") {
+      u_new.col(d_ + disc_count) = u.col(i);
+    }
+  }
+  return u_new;
 }
 
 //! summarizes the model into a string (can be used for printing).

--- a/include/vinecopulib/vinecop/implementation/class.ipp
+++ b/include/vinecopulib/vinecop/implementation/class.ipp
@@ -741,8 +741,10 @@ Vinecop::pdf(const Eigen::MatrixXd& u, const size_t num_threads) const
 
     // fill first row of hfunc2 matrix with evaluation points;
     // points have to be reordered to correspond to natural order
-    for (size_t j = 0; j < d; ++j)
+    for (size_t j = 0; j < d; ++j) {
       hfunc2.col(j) = u.block(b.begin, order[j] - 1, b.size, 1);
+      hfunc2_sub.col(j) = u.block(b.begin, d_ + order[j] - 1, b.size, 1);
+    }
 
     for (size_t tree = 0; tree < trunc_lvl; ++tree) {
       tools_interface::check_user_interrupt(n * d > 1e5);

--- a/include/vinecopulib/vinecop/implementation/tools_select.ipp
+++ b/include/vinecopulib/vinecop/implementation/tools_select.ipp
@@ -988,10 +988,9 @@ VinecopSelector::select_pair_copulas(VineTree& tree, const VineTree& tree_opt)
 
     tree[e].hfunc1 = tree[e].pair_copula.hfunc1(tree[e].pc_data);
     tree[e].hfunc2 = tree[e].pair_copula.hfunc2(tree[e].pc_data);
-    int n_disc = (tree[e].var_types[0] == "d") + (tree[e].var_types[1] == "d");
     if (tree[e].var_types[1] == "d") {
       auto sub_data = tree[e].pc_data;
-      sub_data.col(1) = sub_data.col(1 + n_disc);
+      sub_data.col(1) = sub_data.col(3);
       tree[e].hfunc1_sub = tree[e].pair_copula.hfunc1(sub_data);
     }
     if (tree[e].var_types[0] == "d") {

--- a/include/vinecopulib/vinecop/tools_select.hpp
+++ b/include/vinecopulib/vinecop/tools_select.hpp
@@ -42,6 +42,9 @@ calculate_criterion_matrix(const Eigen::MatrixXd& data,
                            std::string tree_criterion,
                            const Eigen::VectorXd& weights);
 
+std::vector<size_t>
+get_disc_cols(std::vector<std::string> var_types);
+
 // boost::graph represenation of a vine tree
 struct VertexProperties
 {

--- a/test/src_test/include/test_discrete.hpp
+++ b/test/src_test/include/test_discrete.hpp
@@ -97,6 +97,7 @@ TEST(discrete, vinecop)
   auto controls = FitControlsVinecop({ BicopFamily::clayton });
   // controls.set_show_trace(true);
   vc.select_families(u, controls);
+  vc.pdf(u);
 
   // check output
   auto pcs = vc.get_all_pair_copulas();

--- a/test/src_test/include/test_discrete.hpp
+++ b/test/src_test/include/test_discrete.hpp
@@ -103,6 +103,25 @@ TEST(discrete, vinecop)
 
   // check output
   auto pcs = vc.get_all_pair_copulas();
+  // for (size_t t = 0; t < 4; t++) {
+  //   for (auto pc : pcs[t]) {
+  //     EXPECT_EQ(pc.get_rotation(), 90);
+  //     EXPECT_NEAR(pc.get_parameters()(0), 2.0 / (t + 1), 1);
+  //   }
+  // }
+
+  // test other input format
+  u = Eigen::MatrixXd(utmp.rows(), 10);
+  u.leftCols(5) = utmp;
+  u.col(0) = (utmp.col(0).array() * 10).ceil() / 10;
+  u.col(5) = (utmp.col(0).array() * 10).floor() / 10;
+  u.col(2) = (utmp.col(2).array() * 10).ceil() / 10;
+  u.col(7) = (utmp.col(2).array() * 10).floor() / 10;
+  u.col(3) = (utmp.col(3).array() * 10).ceil() / 10;
+  u.col(8) = (utmp.col(3).array() * 10).floor() / 10;
+  vc.select_families(u, controls);
+  vc.pdf(u);
+  pcs = vc.get_all_pair_copulas();
   for (size_t t = 0; t < 4; t++) {
     for (auto pc : pcs[t]) {
       EXPECT_EQ(pc.get_rotation(), 90);

--- a/test/src_test/include/test_discrete.hpp
+++ b/test/src_test/include/test_discrete.hpp
@@ -82,7 +82,7 @@ TEST(discrete, vinecop)
   vc.set_var_types({ "d", "c", "d", "d", "c" });
 
   // simulate data with continuous and discrete variables
-  auto utmp = vc.simulate(1000, true, { 1 });
+  auto utmp = vc.simulate(5000, true, 1, { 1 });
   Eigen::MatrixXd u(utmp.rows(), 5 + 3); // 3 discrete vars
   u.leftCols(5) = utmp;
 
@@ -103,12 +103,12 @@ TEST(discrete, vinecop)
 
   // check output
   auto pcs = vc.get_all_pair_copulas();
-  // for (size_t t = 0; t < 4; t++) {
-  //   for (auto pc : pcs[t]) {
-  //     EXPECT_EQ(pc.get_rotation(), 90);
-  //     EXPECT_NEAR(pc.get_parameters()(0), 2.0 / (t + 1), 1);
-  //   }
-  // }
+  for (size_t t = 0; t < 4; t++) {
+    for (auto pc : pcs[t]) {
+      EXPECT_EQ(pc.get_rotation(), 90);
+      EXPECT_NEAR(pc.get_parameters()(0), 2.0 / (t + 1), 0.5);
+    }
+  }
 
   // test other input format
   u = Eigen::MatrixXd(utmp.rows(), 10);
@@ -125,7 +125,7 @@ TEST(discrete, vinecop)
   for (size_t t = 0; t < 4; t++) {
     for (auto pc : pcs[t]) {
       EXPECT_EQ(pc.get_rotation(), 90);
-      EXPECT_NEAR(pc.get_parameters()(0), 2.0 / (t + 1), 1);
+      EXPECT_NEAR(pc.get_parameters()(0), 2.0 / (t + 1), 0.5);
     }
   }
 }

--- a/test/src_test/include/test_discrete.hpp
+++ b/test/src_test/include/test_discrete.hpp
@@ -44,9 +44,11 @@ TEST(discrete, bicop)
               bc.as_continuous().cdf(uu.leftCols(2).topRows(20)));
 
     // c_d
+    uu = Eigen::MatrixXd(u.rows(), 4);
     uu.col(0) = u.col(0);
+    uu.col(2) = u.col(0);
     uu.col(1) = u_disc.col(1);
-    uu.col(2) = u_disc.col(3);
+    uu.col(3) = u_disc.col(3);
     bc.set_var_types({ "c", "d" });
     EXPECT_GE(bc.pdf(uu.topRows(20)).minCoeff(), 0);
     bc.fit(uu);

--- a/test/src_test/include/test_discrete.hpp
+++ b/test/src_test/include/test_discrete.hpp
@@ -19,9 +19,12 @@ TEST(discrete, bicop)
   for (auto rot : { 0, 90, 180, 270 }) {
     auto bc = Bicop(BicopFamily::clayton, rot, Eigen::VectorXd::Constant(1, 3));
     auto u = bc.simulate(1000, true, { 1 });
-    Eigen::MatrixXd u_new(u.rows(), 4);
-    u_new.block(0, 0, u.rows(), 2) = u;
-    u_new.block(0, 2, u.rows(), 2) = u;
+
+    Eigen::MatrixXd u_disc(u.rows(), 4);
+    u_disc.col(0) = (u.col(0).array() * 2).ceil() / 2;
+    u_disc.col(2) = (u.col(0).array() * 2).floor() / 2;
+    u_disc.col(1) = (u.col(1).array() * 2).ceil() / 2;
+    u_disc.col(3) = (u.col(1).array() * 2).floor() / 2;
 
     // c_c
     EXPECT_GE(bc.pdf(u.topRows(20)).minCoeff(), 0);
@@ -29,76 +32,76 @@ TEST(discrete, bicop)
     EXPECT_NEAR(bc.get_parameters()(0), 3, 0.5);
 
     // d_c
-    u_new.col(0) = (u.col(0).array() * 2).ceil() / 2;
-    u_new.col(2) = (u.col(0).array() * 2).floor() / 2;
+    Eigen::MatrixXd uu(u.rows(), 3);
+    uu.col(0) = u_disc.col(0);
+    uu.col(1) = u.col(1);
+    uu.col(2) = u_disc.col(2);
     bc.set_var_types({ "d", "c" });
-    EXPECT_GE(bc.pdf(u_new.topRows(20)).minCoeff(), 0);
-    bc.fit(u_new);
+    EXPECT_GE(bc.pdf(uu.topRows(20)).minCoeff(), 0);
+    bc.fit(uu);
     EXPECT_NEAR(bc.get_parameters()(0), 3, 0.5);
-    EXPECT_EQ(bc.cdf(u_new.topRows(20)),
-              bc.as_continuous().cdf(u_new.leftCols(2).topRows(20)));
+    EXPECT_EQ(bc.cdf(uu.topRows(20)),
+              bc.as_continuous().cdf(uu.leftCols(2).topRows(20)));
 
     // c_d
-    u_new.block(0, 0, u.rows(), 2) = u;
-    u_new.block(0, 2, u.rows(), 2) = u;
-    u_new.col(1) = (u.col(1).array() * 2).ceil() / 2;
-    u_new.col(3) = (u.col(1).array() * 2).floor() / 2;
+    uu.col(0) = u.col(0);
+    uu.col(1) = u_disc.col(1);
+    uu.col(2) = u_disc.col(3);
     bc.set_var_types({ "c", "d" });
-    EXPECT_GE(bc.pdf(u_new.topRows(20)).minCoeff(), 0);
-    bc.fit(u_new);
+    EXPECT_GE(bc.pdf(uu.topRows(20)).minCoeff(), 0);
+    bc.fit(uu);
     EXPECT_NEAR(bc.get_parameters()(0), 3, 0.5);
-    EXPECT_EQ(bc.cdf(u_new.topRows(20)),
-              bc.as_continuous().cdf(u_new.leftCols(2).topRows(20)));
+    EXPECT_EQ(bc.cdf(uu.topRows(20)),
+              bc.as_continuous().cdf(uu.leftCols(2).topRows(20)));
 
     // d_d
-    u_new.col(0) = (u_new.col(0).array() * 2).ceil() / 2.0;
-    u_new.col(2) = (u_new.col(2).array() * 2).floor() / 2.0;
+    uu = u_disc;
     bc.set_var_types({ "d", "d" });
-    EXPECT_GE(bc.pdf(u_new.topRows(20)).minCoeff(), 0);
-    bc.fit(u_new);
+    EXPECT_GE(bc.pdf(uu.topRows(20)).minCoeff(), 0);
+    bc.fit(uu);
     EXPECT_NEAR(bc.get_parameters()(0), 3, 0.5);
-    EXPECT_EQ(bc.cdf(u_new.topRows(20)),
-              bc.as_continuous().cdf(u_new.leftCols(2).topRows(20)));
-    bc.select(u_new.topRows(20)); // all families
+    EXPECT_EQ(bc.cdf(uu.topRows(20)),
+              bc.as_continuous().cdf(uu.leftCols(2).topRows(20)));
+    bc.select(uu.topRows(20)); // all families
   }
 }
 
-TEST(discrete, vinecop)
-{
-  auto pair_copulas = Vinecop::make_pair_copula_store(5);
-  for (size_t t = 0; t < 4; t++) {
-    for (auto& pc : pair_copulas[t]) {
-      auto par = Eigen::VectorXd::Constant(1, 2.0 / (t + 1));
-      pc = Bicop(BicopFamily::clayton, 90, par);
-    }
-  }
-  RVineStructure str(std::vector<size_t>{ 1, 2, 3, 4, 5 });
-  Vinecop vc(pair_copulas, str);
+// TEST(discrete, vinecop)
+// {
+//   auto pair_copulas = Vinecop::make_pair_copula_store(5);
+//   for (size_t t = 0; t < 4; t++) {
+//     for (auto& pc : pair_copulas[t]) {
+//       auto par = Eigen::VectorXd::Constant(1, 2.0 / (t + 1));
+//       pc = Bicop(BicopFamily::clayton, 90, par);
+//     }
+//   }
+//   RVineStructure str(std::vector<size_t>{ 1, 2, 3, 4, 5 });
+//   Vinecop vc(pair_copulas, str);
 
-  auto utmp = vc.simulate(1000, true);
-  Eigen::MatrixXd u(utmp.rows(), 2 * utmp.cols());
-  u.leftCols(5) = utmp;
-  u.rightCols(5) = utmp;
-  u.col(0) = (utmp.col(0).array() * 10).ceil() / 10;
-  u.col(0 + utmp.cols()) = (utmp.col(0).array() * 10).floor() / 10;
-  u.col(2) = (utmp.col(2).array() * 10).ceil() / 10;
-  u.col(2 + utmp.cols()) = (utmp.col(2).array() * 10).floor() / 10;
-  u.col(3) = (utmp.col(3).array() * 10).ceil() / 10;
-  u.col(3 + utmp.cols()) = (utmp.col(3).array() * 10).floor() / 10;
+//   auto utmp = vc.simulate(1000, true);
+//   Eigen::MatrixXd u(utmp.rows(), 2 * utmp.cols());
+//   u.leftCols(5) = utmp;
+//   u.rightCols(5) = utmp;
+//   u.col(0) = (utmp.col(0).array() * 10).ceil() / 10;
+//   u.col(0 + utmp.cols()) = (utmp.col(0).array() * 10).floor() / 10;
+//   u.col(2) = (utmp.col(2).array() * 10).ceil() / 10;
+//   u.col(2 + utmp.cols()) = (utmp.col(2).array() * 10).floor() / 10;
+//   u.col(3) = (utmp.col(3).array() * 10).ceil() / 10;
+//   u.col(3 + utmp.cols()) = (utmp.col(3).array() * 10).floor() / 10;
 
-  // fit vine
-  vc.set_var_types({ "d", "c", "d", "d", "c" });
-  auto controls = FitControlsVinecop({ BicopFamily::clayton });
-  // controls.set_show_trace(true);
-  vc.select_families(u, controls);
+//   // fit vine
+//   vc.set_var_types({ "d", "c", "d", "d", "c" });
+//   auto controls = FitControlsVinecop({ BicopFamily::clayton });
+//   // controls.set_show_trace(true);
+//   vc.select_families(u, controls);
 
-  // check output
-  auto pcs = vc.get_all_pair_copulas();
-  for (size_t t = 0; t < 4; t++) {
-    for (auto pc : pcs[t]) {
-      EXPECT_EQ(pc.get_rotation(), 90);
-      EXPECT_NEAR(pc.get_parameters()(0), 2.0 / (t + 1), 1);
-    }
-  }
-}
+//   // check output
+//   auto pcs = vc.get_all_pair_copulas();
+//   for (size_t t = 0; t < 4; t++) {
+//     for (auto pc : pcs[t]) {
+//       EXPECT_EQ(pc.get_rotation(), 90);
+//       EXPECT_NEAR(pc.get_parameters()(0), 2.0 / (t + 1), 1);
+//     }
+//   }
+// }
 }

--- a/test/src_test/include/test_vinecop_class.hpp
+++ b/test/src_test/include/test_vinecop_class.hpp
@@ -259,7 +259,7 @@ TEST_F(VinecopTest, family_select_finds_true_rotations)
 
 TEST_F(VinecopTest, family_select_returns_pcs_in_right_order)
 {
-   u.conservativeResize(50, 7);
+  u.conservativeResize(50, 7);
   auto pair_copulas = Vinecop::make_pair_copula_store(7);
   auto par = Eigen::VectorXd::Constant(1, 3.0);
   for (auto& tree : pair_copulas) {

--- a/test/test_all.cpp
+++ b/test/test_all.cpp
@@ -7,6 +7,7 @@
 #include "src_test/include/test_bicop_kernel.hpp"
 #include "src_test/include/test_bicop_parametric.hpp"
 #include "src_test/include/test_bicop_sanity_checks.hpp"
+#include "src_test/include/test_discrete.hpp"
 #include "src_test/include/test_rvine_structure.hpp"
 #include "src_test/include/test_serialization.hpp"
 #include "src_test/include/test_tools_bobyqa.hpp"
@@ -18,12 +19,14 @@
 using namespace test_bicop_sanity_checks;
 using namespace test_bicop_parametric;
 using namespace test_bicop_kernel;
+using namespace test_discrete;
 using namespace test_rvine_structure;
 using namespace test_serialization;
 using namespace test_tools_bobyqa;
 using namespace test_tools_stats;
 using namespace test_vinecop_class;
 using namespace test_vinecop_sanity_checks;
+using namespace test_weights;
 using namespace test_weights;
 
 int


### PR DESCRIPTION
- Now requires `n x (d + k)` input, where `k` is the number of discrete variables.
- The internal code got a bit uglier, but I think that's something we can live with. 
- Kept everything in `AbstractBicop` working with `n x 4`. It would've gotten much uglier otherwise, since we would need to set up U^+ and U^- in every function anyway (and should be just as efficient).

We should think again before merging. I found the discrepancy between column and variable indices really annoying. I could imagine the same feeling from a users perspective. Copying the data once is  zero effort and I find it conceptually more appealing to have two full blocks representing different things (although columns may be equal).

In any case, we could allow for both variants as user input (at the cost of more wordy and possibly confusing documentation). Then we just need to choose which one we use internally.
