### PR TITLE
Improvements in memory efficiency (solves #438).

### DIFF
--- a/include/vinecopulib/bicop/class.hpp
+++ b/include/vinecopulib/bicop/class.hpp
@@ -120,7 +120,7 @@ public:
 private:
   Eigen::MatrixXd format_data(const Eigen::MatrixXd& u) const;
 
-  Eigen::MatrixXd rotate_data(const Eigen::MatrixXd& u) const;
+  void rotate_data(Eigen::MatrixXd& u) const;
 
   Eigen::MatrixXd prep_for_abstract(const Eigen::MatrixXd& u) const;
 

--- a/include/vinecopulib/bicop/implementation/abstract.ipp
+++ b/include/vinecopulib/bicop/implementation/abstract.ipp
@@ -144,7 +144,8 @@ AbstractBicop::pdf(const Eigen::MatrixXd& u)
   } else {
     pdf = pdf_c_d(u);
   }
-  return tools_eigen::trim(pdf, DBL_MIN, DBL_MAX);
+  tools_eigen::trim(pdf, DBL_MIN, DBL_MAX);
+  return pdf;
 }
 
 inline Eigen::VectorXd

--- a/include/vinecopulib/bicop/implementation/abstract.ipp
+++ b/include/vinecopulib/bicop/implementation/abstract.ipp
@@ -151,12 +151,10 @@ AbstractBicop::pdf(const Eigen::MatrixXd& u)
 inline Eigen::VectorXd
 AbstractBicop::pdf_c_d(const Eigen::MatrixXd& u)
 {
-  auto umax = u.leftCols(2);
-  auto umin = u.rightCols(2);
   if (var_types_[0] != "c") {
-    return (hfunc2_raw(umax) - hfunc2_raw(umin)).array().abs();
+    return (hfunc2_raw(u.leftCols(2)) - hfunc2_raw(u.rightCols(2))).cwiseAbs();
   } else {
-    return (hfunc1_raw(umax) - hfunc1_raw(umin)).array().abs();
+    return (hfunc1_raw(u.leftCols(2)) - hfunc1_raw(u.rightCols(2))).cwiseAbs();
   }
 }
 

--- a/include/vinecopulib/bicop/implementation/class.ipp
+++ b/include/vinecopulib/bicop/implementation/class.ipp
@@ -173,7 +173,8 @@ Bicop::hfunc1(const Eigen::MatrixXd& u) const
       h = 1.0 - bicop_->hfunc2(prep_for_abstract(u)).array();
       break;
   }
-  return tools_eigen::trim(h, 0.0, 1.0);
+  tools_eigen::trim(h, 0.0, 1.0);
+  return h;
 }
 
 //! @brief calculates the second h-function.
@@ -204,7 +205,8 @@ Bicop::hfunc2(const Eigen::MatrixXd& u) const
       h = bicop_->hfunc1(prep_for_abstract(u)).array();
       break;
   }
-  return tools_eigen::trim(h, 0.0, 1.0);
+  tools_eigen::trim(h, 0.0, 1.0);
+  return h;
 }
 
 //! @brief calculates the inverse of \f$ h_1 \f$ (see hfunc1()) w.r.t. the
@@ -233,7 +235,8 @@ Bicop::hinv1(const Eigen::MatrixXd& u) const
       hi = 1.0 - bicop_->hinv2(prep_for_abstract(u)).array();
       break;
   }
-  return tools_eigen::trim(hi, 0.0, 1.0);
+  tools_eigen::trim(hi, 0.0, 1.0);
+  return hi;
 }
 
 //! @brief calculates the inverse of \f$ h_2 \f$ (see hfunc2()) w.r.t. the first
@@ -262,7 +265,8 @@ Bicop::hinv2(const Eigen::MatrixXd& u) const
       hi = bicop_->hinv1(prep_for_abstract(u));
       break;
   }
-  return tools_eigen::trim(hi, 0.0, 1.0);
+  tools_eigen::trim(hi, 0.0, 1.0);
+  return hi;
 }
 //! @}
 
@@ -740,7 +744,7 @@ Bicop::select(const Eigen::MatrixXd& data, FitControlsBicop controls)
   rotation_ = 0;
   bicop_->set_loglik(0.0);
   if (data_no_nan.rows() >= 10) {
-    data_no_nan = tools_eigen::trim(data_no_nan);
+    tools_eigen::trim(data_no_nan);
     std::vector<Bicop> bicops = create_candidate_bicops(data_no_nan, controls);
     for (auto& bc : bicops) {
       bc.set_var_types(var_types_);
@@ -859,7 +863,7 @@ inline Eigen::MatrixXd
 Bicop::prep_for_abstract(const Eigen::MatrixXd& u) const
 {
   auto u_new = format_data(u);
-  u_new = tools_eigen::trim(u_new);
+  tools_eigen::trim(u_new);
   u_new.leftCols(2) = rotate_data(u_new.leftCols(2));
   if (u_new.cols() == 4) {
     u_new.rightCols(2) = rotate_data(u_new.rightCols(2));

--- a/include/vinecopulib/bicop/implementation/class.ipp
+++ b/include/vinecopulib/bicop/implementation/class.ipp
@@ -828,31 +828,36 @@ Bicop::format_data(const Eigen::MatrixXd& u) const
 
 //! rotates the data corresponding to the models rotation.
 //! @param u an `n x 2` matrix.
-inline Eigen::MatrixXd
-Bicop::rotate_data(const Eigen::MatrixXd& u) const
+inline void
+Bicop::rotate_data(Eigen::MatrixXd& u) const
 {
-  auto u_new = u;
   // counter-clockwise rotations
   switch (rotation_) {
     case 0:
       break;
 
     case 90:
-      u_new.col(0) = u.col(1);
-      u_new.col(1) = 1.0 - u.col(0).array();
+      u.col(0).swap(u.col(1));
+      u.col(1) = 1 - u.col(1).array();
+      if (u.cols() == 4) {
+        u.col(2).swap(u.col(3));
+        u.col(3) = 1 - u.col(3).array();
+      }
       break;
 
     case 180:
-      u_new.col(0) = 1.0 - u.col(0).array();
-      u_new.col(1) = 1.0 - u.col(1).array();
+      u = 1 - u.array();
       break;
 
     case 270:
-      u_new.col(0) = 1.0 - u.col(1).array();
-      u_new.col(1) = u.col(0);
+      u.col(0).swap(u.col(1));
+      u.col(0) = 1 - u.col(0).array();
+      if (u.cols() == 4) {
+        u.col(2).swap(u.col(3));
+        u.col(2) = 1 - u.col(2).array();
+      }
       break;
   }
-  return u_new;
 }
 
 //! prepares data for use with the `AbstractBicop` class:
@@ -864,10 +869,7 @@ Bicop::prep_for_abstract(const Eigen::MatrixXd& u) const
 {
   auto u_new = format_data(u);
   tools_eigen::trim(u_new);
-  u_new.leftCols(2) = rotate_data(u_new.leftCols(2));
-  if (u_new.cols() == 4) {
-    u_new.rightCols(2) = rotate_data(u_new.rightCols(2));
-  }
+  rotate_data(u_new);
   return u_new;
 }
 

--- a/include/vinecopulib/bicop/implementation/kernel.ipp
+++ b/include/vinecopulib/bicop/implementation/kernel.ipp
@@ -33,7 +33,8 @@ inline Eigen::VectorXd
 KernelBicop::pdf_raw(const Eigen::MatrixXd& u)
 {
   auto pdf = interp_grid_->interpolate(u);
-  return tools_eigen::trim(pdf, 1e-20, DBL_MAX);
+  tools_eigen::trim(pdf, 1e-20, DBL_MAX);
+  return pdf;
 }
 
 inline Eigen::VectorXd

--- a/include/vinecopulib/misc/implementation/tools_eigen.ipp
+++ b/include/vinecopulib/misc/implementation/tools_eigen.ipp
@@ -5,6 +5,7 @@
 // vinecopulib or https://vinecopulib.github.io/vinecopulib/.
 
 #include <boost/math/special_functions/fpclassify.hpp>
+#include <algorithm>
 #include <fstream>
 #include <iostream>
 #include <vinecopulib/misc/tools_stl.hpp>
@@ -63,13 +64,32 @@ remove_nans(Eigen::MatrixXd& x, Eigen::VectorXd& weights)
 //! @param x data matrix.
 //! @param lower lower bound of the interval.
 //! @param upper upper bound of the interval.
-inline Eigen::MatrixXd
-trim(const Eigen::MatrixXd& x, const double& lower, const double& upper)
+inline void
+trim(Eigen::MatrixXd& x, const double& lower, const double& upper)
 {
-  auto trim_one = [&lower, &upper](const double& x) {
-    return std::min(std::max(x, lower), upper);
-  };
-  return tools_eigen::unaryExpr_or_nan(x, trim_one);
+  // code of std::for_each (save some compile time by not including <algorithm>)
+  auto it = x.data();
+  auto last = x.data() + x.size();
+  for (; it != last; ++it) {
+    if (!std::isnan(*it))
+      *it = std::min(std::max(*it, lower), upper);
+  }
+}
+
+//! trims all elements in the matrix to the interval `[lower, upper]`.
+//! @param x data matrix.
+//! @param lower lower bound of the interval.
+//! @param upper upper bound of the interval.
+inline void
+trim(Eigen::VectorXd& x, const double& lower, const double& upper)
+{
+  // code of std::for_each (save some compile time by not including <algorithm>)
+  auto it = x.data();
+  auto last = x.data() + x.size();
+  for (; it != last; ++it) {
+    if (!std::isnan(*it))
+      *it = std::min(std::max(*it, lower), upper);
+  }
 }
 
 //! check if all elements are contained in the unit cube.

--- a/include/vinecopulib/misc/implementation/tools_eigen.ipp
+++ b/include/vinecopulib/misc/implementation/tools_eigen.ipp
@@ -5,7 +5,6 @@
 // vinecopulib or https://vinecopulib.github.io/vinecopulib/.
 
 #include <boost/math/special_functions/fpclassify.hpp>
-#include <algorithm>
 #include <fstream>
 #include <iostream>
 #include <vinecopulib/misc/tools_stl.hpp>

--- a/include/vinecopulib/misc/tools_eigen.hpp
+++ b/include/vinecopulib/misc/tools_eigen.hpp
@@ -51,8 +51,13 @@ remove_nans(Eigen::MatrixXd& x);
 void
 remove_nans(Eigen::MatrixXd& x, Eigen::VectorXd& weights);
 
-Eigen::MatrixXd
-trim(const Eigen::MatrixXd& x,
+void
+trim(Eigen::MatrixXd& x,
+     const double& lower = 1e-10,
+     const double& upper = 1 - 1e-10);
+
+void
+trim(Eigen::VectorXd& x,
      const double& lower = 1e-10,
      const double& upper = 1 - 1e-10);
 

--- a/include/vinecopulib/vinecop/implementation/class.ipp
+++ b/include/vinecopulib/vinecop/implementation/class.ipp
@@ -771,8 +771,8 @@ Vinecop::pdf(Eigen::MatrixXd u, const size_t num_threads) const
   // info about the vine structure (reverse rows (!) for more natural indexing)
   size_t trunc_lvl = vine_struct_.get_trunc_lvl();
   std::vector<size_t> order;
-  TriangularArray<size_t> natural_array, min_array, needed_hfunc1,
-    needed_hfunc2;
+  TriangularArray<size_t> natural_array, min_array;
+  TriangularArray<short unsigned> needed_hfunc1, needed_hfunc2;
   if (trunc_lvl > 0) {
     order = vine_struct_.get_order();
     natural_array = vine_struct_.get_struct_array(true);
@@ -1063,8 +1063,8 @@ Vinecop::rosenblatt(const Eigen::MatrixXd& u, const size_t num_threads) const
   // info about the vine structure (reverse rows (!) for more natural indexing)
   size_t trunc_lvl = vine_struct_.get_trunc_lvl();
   std::vector<size_t> order, inverse_order;
-  TriangularArray<size_t> natural_array, min_array, needed_hfunc1,
-    needed_hfunc2;
+  TriangularArray<size_t> natural_array, min_array;
+  TriangularArray<short unsigned> needed_hfunc1, needed_hfunc2;
   if (trunc_lvl > 0) {
     order = vine_struct_.get_order();
     inverse_order = tools_stl::invert_permutation(order);
@@ -1173,8 +1173,8 @@ Vinecop::inverse_rosenblatt(const Eigen::MatrixXd& u,
   // info about the vine structure (in upper triangular matrix notation)
   size_t trunc_lvl = vine_struct_.get_trunc_lvl();
   std::vector<size_t> order, inverse_order;
-  TriangularArray<size_t> natural_array, min_array, needed_hfunc1,
-    needed_hfunc2;
+  TriangularArray<size_t> natural_array, min_array;
+  TriangularArray<short unsigned> needed_hfunc1, needed_hfunc2;
   if (trunc_lvl > 0) {
     order = vine_struct_.get_order();
     inverse_order = tools_stl::invert_permutation(order);

--- a/include/vinecopulib/vinecop/implementation/rvine_structure.ipp
+++ b/include/vinecopulib/vinecop/implementation/rvine_structure.ipp
@@ -300,6 +300,22 @@ RVineStructure::min_array(size_t tree, size_t edge) const
   return min_array_(tree, edge);
 }
 
+//! @brief access elements of the needed_hfunc1 array.
+//! @param tree tree index.
+//! @param edge edge index.
+size_t
+RVineStructure::needed_hfunc1(size_t tree, size_t edge) const
+{
+  return needed_hfunc1_(tree, edge);
+}
+
+//! @brief access elements of the needed_hfunc2 array.
+size_t
+RVineStructure::needed_hfunc2(size_t tree, size_t edge) const
+{
+  return needed_hfunc2_(tree, edge);
+}
+
 //! @brief truncates the R-vine structure.
 //! @param trunc_lvl the truncation level.
 //!

--- a/include/vinecopulib/vinecop/implementation/rvine_structure.ipp
+++ b/include/vinecopulib/vinecop/implementation/rvine_structure.ipp
@@ -70,24 +70,13 @@ inline RVineStructure::RVineStructure(const std::vector<size_t>& order,
 inline RVineStructure::RVineStructure(const std::vector<size_t>& order,
                                       const size_t& trunc_lvl,
                                       bool check)
-  : order_(order)
-  , d_(order.size())
-  , trunc_lvl_(std::min(trunc_lvl, d_ - 1))
+  : RVineStructure(order,
+                   make_dvine_struct_array(order.size(), trunc_lvl),
+                   true,
+                   false)
 {
   if (check)
     check_antidiagonal();
-
-  if (trunc_lvl > 0) {
-    struct_array_ = compute_dvine_struct_array();
-    min_array_ = compute_min_array();
-    needed_hfunc1_ = compute_needed_hfunc1();
-    needed_hfunc2_ = compute_needed_hfunc2();
-  } else {
-    struct_array_ = TriangularArray<size_t>(d_, trunc_lvl);
-    min_array_ = TriangularArray<size_t>(d_, trunc_lvl);
-    needed_hfunc1_ = TriangularArray<short unsigned>(d_, trunc_lvl);
-    needed_hfunc2_ = TriangularArray<short unsigned>(d_, trunc_lvl);
-  }
 }
 
 //! @brief instantiates an RVineStructure object from the variable order
@@ -525,11 +514,11 @@ RVineStructure::to_natural_order() const
 
 //! creates a structure array corresponding to a D-vine (in natural order).
 inline TriangularArray<size_t>
-RVineStructure::compute_dvine_struct_array() const
+RVineStructure::make_dvine_struct_array(size_t d, size_t trunc_lvl)
 {
-  TriangularArray<size_t> struct_array(d_, trunc_lvl_);
-  for (size_t j = 0; j < d_ - 1; j++) {
-    for (size_t i = 0; i < std::min(d_ - 1 - j, trunc_lvl_); i++) {
+  TriangularArray<size_t> struct_array(d, trunc_lvl);
+  for (size_t j = 0; j < d - 1; j++) {
+    for (size_t i = 0; i < std::min(d - 1 - j, trunc_lvl); i++) {
       struct_array(i, j) = i + j + 2;
     }
   }

--- a/include/vinecopulib/vinecop/implementation/rvine_structure.ipp
+++ b/include/vinecopulib/vinecop/implementation/rvine_structure.ipp
@@ -85,8 +85,8 @@ inline RVineStructure::RVineStructure(const std::vector<size_t>& order,
   } else {
     struct_array_ = TriangularArray<size_t>(d_, trunc_lvl);
     min_array_ = TriangularArray<size_t>(d_, trunc_lvl);
-    needed_hfunc1_ = TriangularArray<size_t>(d_, trunc_lvl);
-    needed_hfunc2_ = TriangularArray<size_t>(d_, trunc_lvl);
+    needed_hfunc1_ = TriangularArray<short unsigned>(d_, trunc_lvl);
+    needed_hfunc2_ = TriangularArray<short unsigned>(d_, trunc_lvl);
   }
 }
 
@@ -139,8 +139,8 @@ inline RVineStructure::RVineStructure(
   } else {
     struct_array_ = TriangularArray<size_t>(d_, trunc_lvl_);
     min_array_ = TriangularArray<size_t>(d_, trunc_lvl_);
-    needed_hfunc1_ = TriangularArray<size_t>(d_, trunc_lvl_);
-    needed_hfunc2_ = TriangularArray<size_t>(d_, trunc_lvl_);
+    needed_hfunc1_ = TriangularArray<short unsigned>(d_, trunc_lvl_);
+    needed_hfunc2_ = TriangularArray<short unsigned>(d_, trunc_lvl_);
   }
 }
 
@@ -258,7 +258,7 @@ RVineStructure::get_min_array() const
 //!
 //! (it is usually not necessary to compute both h-functions for each
 //! pair-copula).
-inline TriangularArray<size_t>
+inline TriangularArray<short unsigned>
 RVineStructure::get_needed_hfunc1() const
 {
   return needed_hfunc1_;
@@ -269,7 +269,7 @@ RVineStructure::get_needed_hfunc1() const
 //!
 //! (it is usually not necessary to compute both h-functions for each
 //! pair-copula).
-inline TriangularArray<size_t>
+inline TriangularArray<short unsigned>
 RVineStructure::get_needed_hfunc2() const
 {
   return needed_hfunc2_;
@@ -303,14 +303,14 @@ RVineStructure::min_array(size_t tree, size_t edge) const
 //! @brief access elements of the needed_hfunc1 array.
 //! @param tree tree index.
 //! @param edge edge index.
-size_t
+bool
 RVineStructure::needed_hfunc1(size_t tree, size_t edge) const
 {
   return needed_hfunc1_(tree, edge);
 }
 
 //! @brief access elements of the needed_hfunc2 array.
-size_t
+bool
 RVineStructure::needed_hfunc2(size_t tree, size_t edge) const
 {
   return needed_hfunc2_(tree, edge);
@@ -550,10 +550,10 @@ RVineStructure::compute_min_array() const
   return min_array;
 }
 
-inline TriangularArray<size_t>
+inline TriangularArray<short unsigned>
 RVineStructure::compute_needed_hfunc1() const
 {
-  TriangularArray<size_t> needed_hfunc1(d_, trunc_lvl_);
+  TriangularArray<short unsigned> needed_hfunc1(d_, trunc_lvl_);
 
   for (size_t i = 0; i < std::min(d_ - 2, trunc_lvl_ - 1); i++) {
     for (size_t j = 0; j < d_ - 2 - i; j++) {
@@ -565,10 +565,10 @@ RVineStructure::compute_needed_hfunc1() const
   return needed_hfunc1;
 }
 
-inline TriangularArray<size_t>
+inline TriangularArray<short unsigned>
 RVineStructure::compute_needed_hfunc2() const
 {
-  TriangularArray<size_t> needed_hfunc2(d_, trunc_lvl_);
+  TriangularArray<short unsigned> needed_hfunc2(d_, trunc_lvl_);
 
   for (size_t i = 0; i < std::min(d_ - 2, trunc_lvl_ - 1); i++) {
     for (size_t j = 0; j < d_ - 2 - i; j++) {

--- a/include/vinecopulib/vinecop/rvine_structure.hpp
+++ b/include/vinecopulib/vinecop/rvine_structure.hpp
@@ -118,7 +118,8 @@ protected:
     const Eigen::Matrix<size_t, Eigen::Dynamic, Eigen::Dynamic>& mat) const;
 
   TriangularArray<size_t> to_natural_order() const;
-  TriangularArray<size_t> compute_dvine_struct_array() const;
+  static TriangularArray<size_t> make_dvine_struct_array(size_t d,
+                                                         size_t trunc_lvl);
   TriangularArray<size_t> compute_min_array() const;
   TriangularArray<short unsigned> compute_needed_hfunc1() const;
   TriangularArray<short unsigned> compute_needed_hfunc2() const;

--- a/include/vinecopulib/vinecop/rvine_structure.hpp
+++ b/include/vinecopulib/vinecop/rvine_structure.hpp
@@ -99,6 +99,8 @@ public:
                       size_t edge,
                       bool natural_order = false) const;
   size_t min_array(size_t tree, size_t edge) const;
+  size_t needed_hfunc1(size_t tree, size_t edge) const;
+  size_t needed_hfunc2(size_t tree, size_t edge) const;
 
   void truncate(size_t trunc_lvl);
   std::string str() const;

--- a/include/vinecopulib/vinecop/rvine_structure.hpp
+++ b/include/vinecopulib/vinecop/rvine_structure.hpp
@@ -91,16 +91,16 @@ public:
   std::vector<size_t> get_order() const;
   TriangularArray<size_t> get_struct_array(bool natural_order = false) const;
   TriangularArray<size_t> get_min_array() const;
-  TriangularArray<size_t> get_needed_hfunc1() const;
-  TriangularArray<size_t> get_needed_hfunc2() const;
+  TriangularArray<short unsigned> get_needed_hfunc1() const;
+  TriangularArray<short unsigned> get_needed_hfunc2() const;
   Eigen::Matrix<size_t, Eigen::Dynamic, Eigen::Dynamic> get_matrix() const;
 
   size_t struct_array(size_t tree,
                       size_t edge,
                       bool natural_order = false) const;
   size_t min_array(size_t tree, size_t edge) const;
-  size_t needed_hfunc1(size_t tree, size_t edge) const;
-  size_t needed_hfunc2(size_t tree, size_t edge) const;
+  bool needed_hfunc1(size_t tree, size_t edge) const;
+  bool needed_hfunc2(size_t tree, size_t edge) const;
 
   void truncate(size_t trunc_lvl);
   std::string str() const;
@@ -120,8 +120,8 @@ protected:
   TriangularArray<size_t> to_natural_order() const;
   TriangularArray<size_t> compute_dvine_struct_array() const;
   TriangularArray<size_t> compute_min_array() const;
-  TriangularArray<size_t> compute_needed_hfunc1() const;
-  TriangularArray<size_t> compute_needed_hfunc2() const;
+  TriangularArray<short unsigned> compute_needed_hfunc1() const;
+  TriangularArray<short unsigned> compute_needed_hfunc2() const;
 
   void check_if_quadratic(
     const Eigen::Matrix<size_t, Eigen::Dynamic, Eigen::Dynamic>& mat) const;
@@ -137,8 +137,9 @@ protected:
   size_t trunc_lvl_;
   TriangularArray<size_t> struct_array_;
   TriangularArray<size_t> min_array_;
-  TriangularArray<size_t> needed_hfunc1_;
-  TriangularArray<size_t> needed_hfunc2_;
+  // can't use bool b/c the comittee messed up std::vector<bool>
+  TriangularArray<short unsigned> needed_hfunc1_;
+  TriangularArray<short unsigned> needed_hfunc2_;
 };
 
 std::ostream&

--- a/test/src_test/include/test_rvine_structure.hpp
+++ b/test/src_test/include/test_rvine_structure.hpp
@@ -132,12 +132,12 @@ TEST(rvine_structure, needed_hfunc1_is_correct)
          7, 3, 0, 0, 0, 0, 0,
          4, 0, 0, 0, 0, 0, 0;
 
-  TriangularArray<size_t> true_hfunc1({ { 0, 0, 0, 0, 1, 1 },
-                                        { 0, 0, 0, 1, 1 },
-                                        { 0, 0, 0, 1 },
-                                        { 0, 0, 0 },
-                                        { 0, 1 },
-                                        { 0 } });
+  TriangularArray<short unsigned> true_hfunc1({ { 0, 0, 0, 0, 1, 1 },
+                                                { 0, 0, 0, 1, 1 },
+                                                { 0, 0, 0, 1 },
+                                                { 0, 0, 0 },
+                                                { 0, 1 },
+                                                { 0 } });
 
   RVineStructure rvine_structure(mat);
   EXPECT_EQ(rvine_structure.get_needed_hfunc1(), true_hfunc1);
@@ -157,12 +157,12 @@ TEST(rvine_structure, needed_hfunc2_is_correct)
          7, 3, 0, 0, 0, 0, 0,
          4, 0, 0, 0, 0, 0, 0;
 
-  TriangularArray<size_t> true_hfunc2({ { 1, 1, 1, 1, 1, 1 },
-                                        { 1, 1, 1, 1, 1 },
-                                        { 1, 1, 1, 1 },
-                                        { 1, 1, 1 },
-                                        { 1, 0 },
-                                        { 0 } });
+  TriangularArray<short unsigned> true_hfunc2({ { 1, 1, 1, 1, 1, 1 },
+                                                { 1, 1, 1, 1, 1 },
+                                                { 1, 1, 1, 1 },
+                                                { 1, 1, 1 },
+                                                { 1, 0 },
+                                                { 0 } });
 
   RVineStructure rvine_structure(mat);
   EXPECT_EQ(rvine_structure.get_needed_hfunc2(), true_hfunc2);


### PR DESCRIPTION
See #438.

**Summary:** (links show you the new version)
- Added [`RVineStructure::neded_hfunc1/2()`](https://github.com/vinecopulib/vinecopulib/blob/mem-efficiency/include/vinecopulib/vinecop/rvine_structure.hpp#L102) methods to avoid copying the objects in `pdf()`, `rosenblatt()`, and `inverse_rosenblatt()`.
- Made [`RVineStructure::needed_hfunc1/2_`](https://github.com/vinecopulib/vinecopulib/blob/mem-efficiency/include/vinecopulib/vinecop/rvine_structure.hpp#L142) data members `TriangularArray<short unsigned>` (instead of `size_t`). Unfortunately, we can't make it `bool` since the standard comittee messed up [`std::vector<bool>`](https://en.cppreference.com/w/cpp/container/vector_bool)
- Made [`tools_eigen::trim()`](https://github.com/vinecopulib/vinecopulib/blob/mem-efficiency/include/vinecopulib/misc/implementation/tools_eigen.ipp#L68) and [`Bicop::rotate_data()`](https://github.com/vinecopulib/vinecopulib/blob/mem-efficiency/include/vinecopulib/bicop/implementation/class.ipp#L832) modify the input in-place to avoid copies. Only one (necessary) copy is made in [`Bicop::prep_for_abstract()`](https://github.com/vinecopulib/vinecopulib/blob/mem-efficiency/include/vinecopulib/bicop/implementation/class.ipp#L868).
- Avoid unnecessary data copies in [`Vinecop::pdf()`](https://github.com/vinecopulib/vinecopulib/blob/mem-efficiency/include/vinecopulib/vinecop/implementation/class.ipp#L782) for continuous variables. It's actually not that ugly at all.
- Similar for  [`VinecopSelector::add_pc_info()`](https://github.com/vinecopulib/vinecopulib/blob/mem-efficiency/include/vinecopulib/vinecop/implementation/tools_select.ipp#L582).