### PR TITLE
Better constructors

### DIFF
--- a/include/vinecopulib/bicop/class.hpp
+++ b/include/vinecopulib/bicop/class.hpp
@@ -148,7 +148,7 @@ private:
   BicopPtr get_bicop() const;
 
   BicopPtr bicop_;
-  int rotation_;
+  int rotation_{ 0 };
   size_t nobs_{ 0 };
   mutable std::vector<std::string> var_types_;
 };

--- a/include/vinecopulib/bicop/class.hpp
+++ b/include/vinecopulib/bicop/class.hpp
@@ -132,7 +132,7 @@ private:
 
   void check_data_dim(const Eigen::MatrixXd& u) const;
 
-  void check_var_types(const Eigen::MatrixXd& u) const;
+  void check_var_types(const std::vector<std::string>& var_types) const;
 
   void flip_var_types();
 

--- a/include/vinecopulib/bicop/class.hpp
+++ b/include/vinecopulib/bicop/class.hpp
@@ -26,10 +26,12 @@ public:
   // Constructors
   Bicop(const BicopFamily family = BicopFamily::indep,
         const int rotation = 0,
-        const Eigen::MatrixXd& parameters = Eigen::MatrixXd());
+        const Eigen::MatrixXd& parameters = Eigen::MatrixXd(),
+        const std::vector<std::string>& var_types = { "c", "c" });
 
   Bicop(const Eigen::MatrixXd& data,
-        const FitControlsBicop& controls = FitControlsBicop());
+        const FitControlsBicop& controls = FitControlsBicop(),
+        const std::vector<std::string>& var_types = { "c", "c" });
 
   Bicop(const std::string filename);
 
@@ -63,8 +65,8 @@ public:
 
   void set_parameters(const Eigen::MatrixXd& parameters);
 
-  void set_var_types(const std::vector<std::string>& var_types);
-  
+  void set_var_types(const std::vector<std::string>& var_types = { "c", "c" });
+
   std::vector<std::string> get_var_types() const;
 
   // Stats methods
@@ -130,6 +132,8 @@ private:
 
   void check_data_dim(const Eigen::MatrixXd& u) const;
 
+  void check_var_types(const Eigen::MatrixXd& u) const;
+
   void flip_var_types();
 
   void check_weights_size(const Eigen::VectorXd& weights,
@@ -145,8 +149,8 @@ private:
 
   BicopPtr bicop_;
   int rotation_;
-  size_t nobs_{0};
-  mutable std::vector<std::string> var_types_{ "c", "c" };
+  size_t nobs_{ 0 };
+  mutable std::vector<std::string> var_types_;
 };
 }
 

--- a/include/vinecopulib/bicop/implementation/class.ipp
+++ b/include/vinecopulib/bicop/implementation/class.ipp
@@ -577,9 +577,9 @@ Bicop::set_var_types(const std::vector<std::string>& var_types)
   var_types_ = var_types;
   if (bicop_) {
     bicop_->set_var_types(var_types);
-  }
-  if (tools_stl::is_member(static_cast<size_t>(rotation_), { 90, 270 })) {
-    flip_var_types();
+    if (tools_stl::is_member(static_cast<size_t>(rotation_), { 90, 270 })) {
+      flip_var_types();
+    }
   }
 }
 

--- a/include/vinecopulib/bicop/implementation/class.ipp
+++ b/include/vinecopulib/bicop/implementation/class.ipp
@@ -36,8 +36,7 @@ inline Bicop::Bicop(const BicopFamily family,
   } else {
     bicop_->set_loglik(0.0);
   }
-  check_var_types(var_types);
-  var_types_ = var_types;
+  set_var_types(var_types);
 }
 
 //! @brief create a copula model from the data,
@@ -46,13 +45,12 @@ inline Bicop::Bicop(const BicopFamily family,
 //! @param data see select().
 //! @param controls see select().
 //! @param var_types a vector of size two specifying the types of the variables,
-//!   e.g., `{"c", "d"}` means first varible continuous, second discrete.
+//!   e.g., `{"c", "d"}` means first variable continuous, second discrete.
 inline Bicop::Bicop(const Eigen::MatrixXd& data,
                     const FitControlsBicop& controls,
                     const std::vector<std::string>& var_types)
 {
-  check_var_types(var_types);
-  var_types_ = var_types;
+  set_var_types(var_types);
   select(data, controls);
 }
 
@@ -571,7 +569,7 @@ Bicop::set_parameters(const Eigen::MatrixXd& parameters)
 
 //! @brief sets variable types.
 //! @param var_types a vector of size two specifying the types of the variables,
-//!   e.g., `{"c", "d"}` means first varible continuous, second discrete.
+//!   e.g., `{"c", "d"}` means first variable continuous, second discrete.
 inline void
 Bicop::set_var_types(const std::vector<std::string>& var_types)
 {

--- a/include/vinecopulib/bicop/implementation/class.ipp
+++ b/include/vinecopulib/bicop/implementation/class.ipp
@@ -21,9 +21,12 @@ namespace vinecopulib {
 //!     (for Independence, Gaussian, Student, Frank, and nonparametric
 //!     families, only 0 is allowed).
 //! @param parameters the copula parameters.
+//! @param var_types a vector of size two specifying the types of the variables,
+//!   e.g., `{"c", "d"}` means first varible continuous, second discrete.
 inline Bicop::Bicop(const BicopFamily family,
                     const int rotation,
-                    const Eigen::MatrixXd& parameters)
+                    const Eigen::MatrixXd& parameters,
+                    const std::vector<std::string>& var_types)
 {
   bicop_ = AbstractBicop::create(family, parameters);
   // family must be set before checking the rotation
@@ -33,6 +36,8 @@ inline Bicop::Bicop(const BicopFamily family,
   } else {
     bicop_->set_loglik(0.0);
   }
+  check_var_types(var_types);
+  var_types_ = var_types;
 }
 
 //! @brief create a copula model from the data,
@@ -40,9 +45,14 @@ inline Bicop::Bicop(const BicopFamily family,
 //!
 //! @param data see select().
 //! @param controls see select().
+//! @param var_types a vector of size two specifying the types of the variables,
+//!   e.g., `{"c", "d"}` means first varible continuous, second discrete.
 inline Bicop::Bicop(const Eigen::MatrixXd& data,
-                    const FitControlsBicop& controls)
+                    const FitControlsBicop& controls,
+                    const std::vector<std::string>& var_types)
 {
+  check_var_types(var_types);
+  var_types_ = var_types;
   select(data, controls);
 }
 
@@ -61,7 +71,8 @@ inline Bicop::Bicop(const boost::property_tree::ptree input)
       input.get_child("var_types"));
     nobs_ = input.get<size_t>("nobs_");
     bicop_->set_loglik(input.get<double>("loglik"));
-  } catch (...) {}
+  } catch (...) {
+  }
 }
 
 //! @brief creates from a JSON file
@@ -532,7 +543,7 @@ Bicop::check_data_dim(const Eigen::MatrixXd& u) const
   if ((n_cols != n_cols_exp) & (n_cols != 4)) {
     std::stringstream msg;
     msg << "data has wrong number of columns; "
-        << "expected: " << n_cols_exp << " or 4, actual: " << n_cols 
+        << "expected: " << n_cols_exp << " or 4, actual: " << n_cols
         << " (model contains ";
     if (n_disc == 0) {
       msg << "no discrete variables)." << std::endl;
@@ -564,14 +575,7 @@ Bicop::set_parameters(const Eigen::MatrixXd& parameters)
 inline void
 Bicop::set_var_types(const std::vector<std::string>& var_types)
 {
-  if (var_types.size() != 2) {
-    throw std::runtime_error("var_types must have size two.");
-  }
-  for (auto t : var_types) {
-    if (!tools_stl::is_member(t, { "c", "d" })) {
-      throw std::runtime_error("var type must be either 'c' or 'd'.");
-    }
-  }
+  check_var_types(var_types);
   var_types_ = var_types;
   bicop_->set_var_types(var_types);
   if (tools_stl::is_member(static_cast<size_t>(rotation_), { 90, 270 })) {
@@ -805,7 +809,7 @@ Bicop::select(const Eigen::MatrixXd& data, FitControlsBicop controls)
 }
 
 //! adds an additional column if there's only one discrete variable;
-//! removes superfluous columns for continuous variables. 
+//! removes superfluous columns for continuous variables.
 //! (continuous models only require two columns, discrete models always four)
 inline Eigen::MatrixXd
 Bicop::format_data(const Eigen::MatrixXd& u) const
@@ -824,7 +828,6 @@ Bicop::format_data(const Eigen::MatrixXd& u) const
   u_new.col(2 + cont_col) = u.col(cont_col);
   return u_new;
 }
-
 
 //! rotates the data corresponding to the models rotation.
 //! @param u an `n x 2` matrix.
@@ -910,6 +913,20 @@ Bicop::check_fitted() const
   }
 }
 
+//! checks whether var_types have the correct length and are either "c" or "d".
+inline void
+Bicop::check_var_types(const std::vector<std::string>& var_types) const
+{
+  if (var_types.size() != 2) {
+    throw std::runtime_error("var_types must have size two.");
+  }
+  for (auto t : var_types) {
+    if (!tools_stl::is_member(t, { "c", "d" })) {
+      throw std::runtime_error("var type must be either 'c' or 'd'.");
+    }
+  }
+}
+
 //! returns the number of discrete variables.
 inline unsigned short
 Bicop::get_n_discrete() const
@@ -920,5 +937,4 @@ Bicop::get_n_discrete() const
   }
   return n_discrete;
 }
-
 }

--- a/include/vinecopulib/bicop/implementation/class.ipp
+++ b/include/vinecopulib/bicop/implementation/class.ipp
@@ -575,7 +575,9 @@ Bicop::set_var_types(const std::vector<std::string>& var_types)
 {
   check_var_types(var_types);
   var_types_ = var_types;
-  bicop_->set_var_types(var_types);
+  if (bicop_) {
+    bicop_->set_var_types(var_types);
+  }
   if (tools_stl::is_member(static_cast<size_t>(rotation_), { 90, 270 })) {
     flip_var_types();
   }

--- a/include/vinecopulib/misc/triangular_array.hpp
+++ b/include/vinecopulib/misc/triangular_array.hpp
@@ -82,8 +82,8 @@ TriangularArray<T>::TriangularArray(size_t d, size_t trunc_lvl)
   : d_(d)
   , trunc_lvl_(std::min(d - 1, trunc_lvl))
 {
-  /*   if (d < 2) */
-  /* throw std::runtime_error("d should be greater than 1"); */
+  if (d < 1)
+    throw std::runtime_error("d should be greater than 0");
 
   arr_ = std::vector<std::vector<T>>(trunc_lvl_);
   for (size_t i = 0; i < trunc_lvl_; i++)

--- a/include/vinecopulib/misc/triangular_array.hpp
+++ b/include/vinecopulib/misc/triangular_array.hpp
@@ -82,8 +82,8 @@ TriangularArray<T>::TriangularArray(size_t d, size_t trunc_lvl)
   : d_(d)
   , trunc_lvl_(std::min(d - 1, trunc_lvl))
 {
-  if (d < 2)
-    throw std::runtime_error("d should be greater than 1");
+  /*   if (d < 2) */
+  /* throw std::runtime_error("d should be greater than 1"); */
 
   arr_ = std::vector<std::vector<T>>(trunc_lvl_);
   for (size_t i = 0; i < trunc_lvl_; i++)

--- a/include/vinecopulib/vinecop/class.hpp
+++ b/include/vinecopulib/vinecop/class.hpp
@@ -33,23 +33,23 @@ public:
   // Constructors without data
   Vinecop(const RVineStructure& structure,
           const std::vector<std::vector<Bicop>>& pair_copulas = {},
-          const std::vector<std::string> var_types = {});
+          const std::vector<std::string>& var_types = {});
 
   Vinecop(const Eigen::Matrix<size_t, Eigen::Dynamic, Eigen::Dynamic>& matrix,
           const std::vector<std::vector<Bicop>>& pair_copulas = {},
-          const std::vector<std::string> var_types = {});
+          const std::vector<std::string>& var_types = {});
 
   // Constructors from data
   Vinecop(const Eigen::MatrixXd& data,
           const RVineStructure& structure = RVineStructure(),
-          const std::vector<std::string> var_types = {},
-          FitControlsVinecop controls = FitControlsVinecop());
+          const std::vector<std::string>& var_types = {},
+          const FitControlsVinecop& controls = FitControlsVinecop());
 
   Vinecop(const Eigen::MatrixXd& data,
           const Eigen::Matrix<size_t, Eigen::Dynamic, Eigen::Dynamic>& matrix =
             Eigen::Matrix<size_t, Eigen::Dynamic, Eigen::Dynamic>(),
-          const std::vector<std::string> var_types = {},
-          FitControlsVinecop controls = FitControlsVinecop());
+          const std::vector<std::string>& var_types = {},
+          const FitControlsVinecop& controls = FitControlsVinecop());
 
   // Constructors from files/serialized objects
   Vinecop(const std::string filename, const bool check = true);
@@ -60,15 +60,15 @@ public:
   void to_json(const std::string filename) const;
 
   // Methods modifying structure and/or families and parameters
-  void select(Eigen::MatrixXd data,
+  void select(const Eigen::MatrixXd& data,
               const FitControlsVinecop& controls = FitControlsVinecop());
 
   DEPRECATED void select_all(
-    Eigen::MatrixXd data,
+    const Eigen::MatrixXd& data,
     const FitControlsVinecop& controls = FitControlsVinecop());
 
   DEPRECATED void select_families(
-    Eigen::MatrixXd data,
+    const Eigen::MatrixXd& data,
     const FitControlsVinecop& controls = FitControlsVinecop());
 
   // Getters for a single pair copula

--- a/include/vinecopulib/vinecop/class.hpp
+++ b/include/vinecopulib/vinecop/class.hpp
@@ -30,47 +30,26 @@ public:
 
   Vinecop(size_t d);
 
-  // Constructors with structure only
-  Vinecop(const RVineStructure& structure);
+  // Constructors without data
+  Vinecop(const RVineStructure& structure,
+          const std::vector<std::vector<Bicop>>& pair_copulas = {},
+          const std::vector<std::string> var_types = {});
 
   Vinecop(const Eigen::Matrix<size_t, Eigen::Dynamic, Eigen::Dynamic>& matrix,
-          const bool check = true);
-
-  Vinecop(const std::vector<size_t>& order,
-          const TriangularArray<size_t>& struct_array,
-          const bool check = true);
-
-  // Constructors with pair_copulas + structure
-  Vinecop(const std::vector<std::vector<Bicop>>& pair_copulas,
-          const RVineStructure& structure);
-
-  Vinecop(const std::vector<std::vector<Bicop>>& pair_copulas,
-          const Eigen::Matrix<size_t, Eigen::Dynamic, Eigen::Dynamic>& matrix,
-          const bool check = true);
-
-  Vinecop(const std::vector<std::vector<Bicop>>& pair_copulas,
-          const std::vector<size_t>& order,
-          const TriangularArray<size_t>& struct_array,
-          const bool check = true);
+          const std::vector<std::vector<Bicop>>& pair_copulas = {},
+          const std::vector<std::string> var_types = {});
 
   // Constructors from data
   Vinecop(const Eigen::MatrixXd& data,
-          const FitControlsVinecop& controls = FitControlsVinecop());
-
-  Vinecop(const Eigen::MatrixXd& data,
-          const RVineStructure& structure,
+          const RVineStructure& structure = RVineStructure(),
+          const std::vector<std::string> var_types = {},
           FitControlsVinecop controls = FitControlsVinecop());
 
   Vinecop(const Eigen::MatrixXd& data,
-          const Eigen::Matrix<size_t, Eigen::Dynamic, Eigen::Dynamic>& matrix,
-          FitControlsVinecop controls = FitControlsVinecop(),
-          const bool check = true);
-
-  Vinecop(const Eigen::MatrixXd& data,
-          const std::vector<size_t>& order,
-          const TriangularArray<size_t>& struct_array,
-          FitControlsVinecop controls = FitControlsVinecop(),
-          const bool check = true);
+          const Eigen::Matrix<size_t, Eigen::Dynamic, Eigen::Dynamic>& matrix =
+            Eigen::Matrix<size_t, Eigen::Dynamic, Eigen::Dynamic>(),
+          const std::vector<std::string> var_types = {},
+          FitControlsVinecop controls = FitControlsVinecop());
 
   // Constructors from files/serialized objects
   Vinecop(const std::string filename, const bool check = true);
@@ -154,6 +133,8 @@ public:
   Eigen::MatrixXd inverse_rosenblatt(const Eigen::MatrixXd& u,
                                      const size_t num_threads = 1) const;
 
+  void set_all_pair_copulas(
+    const std::vector<std::vector<Bicop>>& pair_copulas);
   void set_var_types(const std::vector<std::string>& var_types);
 
   std::vector<std::string> get_var_types() const;
@@ -184,7 +165,7 @@ public:
 
 protected:
   size_t d_;
-  RVineStructure vine_struct_;
+  RVineStructure rvine_structure_;
   mutable std::vector<std::vector<Bicop>> pair_copulas_;
   double threshold_{ 0.0 };
   double loglik_{ NAN };

--- a/include/vinecopulib/vinecop/implementation/class.ipp
+++ b/include/vinecopulib/vinecop/implementation/class.ipp
@@ -19,88 +19,100 @@ namespace vinecopulib {
 //! independence.
 //! @param d the dimension (= number of variables) of the model.
 inline Vinecop::Vinecop(const size_t d)
-  : Vinecop(RVineStructure(tools_stl::seq_int(1, d), static_cast<size_t>(0)))
-{}
-
-//! @brief creates a vine copula with structure specified by an RVineStructure
-//! object; all pair-copulas are set to independence.
-//! @param structure an RVineStructure object representing the structure of
-//! the vine.
-inline Vinecop::Vinecop(const RVineStructure& structure)
-  : d_(structure.get_dim())
-  , vine_struct_(structure)
-  // pair_copulas_ empty = everything independence
-  , threshold_(0.0)
-  , loglik_(NAN)
-{
-  set_continuous_var_types();
-}
-
-//! @brief creates a vine copula with structure specified by an R-vine matrix;
-//! all pair-copulas are set to independence.
-//! @param matrix an R-vine matrix.
-//! @param check whether to check if `matrix` is a valid R-vine
-//!     matrix.
-inline Vinecop::Vinecop(
-  const Eigen::Matrix<size_t, Eigen::Dynamic, Eigen::Dynamic>& matrix,
-  const bool check)
-  : Vinecop(RVineStructure(matrix, check))
-{}
-
-//! @brief creates a vine copula with structure specified by an R-vine matrix;
-//! all pair-copulas are set to independence.
-//! @param order the order of the variables in the vine structure, see
-//! RVineStructure's corresponding constructor.
-//! @param struct_array a triangular array object specifying the vine structure,
-//! see RVineStructure's corresponding constructor.
-//! @param check whether `order` and `struct_array` shall be checked
-//! for validity.
-inline Vinecop::Vinecop(const std::vector<size_t>& order,
-                        const TriangularArray<size_t>& struct_array,
-                        const bool check)
-  : Vinecop(RVineStructure(order, struct_array, false, check))
+  : Vinecop(RVineStructure(d, static_cast<size_t>(0)))
 {}
 
 //! @brief creates an arbitrary vine copula model.
-//! @param pair_copulas Bicop objects specifying the pair-copulas, see
-//!     make_pair_copula_store().
 //! @param structure an RVineStructure object specifying the vine structure.
-inline Vinecop::Vinecop(const std::vector<std::vector<Bicop>>& pair_copulas,
-                        const RVineStructure& structure)
-  : Vinecop(structure)
+//! @param pair_copulas Bicop objects specifying the pair-copulas, see
+//!     make_pair_copula_store().
+//! @param var_types a vector specifying the types of the variables,
+//!   e.g., `{"c", "d"}` means first variable continuous, second discrete.
+//!   If empty, then all variables are set as continuous.
+inline Vinecop::Vinecop(const RVineStructure& structure,
+                        const std::vector<std::vector<Bicop>>& pair_copulas,
+                        const std::vector<std::string> var_types)
+  : d_(structure.get_dim())
+  , rvine_structure_(structure)
 {
-  check_pair_copulas_rvine_structure(pair_copulas);
-  pair_copulas_ = pair_copulas;
-  vine_struct_.truncate(pair_copulas.size());
+
+  if (pair_copulas.size() > 0) {
+    set_all_pair_copulas(pair_copulas);
+  }
+  if (var_types.size() > 0) {
+    set_var_types(var_types);
+  } else {
+    set_continuous_var_types();
+  }
 }
 
 //! @brief creates an arbitrary vine copula model.
+//! @param matrix an R-vine matrix specifying the vine structure.
 //! @param pair_copulas Bicop objects specifying the pair-copulas, see
 //!     make_pair_copula_store().
-//! @param matrix an R-vine matrix specifying the vine structure.
-//! @param check whether to check if `matrix` is a valid R-vine
-//!     matrix.
+//! @param var_types a vector specifying the types of the variables,
+//!   e.g., `{"c", "d"}` means first variable continuous, second discrete.
+//!   If empty, then all variables are set as continuous.
 inline Vinecop::Vinecop(
-  const std::vector<std::vector<Bicop>>& pair_copulas,
   const Eigen::Matrix<size_t, Eigen::Dynamic, Eigen::Dynamic>& matrix,
-  const bool check)
-  : Vinecop(pair_copulas, RVineStructure(matrix, check))
+  const std::vector<std::vector<Bicop>>& pair_copulas,
+  const std::vector<std::string> var_types)
+  : Vinecop(RVineStructure(matrix), pair_copulas, var_types)
 {}
 
-//! @brief creates an arbitrary vine copula model.
-//! @param pair_copulas Bicop objects specifying the pair-copulas, see
-//!     make_pair_copula_store().
-//! @param order the order of the variables in the vine structure, see
-//! RVineStructure's corresponding constructor.
-//! @param struct_array a triangular array object specifying the vine structure,
-//! see the corresponding constructor of RVineStructure.
-//! @param check whether `order` and `struct_array` shall be checked
-//! for validity.
-inline Vinecop::Vinecop(const std::vector<std::vector<Bicop>>& pair_copulas,
-                        const std::vector<size_t>& order,
-                        const TriangularArray<size_t>& struct_array,
-                        const bool check)
-  : Vinecop(pair_copulas, RVineStructure(order, struct_array, false, check))
+//! @brief constructs a vine copula model from data by creating a model and
+//! calling select().
+//!
+//! @param data an \f$ n \times d \f$ matrix of observations.
+//! @param structure an RVineStructure object specifying the vine structure.
+//!    If empty, then it is selected as part of the fit.
+//! @param var_types a vector specifying the types of the variables,
+//!   e.g., `{"c", "d"}` means first variable continuous, second discrete.
+//!   If empty, then all variables are set as continuous.
+//! @param controls see FitControlsVinecop.
+inline Vinecop::Vinecop(const Eigen::MatrixXd& data,
+                        const RVineStructure& structure,
+                        const std::vector<std::string> var_types,
+                        FitControlsVinecop controls)
+{
+  check_enough_data(data);
+  if (structure.get_dim() > 1) {
+    d_ = structure.get_dim();
+    rvine_structure_ = structure;
+  } else {
+    if (var_types.size() > 0) {
+      d_ = var_types.size();
+    } else {
+      d_ = data.cols();
+    }
+    rvine_structure_ = RVineStructure(d_, static_cast<size_t>(0));
+  }
+  if (var_types.size() == 0) {
+    set_continuous_var_types();
+  } else {
+    set_var_types(var_types);
+  }
+  std::cout << rvine_structure_.str() << std::endl;
+  check_weights_size(controls.get_weights(), data);
+  select(data, controls);
+}
+
+//! @brief constructs a vine copula model from data by creating a model and
+//! calling select().
+//!
+//! @param data an \f$ n \times d \f$ matrix of observations.
+//! @param matrix either an empty matrix (default) or an R-vine structure
+//!     matrix, see select(). If empty, then it is selected as part of the fit.
+//! @param var_types a vector specifying the types of the variables,
+//!   e.g., `{"c", "d"}` means first variable continuous, second discrete.
+//!   If empty, then all variables are set as continuous.
+//! @param controls see FitControlsVinecop.
+inline Vinecop::Vinecop(
+  const Eigen::MatrixXd& data,
+  const Eigen::Matrix<size_t, Eigen::Dynamic, Eigen::Dynamic>& matrix,
+  const std::vector<std::string> var_types,
+  FitControlsVinecop controls)
+  : Vinecop(data, RVineStructure(matrix), var_types, controls)
 {}
 
 //! @brief creates from a boost::property_tree::ptree object
@@ -111,8 +123,8 @@ inline Vinecop::Vinecop(const std::vector<std::vector<Bicop>>& pair_copulas,
 inline Vinecop::Vinecop(const boost::property_tree::ptree input,
                         const bool check)
 {
-  vine_struct_ = RVineStructure(input.get_child("structure"), check);
-  d_ = static_cast<size_t>(vine_struct_.get_dim());
+  rvine_structure_ = RVineStructure(input.get_child("structure"), check);
+  d_ = static_cast<size_t>(rvine_structure_.get_dim());
 
   boost::property_tree::ptree pcs_node = input.get_child("pair copulas");
   for (size_t tree = 0; tree < d_ - 1; ++tree) {
@@ -154,78 +166,6 @@ inline Vinecop::Vinecop(const std::string filename, const bool check)
   : Vinecop(tools_serialization::json_to_ptree(filename.c_str()), check)
 {}
 
-//! @brief constructs a vine copula model from data by creating a model and
-//! calling select().
-//!
-//! @param data an \f$ n \times d \f$ matrix of observations.
-//! @param structure an RVineStructure object specifying the vine structure.
-//! @param controls see FitControlsVinecop.
-inline Vinecop::Vinecop(const Eigen::MatrixXd& data,
-                        const RVineStructure& structure,
-                        FitControlsVinecop controls)
-  : Vinecop(structure)
-{
-  nobs_ = data.rows();
-  check_enough_data(data);
-  if (static_cast<size_t>(data.cols()) != d_) {
-    throw std::runtime_error("data and structure have "
-                             "incompatible dimensions.");
-  }
-  check_weights_size(controls.get_weights(), data);
-  select(data, controls);
-}
-
-//! @brief constructs a vine copula model from data by creating a model and
-//! calling select().
-//!
-//! @param data an \f$ n \times d \f$ matrix of observations.
-//! @param matrix either an empty matrix (default) or an R-vine structure
-//!     matrix, see select().
-//! @param controls see FitControlsVinecop.
-//! @param check whether to check if `matrix` is a valid R-vine
-//!     matrix.
-inline Vinecop::Vinecop(
-  const Eigen::MatrixXd& data,
-  const Eigen::Matrix<size_t, Eigen::Dynamic, Eigen::Dynamic>& matrix,
-  FitControlsVinecop controls,
-  const bool check)
-  : Vinecop(data, RVineStructure(matrix, check), controls)
-{}
-
-//! @brief constructs a vine copula model from data by creating a model and
-//! calling select().
-//!
-//! @param data an \f$ n \times d \f$ matrix of observations.
-//! @param order the order of the variables in the vine structure, see
-//! the corresponding constructor of RVineStructure.
-//! @param struct_array a triangular array object specifying the vine structure,
-//! see the corresponding constructor of RVineStructure.
-//! @param controls see FitControlsVinecop.
-//! @param check whether `order` and `struct_array` shall be checked
-//! for validity.
-inline Vinecop::Vinecop(const Eigen::MatrixXd& data,
-                        const std::vector<size_t>& order,
-                        const TriangularArray<size_t>& struct_array,
-                        FitControlsVinecop controls,
-                        const bool check)
-  : Vinecop(data, RVineStructure(order, struct_array, false, check), controls)
-{}
-
-//! @brief constructs a vine copula model from data by creating a model and
-//! calling select().
-//!
-//! @param data an \f$ n \times d \f$ matrix of observations.
-//! @param controls see FitControlsVinecop.
-inline Vinecop::Vinecop(const Eigen::MatrixXd& data,
-                        const FitControlsVinecop& controls)
-  : Vinecop(data.cols())
-{
-  nobs_ = data.rows();
-  check_enough_data(data);
-  check_weights_size(controls.get_weights(), data);
-  select(data, controls);
-}
-
 //! @brief converts the copula into a boost::property_tree::ptree object.
 //!
 //! The `ptree` object contains two nodes : `"structure"` for the vine
@@ -252,7 +192,7 @@ Vinecop::to_ptree() const
 
   boost::property_tree::ptree output;
   output.add_child("pair copulas", pair_copulas);
-  auto structure_node = vine_struct_.to_ptree();
+  auto structure_node = rvine_structure_.to_ptree();
   output.add_child("structure", structure_node);
   output.add_child("var_types",
                    tools_serialization::vector_to_ptree(var_types_));
@@ -326,7 +266,7 @@ Vinecop::select(Eigen::MatrixXd data, const FitControlsVinecop& controls)
   data = collapse_data(data);
 
   tools_select::VinecopSelector selector(
-    data, vine_struct_, controls, var_types_);
+    data, rvine_structure_, controls, var_types_);
   if (controls.needs_sparse_select()) {
     selector.sparse_select_all_trees(data);
   } else {
@@ -358,7 +298,7 @@ Vinecop::select(Eigen::MatrixXd data, const FitControlsVinecop& controls)
 inline void
 Vinecop::select_all(Eigen::MatrixXd data, const FitControlsVinecop& controls)
 {
-  vine_struct_ =
+  rvine_structure_ =
     RVineStructure(tools_stl::seq_int(1, d_), static_cast<size_t>(0));
   select(data, controls);
 }
@@ -384,7 +324,7 @@ Vinecop::select_families(Eigen::MatrixXd data,
                          const FitControlsVinecop& controls)
 {
   auto controls_trunc_lvl = controls;
-  controls_trunc_lvl.set_trunc_lvl(vine_struct_.get_trunc_lvl());
+  controls_trunc_lvl.set_trunc_lvl(rvine_structure_.get_trunc_lvl());
   select(data, controls);
 }
 
@@ -509,7 +449,7 @@ Vinecop::get_tau(const size_t tree, const size_t edge) const
 inline size_t
 Vinecop::get_trunc_lvl() const
 {
-  return vine_struct_.get_trunc_lvl();
+  return rvine_structure_.get_trunc_lvl();
 }
 
 //! @brief extracts the parameters of all pair copulas.
@@ -559,21 +499,21 @@ Vinecop::get_dim() const
 inline std::vector<size_t>
 Vinecop::get_order() const
 {
-  return vine_struct_.get_order();
+  return rvine_structure_.get_order();
 }
 
 //! @brief extracts the structure matrix of the vine copula model.
 inline RVineStructure
 Vinecop::get_rvine_structure() const
 {
-  return vine_struct_;
+  return rvine_structure_;
 }
 
 //! @brief extracts the structure matrix of the vine copula model.
 inline Eigen::Matrix<size_t, Eigen::Dynamic, Eigen::Dynamic>
 Vinecop::get_matrix() const
 {
-  return vine_struct_.get_matrix();
+  return rvine_structure_.get_matrix();
 }
 
 //! @brief extracts the above diagonal coefficients of the vine copula model.
@@ -581,7 +521,7 @@ Vinecop::get_matrix() const
 inline TriangularArray<size_t>
 Vinecop::get_struct_array(bool natural_order) const
 {
-  return vine_struct_.get_struct_array(natural_order);
+  return rvine_structure_.get_struct_array(natural_order);
 }
 
 //! @brief extracts the log-likelihood (throws an error if model has not been
@@ -687,6 +627,18 @@ Vinecop::set_var_types(const std::vector<std::string>& var_types)
   set_var_types_internal(var_types);
 }
 
+//! @brief sets all pair-copulas.
+//! @param pair_copuals a vector of pair-copulas that has to be consistent with
+//!     the current structure (see Vinecop()).
+inline void
+Vinecop::set_all_pair_copulas(
+  const std::vector<std::vector<Bicop>>& pair_copulas)
+{
+  check_pair_copulas_rvine_structure(pair_copulas);
+  pair_copulas_ = pair_copulas;
+  rvine_structure_.truncate(pair_copulas.size());
+}
+
 inline void
 Vinecop::check_var_types(const std::vector<std::string>& var_types) const
 {
@@ -719,20 +671,21 @@ Vinecop::set_var_types_internal(const std::vector<std::string>& var_types) const
   // set new var_types for all pair-copulas
   std::vector<std::string> natural_types(d_), pair_types(2);
   for (size_t j = 0; j < d_; ++j) {
-    natural_types[j] = var_types[vine_struct_.get_order()[j] - 1];
+    natural_types[j] = var_types[rvine_structure_.get_order()[j] - 1];
   }
   // we set the first tree explicitly and deduce later trees
   for (size_t e = 0; e < d_ - 1; ++e) {
     pair_types[0] = natural_types[e];
-    pair_types[1] = natural_types[vine_struct_.struct_array(0, e, true) - 1];
+    pair_types[1] =
+      natural_types[rvine_structure_.struct_array(0, e, true) - 1];
     pair_copulas_[0][e].set_var_types(pair_types);
   }
 
   for (size_t t = 1; t < pair_copulas_.size(); ++t) {
     for (size_t e = 0; e < d_ - t - 1; ++e) {
-      size_t m = vine_struct_.min_array(t, e);
+      size_t m = rvine_structure_.min_array(t, e);
       pair_types[0] = pair_copulas_[t - 1][e].get_var_types()[0];
-      if (m == vine_struct_.struct_array(t, e, true)) {
+      if (m == rvine_structure_.struct_array(t, e, true)) {
         pair_types[1] = pair_copulas_[t - 1][m - 1].get_var_types()[0];
       } else {
         pair_types[1] = pair_copulas_[t - 1][m - 1].get_var_types()[1];
@@ -766,8 +719,8 @@ Vinecop::pdf(Eigen::MatrixXd u, const size_t num_threads) const
   u = collapse_data(u);
 
   // info about the vine structure (reverse rows (!) for more natural indexing)
-  size_t trunc_lvl = vine_struct_.get_trunc_lvl();
-  auto order = vine_struct_.get_order();
+  size_t trunc_lvl = rvine_structure_.get_trunc_lvl();
+  auto order = rvine_structure_.get_order();
   auto disc_cols = tools_select::get_disc_cols(var_types_);
 
   // initial value must be 1.0 for multiplication
@@ -775,8 +728,7 @@ Vinecop::pdf(Eigen::MatrixXd u, const size_t num_threads) const
 
   auto do_batch = [&](const tools_batch::Batch& b) {
     // temporary storage objects (all data must be in (0, 1))
-    Eigen::MatrixXd hfunc1, hfunc2, u_e,
-                    hfunc1_sub, hfunc2_sub, u_e_sub;
+    Eigen::MatrixXd hfunc1, hfunc2, u_e, hfunc1_sub, hfunc2_sub, u_e_sub;
     hfunc1 = Eigen::MatrixXd::Zero(b.size, d_);
     hfunc2 = Eigen::MatrixXd::Zero(b.size, d_);
     if (get_n_discrete() > 0) {
@@ -802,11 +754,11 @@ Vinecop::pdf(Eigen::MatrixXd u, const size_t num_threads) const
         // computed in previous tree level)
         Bicop edge_copula = get_pair_copula(tree, edge);
         auto var_types = edge_copula.get_var_types();
-        size_t m = vine_struct_.min_array(tree, edge);
+        size_t m = rvine_structure_.min_array(tree, edge);
 
         u_e = Eigen::MatrixXd(b.size, 2);
         u_e.col(0) = hfunc2.col(edge);
-        if (m == vine_struct_.struct_array(tree, edge, true)) {
+        if (m == rvine_structure_.struct_array(tree, edge, true)) {
           u_e.col(1) = hfunc2.col(m - 1);
         } else {
           u_e.col(1) = hfunc1.col(m - 1);
@@ -815,7 +767,7 @@ Vinecop::pdf(Eigen::MatrixXd u, const size_t num_threads) const
         if ((var_types[0] == "d") | (var_types[1] == "d")) {
           u_e.conservativeResize(b.size, 4);
           u_e.col(2) = hfunc2_sub.col(edge);
-          if (m == vine_struct_.struct_array(tree, edge, true)) {
+          if (m == rvine_structure_.struct_array(tree, edge, true)) {
             u_e.col(3) = hfunc2_sub.col(m - 1);
           } else {
             u_e.col(3) = hfunc1_sub.col(m - 1);
@@ -826,7 +778,7 @@ Vinecop::pdf(Eigen::MatrixXd u, const size_t num_threads) const
           pdf.segment(b.begin, b.size).cwiseProduct(edge_copula.pdf(u_e));
 
         // h-functions are only evaluated if needed in next step
-        if (vine_struct_.needed_hfunc1(tree, edge)) {
+        if (rvine_structure_.needed_hfunc1(tree, edge)) {
           hfunc1.col(edge) = edge_copula.hfunc1(u_e);
           if (var_types[1] == "d") {
             u_e_sub = u_e;
@@ -834,7 +786,7 @@ Vinecop::pdf(Eigen::MatrixXd u, const size_t num_threads) const
             hfunc1_sub.col(edge) = edge_copula.hfunc1(u_e_sub);
           }
         }
-        if (vine_struct_.needed_hfunc2(tree, edge)) {
+        if (rvine_structure_.needed_hfunc2(tree, edge)) {
           hfunc2.col(edge) = edge_copula.hfunc2(u_e);
           if (var_types[0] == "d") {
             u_e_sub = u_e;
@@ -1056,8 +1008,8 @@ Vinecop::rosenblatt(const Eigen::MatrixXd& u, const size_t num_threads) const
   size_t n = u.rows();
 
   // info about the vine structure
-  size_t trunc_lvl = vine_struct_.get_trunc_lvl();
-  auto order = vine_struct_.get_order();
+  size_t trunc_lvl = rvine_structure_.get_trunc_lvl();
+  auto order = rvine_structure_.get_order();
   auto inverse_order = tools_stl::invert_permutation(order);
 
   // fill first row of hfunc2 matrix with evaluation points;
@@ -1075,9 +1027,9 @@ Vinecop::rosenblatt(const Eigen::MatrixXd& u, const size_t num_threads) const
         tools_interface::check_user_interrupt(edge % 100 == 0);
         // extract evaluation point from hfunction matrices (have been
         // computed in previous tree level)
-        size_t m = vine_struct_.min_array(tree, edge);
+        size_t m = rvine_structure_.min_array(tree, edge);
         u_e.col(0) = hfunc2.block(b.begin, edge, b.size, 1);
-        if (m == vine_struct_.struct_array(tree, edge, true)) {
+        if (m == rvine_structure_.struct_array(tree, edge, true)) {
           u_e.col(1) = hfunc2.block(b.begin, m - 1, b.size, 1);
         } else {
           u_e.col(1) = hfunc1.block(b.begin, m - 1, b.size, 1);
@@ -1085,7 +1037,7 @@ Vinecop::rosenblatt(const Eigen::MatrixXd& u, const size_t num_threads) const
 
         // h-functions are only evaluated if needed in next step
         Bicop edge_copula = get_pair_copula(tree, edge).as_continuous();
-        if (vine_struct_.needed_hfunc1(tree, edge)) {
+        if (rvine_structure_.needed_hfunc1(tree, edge)) {
           hfunc1.block(b.begin, edge, b.size, 1) = edge_copula.hfunc1(u_e);
         }
         hfunc2.block(b.begin, edge, b.size, 1) = edge_copula.hfunc2(u_e);
@@ -1157,8 +1109,8 @@ Vinecop::inverse_rosenblatt(const Eigen::MatrixXd& u,
   }
 
   // info about the vine structure (in upper triangular matrix notation)
-  size_t trunc_lvl = vine_struct_.get_trunc_lvl();
-  auto order = vine_struct_.get_order();
+  size_t trunc_lvl = rvine_structure_.get_trunc_lvl();
+  auto order = rvine_structure_.get_order();
   auto inverse_order = tools_stl::invert_permutation(order);
 
   auto do_batch = [&](const tools_batch::Batch& b) {
@@ -1183,9 +1135,9 @@ Vinecop::inverse_rosenblatt(const Eigen::MatrixXd& u,
 
         // extract data for conditional pair
         Eigen::MatrixXd U_e(b.size, 2);
-        size_t m = vine_struct_.min_array(tree, var);
+        size_t m = rvine_structure_.min_array(tree, var);
         U_e.col(0) = hinv2(tree + 1, var);
-        if (m == vine_struct_.struct_array(tree, var, true)) {
+        if (m == rvine_structure_.struct_array(tree, var, true)) {
           U_e.col(1) = hinv2(tree, m - 1);
         } else {
           U_e.col(1) = hfunc1(tree, m - 1);
@@ -1196,7 +1148,7 @@ Vinecop::inverse_rosenblatt(const Eigen::MatrixXd& u,
 
         // if required at later stage, also calculate hfunc2
         if (var < static_cast<ptrdiff_t>(d_) - 1) {
-          if (vine_struct_.needed_hfunc1(tree, var)) {
+          if (rvine_structure_.needed_hfunc1(tree, var)) {
             U_e.col(0) = hinv2(tree, var);
             hfunc1(tree + 1, var) = edge_copula.hfunc1(U_e);
           }
@@ -1254,7 +1206,7 @@ inline void
 Vinecop::check_pair_copulas_rvine_structure(
   const std::vector<std::vector<Bicop>>& pair_copulas) const
 {
-  size_t trunc_lvl = vine_struct_.get_trunc_lvl();
+  size_t trunc_lvl = rvine_structure_.get_trunc_lvl();
   if (pair_copulas.size() > std::min(d_ - 1, trunc_lvl)) {
     std::stringstream message;
     message << "pair_copulas is too large; "
@@ -1277,7 +1229,7 @@ Vinecop::check_pair_copulas_rvine_structure(
 inline void
 Vinecop::finalize_fit(const tools_select::VinecopSelector& selector)
 {
-  vine_struct_ = selector.get_rvine_structure();
+  rvine_structure_ = selector.get_rvine_structure();
   threshold_ = selector.get_threshold();
   loglik_ = selector.get_loglik();
   nobs_ = selector.get_nobs();
@@ -1319,7 +1271,7 @@ inline void
 Vinecop::truncate(size_t trunc_lvl)
 {
   if (trunc_lvl < this->get_trunc_lvl()) {
-    vine_struct_.truncate(trunc_lvl);
+    rvine_structure_.truncate(trunc_lvl);
     pair_copulas_.resize(trunc_lvl);
   }
 }
@@ -1369,9 +1321,9 @@ inline std::string
 Vinecop::str() const
 {
   std::stringstream str;
-  auto arr = vine_struct_.get_struct_array();
-  auto order = vine_struct_.get_order();
-  for (size_t t = 0; t < vine_struct_.get_trunc_lvl(); ++t) {
+  auto arr = rvine_structure_.get_struct_array();
+  auto order = rvine_structure_.get_order();
+  for (size_t t = 0; t < rvine_structure_.get_trunc_lvl(); ++t) {
     str << "** Tree: " << t << std::endl;
     for (size_t e = 0; e < d_ - 1 - t; ++e) {
       str << order[e] << "," << arr(t, e);

--- a/include/vinecopulib/vinecop/implementation/class.ipp
+++ b/include/vinecopulib/vinecop/implementation/class.ipp
@@ -31,7 +31,7 @@ inline Vinecop::Vinecop(const size_t d)
 //!   If empty, then all variables are set as continuous.
 inline Vinecop::Vinecop(const RVineStructure& structure,
                         const std::vector<std::vector<Bicop>>& pair_copulas,
-                        const std::vector<std::string> var_types)
+                        const std::vector<std::string>& var_types)
   : d_(structure.get_dim())
   , rvine_structure_(structure)
 {
@@ -56,7 +56,7 @@ inline Vinecop::Vinecop(const RVineStructure& structure,
 inline Vinecop::Vinecop(
   const Eigen::Matrix<size_t, Eigen::Dynamic, Eigen::Dynamic>& matrix,
   const std::vector<std::vector<Bicop>>& pair_copulas,
-  const std::vector<std::string> var_types)
+  const std::vector<std::string>& var_types)
   : Vinecop(RVineStructure(matrix), pair_copulas, var_types)
 {}
 
@@ -72,8 +72,8 @@ inline Vinecop::Vinecop(
 //! @param controls see FitControlsVinecop.
 inline Vinecop::Vinecop(const Eigen::MatrixXd& data,
                         const RVineStructure& structure,
-                        const std::vector<std::string> var_types,
-                        FitControlsVinecop controls)
+                        const std::vector<std::string>& var_types,
+                        const FitControlsVinecop& controls)
 {
   check_enough_data(data);
   if (structure.get_dim() > 1) {
@@ -109,8 +109,8 @@ inline Vinecop::Vinecop(const Eigen::MatrixXd& data,
 inline Vinecop::Vinecop(
   const Eigen::MatrixXd& data,
   const Eigen::Matrix<size_t, Eigen::Dynamic, Eigen::Dynamic>& matrix,
-  const std::vector<std::string> var_types,
-  FitControlsVinecop controls)
+  const std::vector<std::string>& var_types,
+  const FitControlsVinecop& controls)
   : Vinecop(data, RVineStructure(matrix), var_types, controls)
 {}
 
@@ -259,17 +259,17 @@ Vinecop::make_pair_copula_store(const size_t d, const size_t trunc_lvl)
 //!   observations, where \f$ k \f$ is the number of discrete variables.
 //! @param controls the controls to the algorithm (see FitControlsVinecop).
 inline void
-Vinecop::select(Eigen::MatrixXd data, const FitControlsVinecop& controls)
+Vinecop::select(const Eigen::MatrixXd& data, const FitControlsVinecop& controls)
 {
   check_data(data);
-  data = collapse_data(data);
+  Eigen::MatrixXd u = collapse_data(data);
 
   tools_select::VinecopSelector selector(
-    data, rvine_structure_, controls, var_types_);
+    u, rvine_structure_, controls, var_types_);
   if (controls.needs_sparse_select()) {
-    selector.sparse_select_all_trees(data);
+    selector.sparse_select_all_trees(u);
   } else {
-    selector.select_all_trees(data);
+    selector.select_all_trees(u);
   }
   finalize_fit(selector);
 }
@@ -295,10 +295,10 @@ Vinecop::select(Eigen::MatrixXd data, const FitControlsVinecop& controls)
 //!   observations, where \f$ k \f$ is the number of discrete variables.
 //! @param controls the controls to the algorithm (see FitControlsVinecop).
 inline void
-Vinecop::select_all(Eigen::MatrixXd data, const FitControlsVinecop& controls)
+Vinecop::select_all(const Eigen::MatrixXd& data,
+                    const FitControlsVinecop& controls)
 {
-  rvine_structure_ =
-    RVineStructure(tools_stl::seq_int(1, d_), static_cast<size_t>(0));
+  rvine_structure_ = RVineStructure(d_, static_cast<size_t>(0));
   select(data, controls);
 }
 
@@ -319,7 +319,7 @@ Vinecop::select_all(Eigen::MatrixXd data, const FitControlsVinecop& controls)
 //!   observations, where \f$ k \f$ is the number of discrete variables.
 //! @param controls the controls to the algorithm (see FitControlsVinecop).
 inline void
-Vinecop::select_families(Eigen::MatrixXd data,
+Vinecop::select_families(const Eigen::MatrixXd& data,
                          const FitControlsVinecop& controls)
 {
   auto controls_trunc_lvl = controls;

--- a/include/vinecopulib/vinecop/implementation/class.ipp
+++ b/include/vinecopulib/vinecop/implementation/class.ipp
@@ -92,7 +92,6 @@ inline Vinecop::Vinecop(const Eigen::MatrixXd& data,
   } else {
     set_var_types(var_types);
   }
-  std::cout << rvine_structure_.str() << std::endl;
   check_weights_size(controls.get_weights(), data);
   select(data, controls);
 }

--- a/include/vinecopulib/vinecop/implementation/rvine_structure.ipp
+++ b/include/vinecopulib/vinecop/implementation/rvine_structure.ipp
@@ -57,29 +57,29 @@ inline RVineStructure::RVineStructure(
   needed_hfunc2_ = compute_needed_hfunc2();
 }
 
-//! @brief instantiates an RVineStructure object to a D-vine with given ordering
-//! of variables.
-//! @param order the order of variables in the D-vine (diagonal entries in the
-//!    R-vine array); must be a permutation of 1, ..., d.
-//! @param check whether `order shall be checked for validity.
-inline RVineStructure::RVineStructure(const std::vector<size_t>& order,
-                                      bool check)
-  : RVineStructure(order, order.size() - 1, check)
+//! @brief instantiates an RVineStructure object to a D-vine for a given
+//! dimension
+//! @param d the dimension.
+//! @param trunc_lvl the truncation level. By default, it is dim - 1.
+inline RVineStructure::RVineStructure(const size_t& d, const size_t& trunc_lvl)
+  : RVineStructure(tools_stl::seq_int(1, d), std::min(d - 1, trunc_lvl), false)
 {}
 
 //! @brief instantiates an RVineStructure object to a D-vine with given ordering
 //! of variables.
 //! @param order the order of variables in the D-vine (diagonal entries in the
 //!    R-vine array); must be a permutation of 1, ..., d.
-//! @param trunc_lvl the truncation level.
+//! @param trunc_lvl the truncation level. By default, it is d - 1.
 //! @param check whether `order shall be checked for validity.
 inline RVineStructure::RVineStructure(const std::vector<size_t>& order,
                                       const size_t& trunc_lvl,
                                       bool check)
-  : RVineStructure(order,
-                   make_dvine_struct_array(order.size(), trunc_lvl),
-                   true,
-                   false)
+  : RVineStructure(
+      order,
+      make_dvine_struct_array(order.size(),
+                              std::min(order.size() - 1, trunc_lvl)),
+      true,
+      false)
 {
   if (check)
     check_antidiagonal();

--- a/include/vinecopulib/vinecop/rvine_structure.hpp
+++ b/include/vinecopulib/vinecop/rvine_structure.hpp
@@ -8,6 +8,7 @@
 
 #include <Eigen/Dense>
 #include <boost/property_tree/ptree.hpp>
+#include <limits>
 #include <vinecopulib/misc/triangular_array.hpp>
 
 namespace vinecopulib {
@@ -66,14 +67,13 @@ namespace vinecopulib {
 class RVineStructure
 {
 public:
-  RVineStructure() {}
-
+  RVineStructure(const size_t& d = static_cast<size_t>(1),
+                 const size_t& trunc_lvl = std::numeric_limits<size_t>::max());
   RVineStructure(
     const Eigen::Matrix<size_t, Eigen::Dynamic, Eigen::Dynamic>& mat,
     bool check = true);
-  RVineStructure(const std::vector<size_t>& order, bool check = true);
   RVineStructure(const std::vector<size_t>& order,
-                 const size_t& trunc_lvl,
+                 const size_t& trunc_lvl = std::numeric_limits<size_t>::max(),
                  bool check = true);
   RVineStructure(const std::vector<size_t>& order,
                  const TriangularArray<size_t>& struct_array,

--- a/test/src_test/include/test_bicop_sanity_checks.hpp
+++ b/test/src_test/include/test_bicop_sanity_checks.hpp
@@ -39,6 +39,13 @@ TEST(bicop_sanity_checks, catches_wrong_rotation)
   EXPECT_ANY_THROW(Bicop(BicopFamily::gaussian, 10));
 }
 
+TEST(bicop_sanity_checks, catches_var_types)
+{
+  auto rho = Eigen::VectorXd::Constant(1, 0.5);
+  EXPECT_ANY_THROW(Bicop(BicopFamily::gaussian, 0, rho, { "c" }));
+  EXPECT_ANY_THROW(Bicop(BicopFamily::gaussian, 0, rho, { "c", "u" }));
+}
+
 TEST(bicop_sanity_checks, catches_not_fitted_to_data)
 {
   auto bc = Bicop(BicopFamily::gaussian);

--- a/test/src_test/include/test_discrete.hpp
+++ b/test/src_test/include/test_discrete.hpp
@@ -82,8 +82,7 @@ TEST(discrete, vinecop)
     }
   }
   RVineStructure str(std::vector<size_t>{ 1, 2, 3, 4, 5 });
-  Vinecop vc(pair_copulas, str);
-  vc.set_var_types({ "d", "c", "d", "d", "c" });
+  Vinecop vc(str, pair_copulas, { "d", "c", "d", "d", "c" });
 
   // simulate data with continuous and discrete variables
   auto utmp = vc.simulate(500, true, 1, { 1 });

--- a/test/src_test/include/test_serialization.hpp
+++ b/test/src_test/include/test_serialization.hpp
@@ -49,7 +49,7 @@ TEST(serialization, vinecop_serialization)
     }
   }
 
-  auto vc = Vinecop(pc_store, mat);
+  auto vc = Vinecop(mat, pc_store);
 
   // serialize
   vc.to_json("temp");

--- a/test/src_test/include/test_vinecop_sanity_checks.hpp
+++ b/test/src_test/include/test_vinecop_sanity_checks.hpp
@@ -30,7 +30,7 @@ TEST(vinecop_sanity_checks, catches_wrong_size)
   auto pair_copulas = Vinecop::make_pair_copula_store(3);
   Eigen::Matrix<size_t, Eigen::Dynamic, Eigen::Dynamic> mat(3, 3);
   mat << 2, 2, 2, 1, 1, 0, 3, 0, 0;
-  Vinecop vinecop(pair_copulas, mat);
+  Vinecop vinecop(mat, pair_copulas);
 
   Eigen::MatrixXd U = Eigen::MatrixXd::Constant(4, 4, 0.5);
   EXPECT_ANY_THROW(vinecop.pdf(U));
@@ -46,9 +46,9 @@ TEST(vinecop_sanity_checks, catches_wrong_size)
   EXPECT_ANY_THROW(vinecop.cdf(U));
 
   pair_copulas.resize(4); // too many
-  EXPECT_ANY_THROW(Vinecop(pair_copulas, mat));
+  EXPECT_ANY_THROW(Vinecop(mat, pair_copulas));
   pair_copulas = Vinecop::make_pair_copula_store(3);
   pair_copulas[0].pop_back(); // to few
-  EXPECT_ANY_THROW(Vinecop(pair_copulas, mat));
+  EXPECT_ANY_THROW(Vinecop(mat, pair_copulas));
 }
 }

--- a/test/src_test/include/test_weights.hpp
+++ b/test/src_test/include/test_weights.hpp
@@ -21,7 +21,7 @@ TEST(test_weights, catches_incompatible_sizes)
   controls.set_weights(w);
   EXPECT_ANY_THROW(Bicop(u, controls));
   u = tools_stats::simulate_uniform(20, 4);
-  EXPECT_ANY_THROW(Vinecop(u, controls));
+  EXPECT_ANY_THROW(Vinecop(u, RVineStructure(), {}, controls));
 }
 
 TEST(test_weights, allows_nans)
@@ -57,9 +57,9 @@ TEST(test_weights, works_in_vinecop_select)
   w.head(100) = Eigen::VectorXd::Ones(100);
 
   FitControlsBicop controls(bicop_families::parametric);
-  auto cop_uw = Vinecop(u.block(0, 0, 100, 7), controls);
+  auto cop_uw = Vinecop(u.block(0, 0, 100, 7), RVineStructure(), {}, controls);
   controls.set_weights(w);
-  auto cop_w = Vinecop(u, controls);
+  auto cop_w = Vinecop(u, RVineStructure(), {}, controls);
   EXPECT_EQ(cop_uw.get_all_families(), cop_w.get_all_families());
   EXPECT_EQ(cop_uw.get_all_parameters(), cop_w.get_all_parameters());
 }


### PR DESCRIPTION
- `Bicop`:
    - [x] add `var_types`
- `Vinecop`
    - [x] add `var_types` 
    - [x] remove checks for matrix inputs
    - [x] remove constructors with order and array
    - [x] collapse constructors using structure only with those using structure + pcs
