### PR TITLE
use stable sort to keep order in ranks

### DIFF
--- a/include/vinecopulib/misc/tools_stl.hpp
+++ b/include/vinecopulib/misc/tools_stl.hpp
@@ -22,7 +22,7 @@ get_order(const std::vector<T>& x)
 {
   std::vector<size_t> order(x.size());
   std::iota(order.begin(), order.end(), 0);
-  std::sort(order.begin(), order.end(), [&](size_t i, size_t j) -> bool {
+  std::stable_sort(order.begin(), order.end(), [&](size_t i, size_t j) -> bool {
     return (x[i] < x[j]);
   });
   return order;


### PR DESCRIPTION
now  pseudo_obs(x, ties = "first")  == rank(x, ties = "first") in R