### PR TITLE
safety net for NA structure weights

### DIFF
--- a/include/vinecopulib/vinecop/implementation/tools_select.ipp
+++ b/include/vinecopulib/vinecop/implementation/tools_select.ipp
@@ -42,6 +42,10 @@ calculate_criterion(const Eigen::MatrixXd& data,
     } else {
       w = wdm::wdm(data_no_nan, tree_criterion, weights)(0, 1);
     }
+
+    if (std::isnan(w)) {
+      w = 0.0;
+    }
   }
   return std::fabs(w) * std::sqrt(freq);
 }


### PR DESCRIPTION
If two variables are perfectly dependent, the edge weight will be `nan`. 
The `VinecopSelector` then builds trees with insufficient number of edges, leading to the unintuitive error message
```
 not a valid R-vine array: the order/antidiagonal must contain the numbers 1, ..., d (the number of variables)
```
This fix sets corresponding weights to zero. Perfect dependence is usually scattered due by estimation + numerical error after a few trees.

It's not a real solution, but a temporary fix: if variables are perfectly dependent, the density does not exist. If there are d variables and the first two are comonotonic, one could define a joint density as 0 if X_1 != X_2 and f_{X_2, ... X_d} otherwise. So we could in principle handle these cases more systematically.