### PR TITLE
Bicop copy ctor/assignment

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -52,7 +52,7 @@ jobs:
           elif [ "${{ matrix.cfg.os }}" == "macos-latest" ]; then
             rm '/usr/local/bin/gfortran'
             brew update
-            brew install gcc lcov eigen gsl doxygen graphviz boost
+            brew install lcov eigen gsl doxygen graphviz boost
           elif [ "${{ matrix.cfg.os }}" == "windows-latest" ]; then
             cmd "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{ matrix.cfg.platform }}
             # choco upgrade cmake

--- a/codecov.yml
+++ b/codecov.yml
@@ -11,6 +11,7 @@ coverage:
     project: yes
     patch: yes
     changes: no
+    threshold: 0.1%
 
 parsers:
   gcov:

--- a/codecov.yml
+++ b/codecov.yml
@@ -8,10 +8,14 @@ coverage:
   range: "70...100"
 
   status:
-    project: yes
-    patch: yes
-    changes: no
-    threshold: 0.1%
+    project:
+      default:
+        changes: no
+        threshold: 0.1%
+    patch:
+      default:
+        changes: no
+        threshold: 0.1%
 
 parsers:
   gcov:

--- a/include/vinecopulib/bicop/class.hpp
+++ b/include/vinecopulib/bicop/class.hpp
@@ -33,9 +33,13 @@ public:
                  const FitControlsBicop& controls = FitControlsBicop(),
                  const std::vector<std::string>& var_types = { "c", "c" });
 
+  Bicop(const Bicop& other);
+
   explicit Bicop(const std::string& filename);
 
   explicit Bicop(const boost::property_tree::ptree input);
+
+  Bicop& operator=(Bicop other);
 
   // Serialize
   boost::property_tree::ptree to_ptree() const;

--- a/include/vinecopulib/bicop/implementation/class.ipp
+++ b/include/vinecopulib/bicop/implementation/class.ipp
@@ -56,6 +56,33 @@ inline Bicop::Bicop(const Eigen::MatrixXd& data,
   select(data, controls);
 }
 
+//! @brief Copy constructor (deep copy)
+//!
+//! @param other Bicop object to copy.
+inline Bicop::Bicop(const Bicop& other)
+  : Bicop(other.get_family(),
+          other.get_rotation(),
+          other.get_parameters(),
+          other.get_var_types())
+{
+  nobs_ = other.nobs_;
+  bicop_->set_loglik(other.bicop_->get_loglik());
+}
+
+//! @brief Copy assignment operator (deep copy)
+//!
+//! @param other Bicop object to copy.
+inline Bicop&
+Bicop::operator=(Bicop other)
+{
+  // copy/swap idiom
+  std::swap(bicop_, other.bicop_);
+  std::swap(rotation_, other.rotation_);
+  std::swap(nobs_, other.nobs_);
+  std::swap(var_types_, other.var_types_);
+  return *this;
+}
+
 //! @brief Instantiates from a boost::property_tree::ptree object.
 //! @param input The boost::property_tree::ptree object to convert from
 //! (see `to_ptree()` for the structure of the input).

--- a/include/vinecopulib/vinecop/class.hpp
+++ b/include/vinecopulib/vinecop/class.hpp
@@ -185,6 +185,7 @@ protected:
                           const Eigen::MatrixXd& data) const;
   void check_enough_data(const Eigen::MatrixXd& data) const;
   void check_fitted() const;
+  void check_indices(const size_t tree, const size_t edge) const;
   void check_var_types(const std::vector<std::string>& var_types) const;
   void set_continuous_var_types() const;
   void set_var_types_internal(const std::vector<std::string>& var_types) const;

--- a/include/vinecopulib/vinecop/implementation/class.ipp
+++ b/include/vinecopulib/vinecop/implementation/class.ipp
@@ -364,27 +364,13 @@ Vinecop::select_families(const Eigen::MatrixXd& data,
 inline Bicop
 Vinecop::get_pair_copula(const size_t tree, const size_t edge) const
 {
-  if (tree > d_ - 2) {
-    std::stringstream message;
-    message << "tree index out of bounds" << std::endl
-            << "allowed: 0, ..., " << d_ - 2 << std::endl
-            << "actual: " << tree << std::endl;
-    throw std::runtime_error(message.str().c_str());
-  }
-  if (edge > d_ - tree - 2) {
-    std::stringstream message;
-    message << "edge index out of bounds" << std::endl
-            << "allowed: 0, ..., " << d_ - tree - 2 << std::endl
-            << "actual: " << edge << std::endl
-            << "tree level: " << tree << std::endl;
-    throw std::runtime_error(message.str().c_str());
-  }
+  this->check_indices(tree, edge);
   if (tree >= pair_copulas_.size()) {
-    // vine is truncated
-    return Bicop();
+    return Bicop(); // vine is truncated
   }
   return pair_copulas_[tree][edge];
 }
+
 
 //! @brief Gets all pair copulas.
 //!
@@ -403,7 +389,11 @@ Vinecop::get_all_pair_copulas() const
 inline BicopFamily
 Vinecop::get_family(const size_t tree, const size_t edge) const
 {
-  return get_pair_copula(tree, edge).get_family();
+  this->check_indices(tree, edge);
+  if (tree >= pair_copulas_.size()) {
+    return BicopFamily::indep; // vine is truncated
+  }
+  return pair_copulas_[tree][edge].get_family();
 }
 
 //! @brief Gets the families of all pair copulas.
@@ -417,7 +407,7 @@ Vinecop::get_all_families() const
   for (size_t tree = 0; tree < pair_copulas_.size(); ++tree) {
     families[tree].resize(d_ - 1 - tree);
     for (size_t edge = 0; edge < d_ - 1 - tree; ++edge) {
-      families[tree][edge] = get_family(tree, edge);
+      families[tree][edge] = pair_copulas_[tree][edge].get_family();
     }
   }
 
@@ -431,7 +421,11 @@ Vinecop::get_all_families() const
 inline int
 Vinecop::get_rotation(const size_t tree, const size_t edge) const
 {
-  return get_pair_copula(tree, edge).get_rotation();
+  this->check_indices(tree, edge);
+  if (tree >= pair_copulas_.size()) {
+    return 0; // vine is truncated
+  }
+  return pair_copulas_[tree][edge].get_rotation();
 }
 
 //! @brief Gets the rotations of all pair copulas.
@@ -445,7 +439,7 @@ Vinecop::get_all_rotations() const
   for (size_t tree = 0; tree < pair_copulas_.size(); ++tree) {
     rotations[tree].resize(d_ - 1 - tree);
     for (size_t edge = 0; edge < d_ - 1 - tree; ++edge) {
-      rotations[tree][edge] = get_rotation(tree, edge);
+      rotations[tree][edge] = pair_copulas_[tree][edge].get_rotation();
     }
   }
 
@@ -459,7 +453,11 @@ Vinecop::get_all_rotations() const
 inline Eigen::MatrixXd
 Vinecop::get_parameters(const size_t tree, const size_t edge) const
 {
-  return get_pair_copula(tree, edge).get_parameters();
+  this->check_indices(tree, edge);
+  if (tree >= pair_copulas_.size()) {
+    return Eigen::MatrixXd(); // vine is truncated
+  }
+  return pair_copulas_[tree][edge].get_parameters();
 }
 
 //! @brief Gets the Kendall's \f$ tau \f$ of a pair copula.
@@ -469,7 +467,11 @@ Vinecop::get_parameters(const size_t tree, const size_t edge) const
 inline double
 Vinecop::get_tau(const size_t tree, const size_t edge) const
 {
-  return get_pair_copula(tree, edge).get_tau();
+  this->check_indices(tree, edge);
+  if (tree >= pair_copulas_.size()) {
+    return 0; // vine is truncated
+  }
+  return pair_copulas_[tree][edge].get_tau();
 }
 
 inline size_t
@@ -489,7 +491,7 @@ Vinecop::get_all_parameters() const
   for (size_t tree = 0; tree < parameters.size(); ++tree) {
     parameters[tree].resize(d_ - 1 - tree);
     for (size_t edge = 0; edge < d_ - 1 - tree; ++edge) {
-      parameters[tree][edge] = get_parameters(tree, edge);
+      parameters[tree][edge] = pair_copulas_[tree][edge].get_parameters();
     }
   }
 
@@ -507,7 +509,7 @@ Vinecop::get_all_taus() const
   for (size_t tree = 0; tree < taus.size(); ++tree) {
     taus[tree].resize(d_ - 1 - tree);
     for (size_t edge = 0; edge < d_ - 1 - tree; ++edge) {
-      taus[tree][edge] = get_tau(tree, edge);
+      taus[tree][edge] = pair_copulas_[tree][edge].get_tau();
     }
   }
 
@@ -780,8 +782,8 @@ Vinecop::pdf(Eigen::MatrixXd u, const size_t num_threads) const
         tools_interface::check_user_interrupt(edge % 100 == 0);
         // extract evaluation point from hfunction matrices (have been
         // computed in previous tree level)
-        Bicop edge_copula = get_pair_copula(tree, edge);
-        auto var_types = edge_copula.get_var_types();
+        Bicop* edge_copula = &pair_copulas_[tree][edge];
+        auto var_types = edge_copula->get_var_types();
         size_t m = rvine_structure_.min_array(tree, edge);
 
         u_e = Eigen::MatrixXd(b.size, 2);
@@ -803,23 +805,23 @@ Vinecop::pdf(Eigen::MatrixXd u, const size_t num_threads) const
         }
 
         pdf.segment(b.begin, b.size) =
-          pdf.segment(b.begin, b.size).cwiseProduct(edge_copula.pdf(u_e));
+          pdf.segment(b.begin, b.size).cwiseProduct(edge_copula->pdf(u_e));
 
         // h-functions are only evaluated if needed in next step
         if (rvine_structure_.needed_hfunc1(tree, edge)) {
-          hfunc1.col(edge) = edge_copula.hfunc1(u_e);
+          hfunc1.col(edge) = edge_copula->hfunc1(u_e);
           if (var_types[1] == "d") {
             u_e_sub = u_e;
             u_e_sub.col(1) = u_e.col(3);
-            hfunc1_sub.col(edge) = edge_copula.hfunc1(u_e_sub);
+            hfunc1_sub.col(edge) = edge_copula->hfunc1(u_e_sub);
           }
         }
         if (rvine_structure_.needed_hfunc2(tree, edge)) {
-          hfunc2.col(edge) = edge_copula.hfunc2(u_e);
+          hfunc2.col(edge) = edge_copula->hfunc2(u_e);
           if (var_types[0] == "d") {
             u_e_sub = u_e;
             u_e_sub.col(0) = u_e.col(2);
-            hfunc2_sub.col(edge) = edge_copula.hfunc2(u_e_sub);
+            hfunc2_sub.col(edge) = edge_copula->hfunc2(u_e_sub);
           }
         }
       }
@@ -1070,7 +1072,7 @@ Vinecop::rosenblatt(const Eigen::MatrixXd& u, const size_t num_threads) const
         }
 
         // h-functions are only evaluated if needed in next step
-        Bicop edge_copula = get_pair_copula(tree, edge).as_continuous();
+        Bicop edge_copula = pair_copulas_[tree][edge].as_continuous();
         if (rvine_structure_.needed_hfunc1(tree, edge)) {
           hfunc1.block(b.begin, edge, b.size, 1) = edge_copula.hfunc1(u_e);
         }
@@ -1166,7 +1168,7 @@ Vinecop::inverse_rosenblatt(const Eigen::MatrixXd& u,
         static_cast<double>(n) * static_cast<double>(d) > 1e5);
       size_t tree_start = std::min(trunc_lvl - 1, d - var - 2);
       for (ptrdiff_t tree = tree_start; tree >= 0; --tree) {
-        Bicop edge_copula = get_pair_copula(tree, var).as_continuous();
+        Bicop edge_copula = pair_copulas_[tree][var].as_continuous();
 
         // extract data for conditional pair
         Eigen::MatrixXd U_e(b.size, 2);
@@ -1295,6 +1297,26 @@ Vinecop::check_fitted() const
 {
   if (std::isnan(loglik_)) {
     throw std::runtime_error("copula has not been fitted from data ");
+  }
+}
+
+inline void
+Vinecop::check_indices(const size_t tree, const size_t edge) const
+{
+  if (tree > d_ - 2) {
+    std::stringstream message;
+    message << "tree index out of bounds" << std::endl
+            << "allowed: 0, ..., " << d_ - 2 << std::endl
+            << "actual: " << tree << std::endl;
+    throw std::runtime_error(message.str().c_str());
+  }
+  if (edge > d_ - tree - 2) {
+    std::stringstream message;
+    message << "edge index out of bounds" << std::endl
+            << "allowed: 0, ..., " << d_ - tree - 2 << std::endl
+            << "actual: " << edge << std::endl
+            << "tree level: " << tree << std::endl;
+    throw std::runtime_error(message.str().c_str());
   }
 }
 

--- a/include/vinecopulib/vinecop/tools_select.hpp
+++ b/include/vinecopulib/vinecop/tools_select.hpp
@@ -72,8 +72,6 @@ struct EdgeProperties
   double weight;
   double crit;
   vinecopulib::Bicop pair_copula;
-  double loglik;
-  double npars;
   double fit_id;
 };
 typedef boost::adjacency_list<

--- a/test/src_test/include/test_bicop_sanity_checks.hpp
+++ b/test/src_test/include/test_bicop_sanity_checks.hpp
@@ -71,4 +71,19 @@ TEST(bicop_sanity_checks, controls_print)
   EXPECT_NO_THROW(controls.str());
 }
 
+TEST(bicop_sanity_checks, copy)
+{
+  auto rho = Eigen::VectorXd::Constant(1, 0.5);
+  Bicop bc1(BicopFamily::gaussian, 0, rho);
+  Bicop bc2 = bc1;
+  bc2.set_parameters(rho.array() + 0.2);
+  EXPECT_EQ(bc1.get_parameters(), rho);
+  EXPECT_ANY_THROW(bc1.get_loglik());
+
+  auto u = bc1.simulate(10);
+  bc2.select(u);
+  auto bc3 = bc2;
+  EXPECT_EQ(bc2.get_loglik(), bc3.get_loglik());
+  EXPECT_EQ(bc2.get_nobs(), bc3.get_nobs());
+}
 }

--- a/test/src_test/include/test_vinecop_class.hpp
+++ b/test/src_test/include/test_vinecop_class.hpp
@@ -126,13 +126,11 @@ TEST_F(VinecopTest, fit_statistics_getters_are_correct)
   auto data = tools_stats::simulate_uniform(100, 3);
   auto vc = Vinecop(
     data, RVineStructure(), {}, FitControlsVinecop({ BicopFamily::clayton }));
-
-  // std::cout << vc.get_pair_copula(0, 0).get_loglik() << std::endl;
-  // EXPECT_NEAR(vc.get_loglik(), vc.loglik(data), 1e-10);
-  // EXPECT_NEAR(static_cast<double>(vc.get_nobs()), 100, 1e-10);
-  // EXPECT_NEAR(vc.get_aic(), vc.aic(data), 1e-10);
-  // EXPECT_NEAR(vc.get_bic(), vc.bic(data), 1e-10);
-  // EXPECT_NEAR(vc.get_mbicv(0.6), vc.mbicv(data, 0.6), 1e-10);
+  EXPECT_NEAR(vc.get_loglik(), vc.loglik(data), 1e-10);
+  EXPECT_NEAR(static_cast<double>(vc.get_nobs()), 100, 1e-10);
+  EXPECT_NEAR(vc.get_aic(), vc.aic(data), 1e-10);
+  EXPECT_NEAR(vc.get_bic(), vc.bic(data), 1e-10);
+  EXPECT_NEAR(vc.get_mbicv(0.6), vc.mbicv(data, 0.6), 1e-10);
 }
 
 TEST_F(VinecopTest, truncate_methods_works)

--- a/test/src_test/include/test_vinecop_class.hpp
+++ b/test/src_test/include/test_vinecop_class.hpp
@@ -30,6 +30,26 @@ TEST_F(VinecopTest, constructors_without_error)
   Vinecop vinecop_parametrized(model_matrix, pair_copulas);
 }
 
+TEST_F(VinecopTest, copy)
+{
+  auto pair_copulas = Vinecop::make_pair_copula_store(7);
+  for (auto& tree : pair_copulas) {
+    for (auto& pc : tree) {
+      pc = Bicop(BicopFamily::clayton, 90);
+    }
+  }
+
+  Vinecop vinecop1(model_matrix, pair_copulas);
+  auto pc = vinecop1.get_pair_copula(0, 0);
+  pc.set_parameters(pc.get_parameters().array() + 1);
+  EXPECT_EQ(vinecop1.get_parameters(0, 0), vinecop1.get_parameters(0, 1));
+
+  Vinecop vinecop2 = vinecop1;
+  pair_copulas[0][0].set_parameters(pc.get_parameters().array() + 1);
+  vinecop2.set_all_pair_copulas(pair_copulas);
+  EXPECT_EQ(vinecop1.get_parameters(0, 0), vinecop1.get_parameters(0, 1));
+}
+
 TEST_F(VinecopTest, getters_are_correct)
 {
   auto pair_copulas = Vinecop::make_pair_copula_store(7);
@@ -107,11 +127,12 @@ TEST_F(VinecopTest, fit_statistics_getters_are_correct)
   auto vc = Vinecop(
     data, RVineStructure(), {}, FitControlsVinecop({ BicopFamily::clayton }));
 
-  EXPECT_NEAR(vc.get_loglik(), vc.loglik(data), 1e-10);
-  EXPECT_NEAR(static_cast<double>(vc.get_nobs()), 100, 1e-10);
-  EXPECT_NEAR(vc.get_aic(), vc.aic(data), 1e-10);
-  EXPECT_NEAR(vc.get_bic(), vc.bic(data), 1e-10);
-  EXPECT_NEAR(vc.get_mbicv(0.6), vc.mbicv(data, 0.6), 1e-10);
+  // std::cout << vc.get_pair_copula(0, 0).get_loglik() << std::endl;
+  // EXPECT_NEAR(vc.get_loglik(), vc.loglik(data), 1e-10);
+  // EXPECT_NEAR(static_cast<double>(vc.get_nobs()), 100, 1e-10);
+  // EXPECT_NEAR(vc.get_aic(), vc.aic(data), 1e-10);
+  // EXPECT_NEAR(vc.get_bic(), vc.bic(data), 1e-10);
+  // EXPECT_NEAR(vc.get_mbicv(0.6), vc.mbicv(data, 0.6), 1e-10);
 }
 
 TEST_F(VinecopTest, truncate_methods_works)


### PR DESCRIPTION
Not sure if this was intentional behavior (but I don't think so):
``` cpp
auto rho = Eigen::VectorXd::Constant(1, 0.5);
Bicop bc1(BicopFamily::gaussian, 0, rho);
std::cout << "bc1 is: " << bc1.str() << std::endl;
Bicop bc2 = bc1;
bc2.set_parameters(rho.array() + 0.2);
std::cout << "bc1 is: " << bc1.str() << std::endl;
```
Output (before PR):
```
bc1 is: Gaussian, parameters = 0.5
bc1 is: Gaussian, parameters = 0.7
```
Output (after PR):
```
bc1 is: Gaussian, parameters = 0.5
bc1 is: Gaussian, parameters = 0.5
```

