### PR TITLE
Discrete fix

### DIFF
--- a/include/vinecopulib/bicop/implementation/class.ipp
+++ b/include/vinecopulib/bicop/implementation/class.ipp
@@ -159,7 +159,7 @@ Bicop::to_json(const std::string& filename) const
 
 //! @brief Evaluates the copula density.
 //!
-//! The copula density is defined as joint density divided by marginal 
+//! The copula density is defined as joint density divided by marginal
 //! densities, irrespective of variable types.
 //!
 //! @param u An \f$ n \times (2 + k) \f$ matrix of observations contained in
@@ -877,7 +877,13 @@ Bicop::format_data(const Eigen::MatrixXd& u) const
   u_new.leftCols(2) = u.leftCols(2);
   int disc_col = (var_types_[1] == "d");
   int cont_col = 1 - disc_col;
-  // in which column is F(x^-) for the discrete variable stored?
+  // We already know that there is one discrete and one continuous variable. Now
+  // there are two cases:
+  // 1. `u.cols() == 3`: then the F(x^-) values for the discrete variable is
+  // always in the last column, i.e. `u.col(2)`.
+  // 2. `u.cols() == 4`: Then the F(x^-) values for the discrete variable is in
+  // the third column if variable 1 is discrete, and in the fourth column if
+  // variable 2 is discrete. Thus, `u.col(2 + disc_col)`.
   int old_disc_col = 2 + (u.cols() == 4) * disc_col;
   u_new.col(2 + disc_col) = u.col(old_disc_col);
   u_new.col(2 + cont_col) = u.col(cont_col);

--- a/include/vinecopulib/bicop/implementation/class.ipp
+++ b/include/vinecopulib/bicop/implementation/class.ipp
@@ -159,6 +159,9 @@ Bicop::to_json(const std::string& filename) const
 
 //! @brief Evaluates the copula density.
 //!
+//! The copula density is defined as joint density divided by marginal 
+//! densities, irrespective of variable types.
+//!
 //! @param u An \f$ n \times (2 + k) \f$ matrix of observations contained in
 //!   \f$(0, 1) \f$, where \f$ k \f$ is the number of discrete variables.
 //! @return The copula density evaluated at \c u.
@@ -353,7 +356,7 @@ Bicop::simulate(const size_t& n,
 //!
 //! The log-likelihood is defined as
 //! \f[ \mathrm{loglik} = \sum_{i = 1}^n \log c(U_{1, i}, U_{2, i}), \f]
-//! where \f$ c \f$ is the copula density `pdf()`.
+//! where \f$ c \f$ is the copula density, see `Bicop::pdf()`.
 //!
 //! @param u An \f$ n \times (2 + k) \f$ matrix of observations contained in
 //!   \f$(0, 1) \f$, where \f$ k \f$ is the number of discrete variables.

--- a/include/vinecopulib/bicop/implementation/class.ipp
+++ b/include/vinecopulib/bicop/implementation/class.ipp
@@ -869,14 +869,17 @@ Bicop::format_data(const Eigen::MatrixXd& u) const
   auto n_disc = get_n_discrete();
   if (n_disc == 0) {
     return u.leftCols(2);
-  } else if ((n_disc != 1) | (u.cols() == 4)) {
+  } else if (n_disc == 2) {
     return u;
   }
+  // n_disc = 1:
   Eigen::MatrixXd u_new(u.rows(), 4);
   u_new.leftCols(2) = u.leftCols(2);
   int disc_col = (var_types_[1] == "d");
   int cont_col = 1 - disc_col;
-  u_new.col(2 + disc_col) = u.col(2);
+  // in which column is F(x^-) for the discrete variable stored?
+  int old_disc_col = 2 + (u.cols() == 4) * disc_col;
+  u_new.col(2 + disc_col) = u.col(old_disc_col);
   u_new.col(2 + cont_col) = u.col(cont_col);
   return u_new;
 }

--- a/include/vinecopulib/vinecop/implementation/class.ipp
+++ b/include/vinecopulib/vinecop/implementation/class.ipp
@@ -734,6 +734,9 @@ Vinecop::get_var_types() const
 
 //! @brief Evaluates the copula density.
 //!
+//! The copula density is defined as joint density divided by marginal 
+//! densities, irrespective of variable types.
+//!
 //! @param u An \f$ n \times (d + k) \f$ or \f$ n \times 2d \f$ matrix of
 //!   evaluation points, where \f$ k \f$ is the number of discrete variables
 //!   (see `select()`).
@@ -913,7 +916,7 @@ Vinecop::simulate(const size_t n,
 //!
 //! The log-likelihood is defined as
 //! \f[ \mathrm{loglik} = \sum_{i = 1}^n \log c(U_{1, i}, ..., U_{d, i}), \f]
-//! where \f$ c \f$ is the copula density `pdf()`.
+//! where \f$ c \f$ is the copula density, see `Vinecop::pdf()`.
 //!
 //! @param u An \f$ n \times (d + k) \f$ or \f$ n \times 2d \f$ matrix of
 //!   evaluation points, where \f$ k \f$ is the number of discrete variables

--- a/include/vinecopulib/vinecop/implementation/class.ipp
+++ b/include/vinecopulib/vinecop/implementation/class.ipp
@@ -774,8 +774,6 @@ Vinecop::pdf(Eigen::MatrixXd u, const size_t num_threads) const
       if (var_types_[order[j] - 1] == "d") {
         hfunc2_sub.col(j) =
           u.block(b.begin, d_ + disc_cols[order[j] - 1], b.size, 1);
-      } else {
-        hfunc2_sub.col(j) = u.block(b.begin, order[j] - 1, b.size, 1);
       }
     }
 

--- a/include/vinecopulib/vinecop/implementation/class.ipp
+++ b/include/vinecopulib/vinecop/implementation/class.ipp
@@ -774,6 +774,8 @@ Vinecop::pdf(Eigen::MatrixXd u, const size_t num_threads) const
       if (var_types_[order[j] - 1] == "d") {
         hfunc2_sub.col(j) =
           u.block(b.begin, d_ + disc_cols[order[j] - 1], b.size, 1);
+      } else {
+        hfunc2_sub.col(j) = u.block(b.begin, order[j] - 1, b.size, 1);
       }
     }
 


### PR DESCRIPTION
Output of pdf/loglik wasn't correct when discrete variables are present. This was caused by unitialized columns that were used later in the algorithm. Also clarified what we call "copula density" in that case, because there's no standard definition.