### PR TITLE
fix uninitialized npars_

### DIFF
--- a/include/vinecopulib/bicop/implementation/kernel.ipp
+++ b/include/vinecopulib/bicop/implementation/kernel.ipp
@@ -22,6 +22,7 @@ inline KernelBicop::KernelBicop()
   interp_grid_ = std::make_shared<tools_interpolation::InterpolationGrid>(
     grid_points, Eigen::MatrixXd::Constant(m, m, 1.0) // independence
   );
+  npars_ = 0.0;
 }
 
 inline Eigen::VectorXd


### PR DESCRIPTION
Valgrind on latest R devel seems to have uncovered an issue: 
https://www.stats.ox.ac.uk/pub/bdr/memtests/valgrind/rvinecopulib/tests/testthat.Rout
https://cran.r-project.org/web/checks/check_results_vinereg.html

This fixes it.