### PR TITLE
Add Zenodo metadata file

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,21 @@
+{
+    "title": "vinecopulib",
+    "description": "<p><a href=\"https://vinecopulib.github.io/vinecopulib/\">vinecopulib</a> is a header-only C++ library for vine copula models based on Eigen. It provides high-performance implementations of the core features of the popular VineCopula R library, in particular inference algorithms for both vine copula and bivariate copula models</p>",
+    "keywords": [
+        "TODO",
+        "TODO"
+    ],
+    "upload_type": "software",
+    "access_right": "open",
+    "license": "MIT",
+    "creators": [
+        {
+            "orcid": "0000-0003-1855-0046",
+            "name": "Nagler, Thomas"
+        },
+        {
+            "orcid": "TODO",
+            "name": "Vatter, Thibault"
+        }
+    ]
+}


### PR DESCRIPTION
This PR add `.zenodo.json` so that new DOIs are automatically generated at each GitHub release. I have added a skeleton with some most entries but some need to be filled in. Before generating a new release make sure to activate this on https://zenodo.org/. See https://guides.github.com/activities/citable-code/. For the current release you will need to upload the zip manually. 