### PR TITLE
Replace sprintf

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -43,7 +43,7 @@ jobs:
           fi
         shell: bash
       - name: Setup-R
-        uses: r-lib/actions/setup-r@master
+        uses: r-lib/actions/setup-r@v2
       - name: Install other dependencies
         run:   |
           if [ "${{ matrix.cfg.os }}" == "ubuntu-latest" ]; then
@@ -60,7 +60,7 @@ jobs:
             cmd "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{ matrix.cfg.platform }}
             # choco upgrade cmake
             choco install wget
-            wget https://github.com/vinecopulib/pyvinecopulib/raw/master/lib/boost_1_71_0.tar.gz
+            wget https://github.com/vinecopulib/pyvinecopulib/raw/main/lib/boost_1_71_0.tar.gz
             set current_dir=%CD%
             echo %current_dir%  
             pwd

--- a/cmake/compilerDefOpt.cmake
+++ b/cmake/compilerDefOpt.cmake
@@ -35,7 +35,7 @@ if(NOT WIN32)
         endif()
 
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-deprecated-register") # -Qunused-arguments
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-const-variable -Wno-unused-parameter")
+        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wno-unused-const-variable ")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fcolor-diagnostics")
     endif()
 endif()

--- a/include/vinecopulib/misc/tools_integration.hpp
+++ b/include/vinecopulib/misc/tools_integration.hpp
@@ -15,7 +15,7 @@
 #define sprintf _sprintf_do_nothing
 namespace std
 {
-constexpr int _sprintf_do_nothing(char* s, const char* format, ...) { return 0; }
+constexpr int _sprintf_do_nothing(char*, const char*, ...) { return 0; }
 }
 #include <boost/numeric/odeint.hpp>
 #undef sprintf

--- a/include/vinecopulib/misc/tools_integration.hpp
+++ b/include/vinecopulib/misc/tools_integration.hpp
@@ -6,7 +6,20 @@
 
 #pragma once
 
+// replace std::sprintf by void function
+// - this is necessary because `sprintf()` is now flagged as potential security
+//   risk and deprecated in macOS 13.
+// - in our case, `boost/odeint` makes (safe) use of the function, but we don't
+//   really need it.
+// - we can remove this hack if and when updates odeint (PR open).
+#define sprintf _sprintf_do_nothing
+namespace std
+{
+constexpr int _sprintf_do_nothing(char* s, const char* format, ...) { return 0; }
+}
 #include <boost/numeric/odeint.hpp>
+#undef sprintf
+
 #include <functional>
 
 namespace vinecopulib {

--- a/include/vinecopulib/misc/tools_interface.hpp
+++ b/include/vinecopulib/misc/tools_interface.hpp
@@ -20,19 +20,6 @@ static RcppThread::RPrinter Rcout = RcppThread::RPrinter();
 #include <iostream>
 #endif
 
-#ifdef INTERFACED_FROM_R
-// replace std::sprintf by void function
-// - this is necessary because `sprintf()` is now flagged as potential se
-//   security  risk by CRAN checks, which issue a WARNING.
-// - in our case, `boost/odeint` makes (safe) use of the function, but we don't 
-//   really need it.
-#define sprintf _sprintf_do_nothing
-namespace std
-{
-  inline int _sprintf_do_nothing(char* s, const char* format, ...) { return 0; }
-}
-#endif
-
 // parallel backend
 #include <vinecopulib/misc/tools_batch.hpp>
 #ifdef INTERFACED_FROM_R

--- a/include/vinecopulib/misc/tools_interface.hpp
+++ b/include/vinecopulib/misc/tools_interface.hpp
@@ -20,6 +20,19 @@ static RcppThread::RPrinter Rcout = RcppThread::RPrinter();
 #include <iostream>
 #endif
 
+#ifdef INTERFACED_FROM_R
+// replace std::sprintf by void function
+// - this is necessary because `sprintf()` is now flagged as potential se
+//   security  risk by CRAN checks, which issue a WARNING.
+// - in our case, `boost/odeint` makes (safe) use of the function, but we don't 
+//   really need it.
+#define sprintf _sprintf_do_nothing
+namespace std
+{
+  inline int _sprintf_do_nothing(char* s, const char* format, ...) { return 0; }
+}
+#endif
+
 // parallel backend
 #include <vinecopulib/misc/tools_batch.hpp>
 #ifdef INTERFACED_FROM_R


### PR DESCRIPTION
 - this is necessary because `sprintf()` is now flagged as potential security  risk by CRAN checks, which issue a WARNING.
 - in our case, `boost/odeint` makes (safe) use of the function, but we don't really need it.