### PR TITLE
Add Vinecop::fit()

### DIFF
--- a/include/vinecopulib/vinecop/class.hpp
+++ b/include/vinecopulib/vinecop/class.hpp
@@ -65,6 +65,10 @@ public:
   void select(const Eigen::MatrixXd& data,
               const FitControlsVinecop& controls = FitControlsVinecop());
 
+  void fit(const Eigen::MatrixXd& data,
+           const FitControlsBicop& controls = FitControlsBicop(),
+           const size_t num_threads = 1);
+
   DEPRECATED void select_all(
     const Eigen::MatrixXd& data,
     const FitControlsVinecop& controls = FitControlsVinecop());

--- a/include/vinecopulib/vinecop/fit_controls.hpp
+++ b/include/vinecopulib/vinecop/fit_controls.hpp
@@ -41,7 +41,7 @@ public:
     bool preselect_families = true,
     bool select_trunc_lvl = false,
     bool select_threshold = false,
-    bool select_families = false,
+    bool select_families = true,
     bool show_trace = false,
     size_t num_threads = 1,
     std::string mst_algorithm = "prim");
@@ -53,7 +53,7 @@ public:
     double threshold = 0.0,
     bool select_trunc_lvl = false,
     bool select_threshold = false,
-    bool select_families = false,
+    bool select_families = true,
     bool show_trace = false,
     size_t num_threads = 1,
     std::string mst_algorithm = "prim");

--- a/include/vinecopulib/vinecop/fit_controls.hpp
+++ b/include/vinecopulib/vinecop/fit_controls.hpp
@@ -41,6 +41,7 @@ public:
     bool preselect_families = true,
     bool select_trunc_lvl = false,
     bool select_threshold = false,
+    bool select_families = false,
     bool show_trace = false,
     size_t num_threads = 1,
     std::string mst_algorithm = "prim");
@@ -52,6 +53,7 @@ public:
     double threshold = 0.0,
     bool select_trunc_lvl = false,
     bool select_threshold = false,
+    bool select_families = false,
     bool show_trace = false,
     size_t num_threads = 1,
     std::string mst_algorithm = "prim");
@@ -70,6 +72,8 @@ public:
   bool get_select_trunc_lvl() const;
 
   bool get_select_threshold() const;
+
+  bool get_select_families() const;
 
   bool needs_sparse_select() const;
 
@@ -92,6 +96,8 @@ public:
 
   void set_select_threshold(bool select_threshold);
 
+  void set_select_families(bool select_families);
+
   void set_fit_controls_bicop(FitControlsBicop controls);
 
   void set_mst_algorithm(std::string mst_algorithm);
@@ -106,6 +112,7 @@ private:
   bool show_trace_;
   bool select_trunc_lvl_;
   bool select_threshold_;
+  bool select_families_;
   std::string mst_algorithm_;
 
   void check_tree_criterion(std::string tree_criterion);

--- a/include/vinecopulib/vinecop/implementation/class.ipp
+++ b/include/vinecopulib/vinecop/implementation/class.ipp
@@ -248,11 +248,17 @@ Vinecop::make_pair_copula_store(const size_t d, const size_t trunc_lvl)
 
 //! @brief Automatically fits and selects a vine copula model.
 //!
-//! @details `select()` behaves differently depending on its current truncation
-//! level and the truncation level specified in the controls, respectively
-//! called `trunc_lvl` and `controls.trunc_lvl` in what follows.
+//! @details This method can be used to select either the pair-copulas only,
+//! or the pair-copulas and the structure. The latter is done by specifying
+//! a truncation level in the controls. The method then selects the structure
+//! and fits the pair-copulas for all trees up to the truncation level.
+
+//! In other words, `select()` behaves differently depending on its current 
+//! truncation level and the truncation level specified in the controls, 
+//! respectively called `trunc_lvl` and `controls.trunc_lvl` in what follows.
 //! Essentially, `controls.trunc_lvl` defines the object's truncation level
 //! after calling `select()`:
+//! 
 //!   - If `controls.trunc_lvl <= trunc_lvl`, the families and parameters for
 //!     all pairs in trees smaller or equal to `controls.trunc_lvl`
 //!     are selected, using the current structure.

--- a/include/vinecopulib/vinecop/implementation/class.ipp
+++ b/include/vinecopulib/vinecop/implementation/class.ipp
@@ -398,7 +398,7 @@ Vinecop::fit(const Eigen::MatrixXd& data,
         u_e.col(1) = hfunc1.col(m - 1);
       }
 
-      if ((var_types[0] == "d") | (var_types[1] == "d")) {
+      if ((var_types[0] == "d") || (var_types[1] == "d")) {
         u_e.conservativeResize(n, 4);
         u_e.col(2) = hfunc2_sub.col(edge);
         if (m == rvine_structure_.struct_array(tree, edge, true)) {

--- a/include/vinecopulib/vinecop/implementation/fit_controls.ipp
+++ b/include/vinecopulib/vinecop/implementation/fit_controls.ipp
@@ -21,6 +21,7 @@ inline FitControlsVinecop::FitControlsVinecop()
   tree_criterion_ = "tau";
   select_trunc_lvl_ = false;
   select_threshold_ = false;
+  select_families_ = true;
   show_trace_ = false;
 }
 
@@ -49,6 +50,9 @@ inline FitControlsVinecop::FitControlsVinecop()
 //!     automatically.
 //! @param select_threshold Whether the threshold parameter shall be
 //!     selected automatically.
+//! @param select_families Whether the families shall be selected
+//! automatically, or should the method simply update the parameters for 
+//! the pair copulas already present in the model.
 //! @param show_trace Whether to show a trace of the building progress.
 //! @param num_threads Number of concurrent threads to use while fitting
 //!     pair copulas within a tree; never uses more than the number
@@ -69,6 +73,7 @@ inline FitControlsVinecop::FitControlsVinecop(
   bool preselect_families,
   bool select_trunc_lvl,
   bool select_threshold,
+  bool select_families,
   bool show_trace,
   size_t num_threads,
   std::string mst_algorithm)
@@ -86,12 +91,15 @@ inline FitControlsVinecop::FitControlsVinecop(
   set_threshold(threshold);
   set_select_trunc_lvl(select_trunc_lvl);
   set_select_threshold(select_threshold);
+  set_select_families(select_families);
   set_show_trace(show_trace);
   set_num_threads(num_threads);
   set_mst_algorithm(mst_algorithm);
 }
 
 //! @brief Instantiates custom controls for fitting vine copula models.
+//!
+//! @param controls See `FitControlsBicop()`.
 //! @param trunc_lvl Truncation level for truncated vines.
 //! @param tree_criterion The criterion for selecting the maximum spanning
 //!     tree (`"tau"`, `"hoeffd"` and `"rho"` implemented so far).
@@ -101,7 +109,9 @@ inline FitControlsVinecop::FitControlsVinecop(
 //!     automatically.
 //! @param select_threshold Whether the threshold parameter shall be
 //!     selected automatically.
-//! @param controls See `FitControlsBicop()`.
+//! @param select_families Whether the families shall be selected
+//! automatically, or should the method simply update the parameters for 
+//! the pair copulas already present in the model.
 //! @param num_threads Number of concurrent threads to use while fitting
 //!     pair copulas within a tree; never uses more than the number returned
 //!     by `std::thread::hardware_concurrency()``.
@@ -113,6 +123,7 @@ inline FitControlsVinecop::FitControlsVinecop(const FitControlsBicop& controls,
                                               double threshold,
                                               bool select_trunc_lvl,
                                               bool select_threshold,
+                                              bool select_families,
                                               bool show_trace,
                                               size_t num_threads,
                                               std::string mst_algorithm)
@@ -123,6 +134,7 @@ inline FitControlsVinecop::FitControlsVinecop(const FitControlsBicop& controls,
   set_threshold(threshold);
   set_select_trunc_lvl(select_trunc_lvl);
   set_select_threshold(select_threshold);
+  set_select_families(select_families);
   set_show_trace(show_trace);
   set_num_threads(num_threads);
   set_mst_algorithm(mst_algorithm);
@@ -178,6 +190,20 @@ inline void
 FitControlsVinecop::set_select_trunc_lvl(bool select_trunc_lvl)
 {
   select_trunc_lvl_ = select_trunc_lvl;
+}
+
+//! @brief Gets whether to select the families automatically.
+inline bool
+FitControlsVinecop::get_select_families() const
+{
+  return select_families_;
+}
+
+//! @brief Sets whether to select the families automatically.
+inline void
+FitControlsVinecop::set_select_families(bool select_families)
+{
+  select_families_ = select_families;
 }
 
 //! @brief Gets the criterion for tree selection.
@@ -310,6 +336,10 @@ FitControlsVinecop::str() const
                << static_cast<std::string>(get_select_trunc_lvl() ? "yes"
                                                                   : "no")
                << std::endl;
+  controls_str << "Select families: "
+                << static_cast<std::string>(get_select_families() ? "yes"
+                                                                  : "no")
+                << std::endl;
   controls_str << "Show trace: "
                << static_cast<std::string>(get_show_trace() ? "yes" : "no")
                << std::endl;

--- a/test/src_test/include/test_discrete.hpp
+++ b/test/src_test/include/test_discrete.hpp
@@ -150,7 +150,8 @@ TEST(discrete, vinecop)
     }
   }
   RVineStructure str(std::vector<size_t>{ 1, 2, 3, 4, 5 });
-  Vinecop vc(str, pair_copulas, { "d", "c", "d", "d", "c" });
+  auto var_types = std::vector<std::string>{ "d", "c", "d", "d", "c" };
+  Vinecop vc(str, pair_copulas, var_types);
 
   // simulate data with continuous and discrete variables
   size_t n = 500;
@@ -183,6 +184,13 @@ TEST(discrete, vinecop)
         pc.get_parameters()(0), 2.0 / (static_cast<double>(t) + 1.0), 0.5);
     }
   }
+
+  for (auto& pc : pcs[0])
+    pc.set_parameters(Eigen::VectorXd::Constant(1, 1));
+  Vinecop vc3(vc2.get_rvine_structure(), pcs, var_types);
+  vc3.fit(u, controls);
+
+  ASSERT_TRUE(vc2.str() == vc3.str());
 
   // test other input format
   u = Eigen::MatrixXd(n, 10);


### PR DESCRIPTION
* Adds the possibility to fit each pair-copula parameter without selecting the corresponding families. 
* This is kinda useful and would also https://github.com/vinecopulib/pyvinecopulib/issues/63 