### PR TITLE
Bicop str

### DIFF
--- a/include/vinecopulib/bicop/implementation/class.ipp
+++ b/include/vinecopulib/bicop/implementation/class.ipp
@@ -754,14 +754,15 @@ inline std::string
 Bicop::str() const
 {
   std::stringstream bicop_str;
-  bicop_str << get_family_name();
-  if (get_rotation() != 0) {
-    bicop_str << " " << get_rotation() << "°";
-  }
+  bicop_str << "Bivariate copula: \n";
+  bicop_str << "  family = " << get_family_name() << "\n";
+  bicop_str << "  rotation = " << get_rotation() << "\n";
+  bicop_str << "  var_types = " << var_types_[0] << ", " << var_types_[1] << "\n";
   if (get_family() == BicopFamily::tll) {
-    bicop_str << ", parameters = [30x30 grid]";
+    double npars = get_npars()
+    bicop_str << "  parameters = [30x30 grid] with " << get_npars() << setprecision(2) << " d.f.\n";
   } else if (get_family() != BicopFamily::indep) {
-    bicop_str << ", parameters = " << get_parameters();
+    bicop_str << "  parameters = " << get_parameters() << "\n";
   }
   return bicop_str.str().c_str();
 }

--- a/include/vinecopulib/bicop/implementation/class.ipp
+++ b/include/vinecopulib/bicop/implementation/class.ipp
@@ -754,13 +754,13 @@ inline std::string
 Bicop::str() const
 {
   std::stringstream bicop_str;
+  bicop_str << std::setprecision(2); // set precision to 2 decimal places
   bicop_str << "Bivariate copula: \n";
   bicop_str << "  family = " << get_family_name() << "\n";
   bicop_str << "  rotation = " << get_rotation() << "\n";
   bicop_str << "  var_types = " << var_types_[0] << ", " << var_types_[1] << "\n";
   if (get_family() == BicopFamily::tll) {
-    double npars = get_npars()
-    bicop_str << "  parameters = [30x30 grid] with " << get_npars() << setprecision(2) << " d.f.\n";
+    bicop_str << "  parameters = [30x30 grid] with " << get_npars() << " d.f.\n";
   } else if (get_family() != BicopFamily::indep) {
     bicop_str << "  parameters = " << get_parameters() << "\n";
   }

--- a/include/vinecopulib/bicop/implementation/class.ipp
+++ b/include/vinecopulib/bicop/implementation/class.ipp
@@ -758,7 +758,7 @@ Bicop::str() const
   bicop_str << "Bivariate copula: \n";
   bicop_str << "  family = " << get_family_name() << "\n";
   bicop_str << "  rotation = " << get_rotation() << "\n";
-  bicop_str << "  var_types = " << var_types_[0] << ", " << var_types_[1] << "\n";
+  bicop_str << "  var_types = " << var_types_[0] << "," << var_types_[1] << "\n";
   if (get_family() == BicopFamily::tll) {
     bicop_str << "  parameters = [30x30 grid] with " << get_npars() << " d.f.\n";
   } else if (get_family() != BicopFamily::indep) {


### PR DESCRIPTION
Similar to R, e.g.:

```
Bivariate copula: 
  family = TLL
  rotation = 0
  var_types = c, c
  parameters = [30x30 grid] with 2.7 d.f.
 ```

Disclaimer: it's mostly because I need it for Python but I think it can be useful to C++ users too.