### PR TITLE
Improve Vinecop.str()

### DIFF
--- a/include/vinecopulib/misc/tools_stl.hpp
+++ b/include/vinecopulib/misc/tools_stl.hpp
@@ -11,6 +11,9 @@
 #include <iterator>
 #include <numeric>
 #include <vector>
+#include <iomanip>  // For std::setw
+#include <sstream>
+#include <string>
 
 namespace vinecopulib {
 
@@ -148,6 +151,34 @@ log1p(const double& x)
   } else {
     return std::log1p(x);
   }
+}
+
+// Function to format vectors of strings like a DataFrame and return a stringstream
+inline std::stringstream dataframe_to_string(const std::vector<std::vector<std::string>>& columns) {
+
+    // TODO: Check if all vectors have the same length
+
+    // Determine maximum column width for pretty printing
+    std::vector<size_t> col_widths;
+    for (const auto& col : columns) {
+        size_t max_width = 0;
+        for (const auto& item : col) {
+            max_width = std::max(max_width, item.size());
+        }
+        col_widths.push_back(max_width);
+    }
+
+    std::stringstream ss;
+    // Assuming all columns have the same number of rows
+    size_t num_rows = columns[0].size();
+    for (size_t row = 0; row < num_rows; ++row) {
+        for (size_t col = 0; col < columns.size(); ++col) {
+            ss << std::setw(static_cast<int>(col_widths[col])) << columns[col][row] << " ";
+        }
+        ss << std::endl;
+    }
+
+    return ss;
 }
 }
 }

--- a/include/vinecopulib/vinecop/class.hpp
+++ b/include/vinecopulib/vinecop/class.hpp
@@ -169,7 +169,7 @@ public:
     const size_t trunc_lvl = std::numeric_limits<size_t>::max());
   void truncate(size_t trunc_lvl);
 
-  std::string str(const std::vector<size_t>trees= {}) const;
+  std::string str(const std::vector<size_t>& trees={}) const;
 
 protected:
   size_t d_;

--- a/include/vinecopulib/vinecop/class.hpp
+++ b/include/vinecopulib/vinecop/class.hpp
@@ -169,7 +169,7 @@ public:
     const size_t trunc_lvl = std::numeric_limits<size_t>::max());
   void truncate(size_t trunc_lvl);
 
-  std::string str() const;
+  std::string str(const std::vector<size_t>trees= {}) const;
 
 protected:
   size_t d_;

--- a/include/vinecopulib/vinecop/implementation/class.ipp
+++ b/include/vinecopulib/vinecop/implementation/class.ipp
@@ -280,7 +280,7 @@ Vinecop::make_pair_copula_store(const size_t d, const size_t trunc_lvl)
 //! The dependence measure used to select trees (default: Kendall's tau) is
 //! corrected for ties (see the [wdm](https://github.com/tnagler/wdm) library).
 //!
-//! If the `controls` object has been instantiated with 
+//! If the `controls` object has been instantiated with
 //! `select_families = false`, then the method simply updates the parameters of
 //! the pair-copulas without selecting the families or the structure.
 //! In this case, this is equivalent to calling `fit()` for each pair-copula,
@@ -333,13 +333,13 @@ Vinecop::select(const Eigen::MatrixXd& data, const FitControlsVinecop& controls)
 //! @details This method fits the pair-copulas of a vine copula model. It is
 //! assumed that the structure  and pair-copula families are already set.
 //! The method is equivalent to calling `fit()` for each pair-copula in the
-//! model. The same can be achieved by calling `select()` with the same data 
-//! and a `FitControlsVinecop` object instantiated 
+//! model. The same can be achieved by calling `select()` with the same data
+//! and a `FitControlsVinecop` object instantiated
 //! with `select_families = false`.
 //!
 //! @param data \f$ n \times (d + k) \f$ or \f$ n \times 2d \f$ matrix of
 //!   observations, where \f$ k \f$ is the number of discrete variables.
-//! @param controls The controls for each bivariate fit (see 
+//! @param controls The controls for each bivariate fit (see
 //! `FitControlsBicop()`).
 //! @param num_threads The number of threads to use for parallel computation.
 inline void
@@ -1665,31 +1665,103 @@ Vinecop::collapse_data(const Eigen::MatrixXd& u) const
 }
 
 //! @brief Summarizes the model into a string (can be used for printing).
+//! @param trees A vector of tree indices to summarize; if empty, all trees.
 inline std::string
-Vinecop::str() const
+Vinecop::str(const std::vector<size_t> trees) const
 {
-  std::stringstream str;
+  std::vector<size_t> trees_to_summarize;
+  std::vector<size_t> all_trees(rvine_structure_.get_trunc_lvl());
+  std::iota(all_trees.begin(), all_trees.end(), 0);
+  if (trees.size() == 0) {
+    trees_to_summarize = all_trees;
+  } else {
+    trees_to_summarize = tools_stl::intersect(all_trees, trees);
+  }
+
+  std::stringstream vinecop_str;
+  vinecop_str << std::setprecision(2);
+  vinecop_str << "Vinecop model with " << d_ << " variables" << std::endl;
   auto arr = rvine_structure_.get_struct_array();
   auto order = rvine_structure_.get_order();
-  for (size_t t = 0; t < rvine_structure_.get_trunc_lvl(); ++t) {
-    str << "** Tree: " << t << std::endl;
+
+  std::vector<std::string> trees_s;
+  std::vector<std::string> edges;
+  std::vector<std::string> conditioned_variables;
+  std::vector<std::string> conditioning_variables;
+  std::vector<std::string> var_types;
+  std::vector<std::string> families;
+  std::vector<std::string> rotations;
+  std::vector<std::string> parameters;
+  std::vector<std::string> dfs;
+  std::vector<std::string> taus;
+  trees_s.push_back("tree");
+  edges.push_back("edge");
+  conditioned_variables.push_back("conditioned variables");
+  conditioning_variables.push_back("conditioning variables");
+  var_types.push_back("var_types");
+  families.push_back("family");
+  rotations.push_back("rotation");
+  parameters.push_back("parameters");
+  dfs.push_back("df");
+  taus.push_back("tau");
+
+  for (size_t t : trees_to_summarize) {
     for (size_t e = 0; e < d_ - 1 - t; ++e) {
-      str << order[e] << "," << arr(t, e);
+      std::cout << "tree: " << t << ", edge: " << e << std::endl;
+      trees_s.push_back(std::to_string(t + 1));
+      edges.push_back(std::to_string(e + 1));
+      conditioned_variables.push_back(std::to_string(order[e]) + ", " +
+                                      std::to_string(arr(t, e)));
       if (t > 0) {
-        str << " | ";
-        for (size_t cv = t - 1; cv > 0; --cv) {
-          str << arr(cv, e) << ",";
+        std::string cv = "";
+        for (size_t cv_ = t - 1; cv_ > 0; --cv_) {
+          cv += std::to_string(arr(cv_, e)) + ", ";
         }
-        str << arr(0, e);
-      }
-      str << " <-> ";
-      if (t < pair_copulas_.size()) {
-        str << pair_copulas_[t][e].str() << std::endl;
+        cv += std::to_string(arr(0, e));
+        conditioning_variables.push_back(cv);
       } else {
-        str << "Independence" << std::endl;
+        conditioning_variables.push_back("");
+      }
+      var_types.push_back(var_types_[order[e] - 1] + ", " +
+                          var_types_[arr(t, e) - 1]);
+
+      if (t < pair_copulas_.size()) {
+        auto bicop = pair_copulas_[t][e];
+        families.push_back(bicop.get_family_name());
+        if (bicop.get_family() == BicopFamily::tll) {
+          parameters.push_back("[30x30 grid]");
+          rotations.push_back("");
+          // dfs are rounded after 1 decimal places
+          dfs.push_back(std::to_string(std::round(bicop.get_npars() * 10) / 10));
+        } else if (bicop.get_family() != BicopFamily::indep) {
+          std::stringstream ss;
+          ss << bicop.get_parameters();
+          parameters.push_back(ss.str());
+          rotations.push_back(std::to_string(bicop.get_rotation()));
+          // no need to round dfs
+          dfs.push_back(std::to_string(bicop.get_npars()));
+        } else {
+          parameters.push_back("");
+          rotations.push_back("");
+          dfs.push_back("");
+        }
+        // taus are rounded after 2 decimal places
+        taus.push_back(std::to_string(std::round(bicop.get_tau() * 100) / 100));
+      } else {
+        families.push_back(get_family_name(BicopFamily::indep));
+        rotations.push_back("");
+        parameters.push_back("");
+        taus.push_back("0.0");
+        dfs.push_back("");
       }
     }
+
   }
-  return str.str();
+
+  std::vector<std::vector<std::string>> vinecop_str_vec = {
+    trees_s, edges, conditioned_variables, conditioning_variables, var_types, families, rotations, parameters, dfs, taus};
+
+  vinecop_str << tools_stl::dataframe_to_string(vinecop_str_vec).str();
+  return vinecop_str.str();
 }
 }

--- a/include/vinecopulib/vinecop/implementation/class.ipp
+++ b/include/vinecopulib/vinecop/implementation/class.ipp
@@ -1667,7 +1667,7 @@ Vinecop::collapse_data(const Eigen::MatrixXd& u) const
 //! @brief Summarizes the model into a string (can be used for printing).
 //! @param trees A vector of tree indices to summarize; if empty, all trees.
 inline std::string
-Vinecop::str(const std::vector<size_t> trees) const
+Vinecop::str(const std::vector<size_t>& trees) const
 {
   std::vector<size_t> trees_to_summarize;
   std::vector<size_t> all_trees(rvine_structure_.get_trunc_lvl());

--- a/test/src_test/include/test_vinecop_class.hpp
+++ b/test/src_test/include/test_vinecop_class.hpp
@@ -54,18 +54,54 @@ TEST_F(VinecopTest, copy)
 TEST_F(VinecopTest, print)
 {
   auto cvine = CVineStructure(std::vector<size_t>({ 5, 4, 3, 2, 1 }));
-  auto vc = Vinecop(cvine);
+  auto vc1 = Vinecop(cvine);
 
-  // check if last line of output is correct
+  // check if first, second and last line are correct
+  std::string expected_first_line = "Vinecop model with 5 variables";
+  std::string expected_second_line = "tree edge conditioned variables conditioning variables var_types       family rotation parameters df tau ";
+  std::string expected_last_line = "   4    1                  5, 4                3, 2, 1      c, c Independence                        0.0 ";
+
   std::istringstream input;
-  input.str(vc.str());
-  std::string last_line;
-  for (std::string line; std::getline(input, line);)
-    last_line = line;
-  EXPECT_EQ(last_line, "5,4 | 3,2,1 <-> Independence");
+  input.str(vc1.str());
 
-  // just shouldn't segfault
-  Vinecop(cvine).str();
+  std::string line;
+  // get first, second and last line
+  std::getline(input, line);
+  EXPECT_EQ(line, expected_first_line);
+  std::getline(input, line);
+  EXPECT_EQ(line, expected_second_line);
+  std::string last_line;
+  while (std::getline(input, line)) {
+    last_line = line;
+  }
+  EXPECT_EQ(last_line, expected_last_line);
+
+  // create vine with 7 variables
+  auto pair_copulas = Vinecop::make_pair_copula_store(7);
+  for (auto& tree : pair_copulas) {
+    for (auto& pc : tree) {
+      pc = Bicop(BicopFamily::tawn, 270);
+    }
+  }
+
+  Vinecop vc2(model_matrix, pair_copulas);
+
+  // check if first, second and last line are correct
+  expected_first_line = "Vinecop model with 7 variables";
+  expected_second_line = "tree edge conditioned variables conditioning variables var_types       family rotation parameters df tau ";
+  expected_last_line = "   4    1                  5, 4                3, 2, 1      c, c Independence                        0.0 ";
+
+  input.str(vc2.str());
+
+  // get first, second and last line
+  std::getline(input, line);
+  EXPECT_EQ(line, expected_first_line) << vc2.str();
+  std::getline(input, line);
+  EXPECT_EQ(line, expected_second_line) << vc2.str();
+  while (std::getline(input, line)) {
+    last_line = line;
+  }
+  EXPECT_EQ(last_line, expected_last_line);
 }
 
 TEST_F(VinecopTest, serialization)

--- a/test/src_test/include/test_vinecop_class.hpp
+++ b/test/src_test/include/test_vinecop_class.hpp
@@ -58,8 +58,12 @@ TEST_F(VinecopTest, print)
 
   // check if first, second and last line are correct
   std::string expected_first_line = "Vinecop model with 5 variables";
-  std::string expected_second_line = "tree edge conditioned variables conditioning variables var_types       family rotation parameters df tau ";
-  std::string expected_last_line = "   4    1                  5, 4                3, 2, 1      c, c Independence                        0.0 ";
+  std::string expected_second_line =
+    "tree edge conditioned variables conditioning variables var_types       "
+    "family rotation parameters df tau ";
+  std::string expected_last_line =
+    "   4    1                  5, 4                3, 2, 1      c, c "
+    "Independence                        0.0 ";
 
   std::istringstream input;
   input.str(vc1.str());
@@ -88,20 +92,44 @@ TEST_F(VinecopTest, print)
 
   // check if first, second and last line are correct
   expected_first_line = "Vinecop model with 7 variables";
-  expected_second_line = "tree edge conditioned variables conditioning variables var_types       family rotation parameters df tau ";
-  expected_last_line = "   4    1                  5, 4                3, 2, 1      c, c Independence                        0.0 ";
+  expected_second_line =
+    "tree edge conditioned variables conditioning variables var_types family "
+    "rotation       parameters  df   tau ";
+  expected_last_line = "   6    1                  4, 7          3, 1, 2, 6, 5 "
+                       "     c, c   Tawn      270 1.00, 1.00, 1.00 3.0 -0.00 ";
 
+  input.clear();
   input.str(vc2.str());
 
   // get first, second and last line
   std::getline(input, line);
-  EXPECT_EQ(line, expected_first_line) << vc2.str();
+  EXPECT_EQ(line, expected_first_line);
   std::getline(input, line);
-  EXPECT_EQ(line, expected_second_line) << vc2.str();
+  EXPECT_EQ(line, expected_second_line);
   while (std::getline(input, line)) {
     last_line = line;
   }
   EXPECT_EQ(last_line, expected_last_line);
+
+  auto data = tools_stats::simulate_uniform(100, 5);
+  auto controls = FitControlsVinecop({ BicopFamily::tll });
+  vc1.select(data, controls);
+
+  // check if first and second are correct
+  // we don't check the last line as it is random
+  // but at least we see it doesn't crash
+  expected_first_line = "Vinecop model with 5 variables";
+  expected_second_line =
+    "tree edge conditioned variables conditioning variables var_types family rotation   parameters   df   tau ";
+
+  input.clear();
+  input.str(vc1.str());
+
+  // get first, second and last line
+  std::getline(input, line);
+  EXPECT_EQ(line, expected_first_line) << vc1.str();
+  std::getline(input, line);
+  EXPECT_EQ(line, expected_second_line) << vc1.str();
 }
 
 TEST_F(VinecopTest, serialization)
@@ -381,7 +409,6 @@ TEST_F(VinecopTest, fit_parameters_is_correct)
   controls.set_select_families(false);
   vc3.select(u, controls);
   ASSERT_TRUE(vc.str() == vc3.str());
-
 }
 
 TEST_F(VinecopTest, family_select_finds_true_rotations)


### PR DESCRIPTION
Make the Vinecop.str() look more like R's summary. E.g., for

```
  auto cvine = CVineStructure(std::vector<size_t>({ 5, 4, 3, 2, 1 }));
  auto vc1 = Vinecop(cvine);
```

Then `vc1.str()` returns:

![image](https://github.com/user-attachments/assets/baf70b0b-0492-4319-a298-91090372a98f)

And for

```
  auto pair_copulas = Vinecop::make_pair_copula_store(7);
  for (auto& tree : pair_copulas) {
    for (auto& pc : tree) {
      pc = Bicop(BicopFamily::tawn, 270);
    }
  }

  Vinecop vc2(model_matrix, pair_copulas);
```

Then `vc2.str()` returns:

![image](https://github.com/user-attachments/assets/6054ea49-863e-4b25-a5e7-206e7e778716)

And for

```
auto data = tools_stats::simulate_uniform(100, 5);
auto controls = FitControlsVinecop({ BicopFamily::tll });
vc1.select(data, controls);
```

Then `vc1.str()` returns:

![image](https://github.com/user-attachments/assets/992bb497-f468-42b3-ac98-737d23704f74)
