### PR TITLE
Remove boost from dpqnorm

### DIFF
--- a/include/vinecopulib/misc/tools_stats.hpp
+++ b/include/vinecopulib/misc/tools_stats.hpp
@@ -8,7 +8,7 @@
 
 #include <boost/math/distributions.hpp>
 #include <vinecopulib/misc/tools_eigen.hpp>
-
+#include <unsupported/Eigen/SpecialFunctions>
 namespace vinecopulib {
 
 namespace tools_stats {
@@ -21,9 +21,8 @@ namespace tools_stats {
 inline Eigen::MatrixXd
 dnorm(const Eigen::MatrixXd& x)
 {
-  boost::math::normal dist;
-  auto f = [&dist](double y) { return boost::math::pdf(dist, y); };
-  return tools_eigen::unaryExpr_or_nan(x, f);
+  const double sqrt_2pi = std::sqrt(2.0 * M_PI);
+  return (1.0 / sqrt_2pi) * (-0.5 * x.array().square()).exp();
 }
 
 //! @brief Distribution function of the Standard normal distribution.
@@ -34,9 +33,8 @@ dnorm(const Eigen::MatrixXd& x)
 inline Eigen::MatrixXd
 pnorm(const Eigen::MatrixXd& x)
 {
-  boost::math::normal dist;
-  auto f = [&dist](double y) { return boost::math::cdf(dist, y); };
-  return tools_eigen::unaryExpr_or_nan(x, f);
+  const double sqrt2 = std::sqrt(2.0);
+  return 0.5 * (1.0 + (x.array() / sqrt2).erf());
 }
 
 //! @brief Quantile function of the Standard normal distribution.
@@ -47,9 +45,7 @@ pnorm(const Eigen::MatrixXd& x)
 inline Eigen::MatrixXd
 qnorm(const Eigen::MatrixXd& x)
 {
-  boost::math::normal dist;
-  auto f = [&dist](double y) { return boost::math::quantile(dist, y); };
-  return tools_eigen::unaryExpr_or_nan(x, f);
+  return x.array().ndtri();
 }
 
 //! @brief Density function of the Student t distribution.

--- a/include/vinecopulib/misc/tools_stats.hpp
+++ b/include/vinecopulib/misc/tools_stats.hpp
@@ -9,6 +9,8 @@
 #include <boost/math/distributions.hpp>
 #include <vinecopulib/misc/tools_eigen.hpp>
 #include <unsupported/Eigen/SpecialFunctions>
+
+
 namespace vinecopulib {
 
 namespace tools_stats {
@@ -21,7 +23,8 @@ namespace tools_stats {
 inline Eigen::MatrixXd
 dnorm(const Eigen::MatrixXd& x)
 {
-  const double sqrt_2pi = std::sqrt(2.0 * M_PI);
+  static const double pi = 3.14159265358979323846;
+  static const double sqrt_2pi = std::sqrt(2.0 * pi);
   return (1.0 / sqrt_2pi) * (-0.5 * x.array().square()).exp();
 }
 
@@ -33,7 +36,7 @@ dnorm(const Eigen::MatrixXd& x)
 inline Eigen::MatrixXd
 pnorm(const Eigen::MatrixXd& x)
 {
-  const double sqrt2 = std::sqrt(2.0);
+  static const double sqrt2 = std::sqrt(2.0);
   return 0.5 * (1.0 + (x.array() / sqrt2).erf());
 }
 

--- a/test/src_test/include/test_tools_stats.hpp
+++ b/test/src_test/include/test_tools_stats.hpp
@@ -110,6 +110,45 @@ TEST(test_tools_stats, seed_works)
   ASSERT_TRUE(U2.cwiseEqual(U3).all());
 }
 
+TEST(test_tools_stats, dpqnorm_work)
+{
+  auto dnorm_boost = [](Eigen::MatrixXd x) {
+    boost::math::normal dist;
+    auto f = [&dist](double y) { return boost::math::pdf(dist, y); };
+    return tools_eigen::unaryExpr_or_nan(x, f);
+  };
+
+  auto pnorm_boost = [](Eigen::MatrixXd x) {
+    boost::math::normal dist;
+    auto f = [&dist](double y) { return boost::math::cdf(dist, y); };
+    return tools_eigen::unaryExpr_or_nan(x, f);
+  };
+
+  auto qnorm_boost = [](Eigen::MatrixXd x) {
+    boost::math::normal dist;
+    auto f = [&dist](double y) { return boost::math::quantile(dist, y); };
+    return tools_eigen::unaryExpr_or_nan(x, f);
+  };
+
+  // linspace from -5 to 5 (1000 points)
+  Eigen::VectorXd X = Eigen::VectorXd::LinSpaced(1000, -5, 5);
+
+  // tools_stats::dnorm is the same as dnorm_boost
+  auto d1 = tools_stats::dnorm(X);
+  auto d2 = dnorm_boost(X);
+  ASSERT_TRUE(d1.isApprox(d2, 1e-6));
+
+  // tools_stats::pnorm is the same as pnorm_boost
+  auto p1 = tools_stats::pnorm(X);
+  auto p2 = pnorm_boost(X);
+  ASSERT_TRUE(p1.isApprox(p2, 1e-6));
+
+  // tools_stats::qnorm is the same as qnorm_boost
+  auto q1 = tools_stats::qnorm(p1);
+  auto q2 = qnorm_boost(p1);
+  ASSERT_TRUE(q1.isApprox(q2, 1e-6));
+}
+
 TEST(test_tools_stats, dpqnorm_are_nan_safe)
 {
   Eigen::VectorXd X = Eigen::VectorXd::Random(10);


### PR DESCRIPTION
On my computer, this gives a 25% speedup for the tll benchmark. Would appreciate if @tnagler can confirm on another machine. Implementation is cleaner anyway, so unless there's a regression, I think it's a good thing.