### PR TITLE
CMake; Bump minimum required

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.10)
 
 set(CMAKE_CXX_STANDARD 14)
 


### PR DESCRIPTION
Avoids a cmake warning stating that <3.10 support will be deprecated

