### PR TITLE
reset default copula families

### DIFF
--- a/docs/overview-bicop.dox
+++ b/docs/overview-bicop.dox
@@ -49,6 +49,9 @@ sub-namespace `bicop_families`:
 - `bb` contains the BB families
 - `itau` families for which estimation by Kendall's tau inversion is available
 (`indep`,`gaussian`, `student`,`clayton`, `gumbel`, `frank`, `joe`)
+- `default` contains the default families for the `select()` methods
+(`indep`, `gaussian`, `student`, `clayton`, `gumbel`, `frank`, `joe`, `bb1`, 
+`bb6`, `bb7`, `bb8`, `tll`).
 
 ```
 // print all available families

--- a/include/vinecopulib/bicop/family.hpp
+++ b/include/vinecopulib/bicop/family.hpp
@@ -135,7 +135,7 @@ const std::vector<BicopFamily> flip_by_rotation = {
 };
 
 //! Families used as the default in Bicop::select() and Vinecop::select().
-const std::vector<BicopFamily> default_set = {
+const std::vector<BicopFamily> default = {
   BicopFamily::indep,   BicopFamily::gaussian, BicopFamily::student,
   BicopFamily::clayton, BicopFamily::gumbel,   BicopFamily::frank,
   BicopFamily::joe,     BicopFamily::bb1,      BicopFamily::bb6,

--- a/include/vinecopulib/bicop/family.hpp
+++ b/include/vinecopulib/bicop/family.hpp
@@ -134,6 +134,14 @@ const std::vector<BicopFamily> flip_by_rotation = {
   BicopFamily::bb7,     BicopFamily::bb8,    BicopFamily::tawn
 };
 
+//! Families used as the default in Bicop::select() and Vinecop::select().
+const std::vector<BicopFamily> default_set = {
+  BicopFamily::indep,   BicopFamily::gaussian, BicopFamily::student,
+  BicopFamily::clayton, BicopFamily::gumbel,   BicopFamily::frank,
+  BicopFamily::joe,     BicopFamily::bb1,      BicopFamily::bb6,
+  BicopFamily::bb7,     BicopFamily::bb8,      BicopFamily::tll
+};
+
 } // end of namespace BicopFamilies
 } // end of namespace vinecopulib
 

--- a/include/vinecopulib/bicop/fit_controls.hpp
+++ b/include/vinecopulib/bicop/fit_controls.hpp
@@ -18,7 +18,7 @@ class FitControlsBicop
 public:
   // Constructor
   FitControlsBicop(
-    std::vector<BicopFamily> family_set = bicop_families::default_set,
+    std::vector<BicopFamily> family_set = bicop_families::default,
     std::string parametric_method = "mle",
     std::string nonparametric_method = "constant",
     double nonparametric_mult = 1.0,

--- a/include/vinecopulib/bicop/fit_controls.hpp
+++ b/include/vinecopulib/bicop/fit_controls.hpp
@@ -17,15 +17,16 @@ class FitControlsBicop
 {
 public:
   // Constructor
-  FitControlsBicop(std::vector<BicopFamily> family_set = bicop_families::all,
-                   std::string parametric_method = "mle",
-                   std::string nonparametric_method = "constant",
-                   double nonparametric_mult = 1.0,
-                   std::string selection_criterion = "aic",
-                   const Eigen::VectorXd& weights = Eigen::VectorXd(),
-                   double psi0 = 0.9,
-                   bool preselect_families = true,
-                   size_t num_threads = 1);
+  FitControlsBicop(
+    std::vector<BicopFamily> family_set = bicop_families::default_set,
+    std::string parametric_method = "mle",
+    std::string nonparametric_method = "constant",
+    double nonparametric_mult = 1.0,
+    std::string selection_criterion = "aic",
+    const Eigen::VectorXd& weights = Eigen::VectorXd(),
+    double psi0 = 0.9,
+    bool preselect_families = true,
+    size_t num_threads = 1);
 
   explicit FitControlsBicop(std::string parametric_method);
 

--- a/include/vinecopulib/bicop/implementation/fit_controls.ipp
+++ b/include/vinecopulib/bicop/implementation/fit_controls.ipp
@@ -13,7 +13,8 @@ namespace vinecopulib {
 //! @brief Instantiates the controls for fitting bivariate copula models.
 //!
 //! @param family_set The set of copula families to consider (if empty, then
-//!     all families are included).
+//!   the following families are included: indep, gaussian, student, clayton, 
+//!   gumbel, frank, joe, bb1, bb6, bb7, bb8, tll).
 //! @param parametric_method The fit method for parametric families;
 //!     possible choices: `"mle"`, `"itau"`.
 //! @param nonparametric_method The fit method for the local-likelihood

--- a/include/vinecopulib/bicop/implementation/fit_controls.ipp
+++ b/include/vinecopulib/bicop/implementation/fit_controls.ipp
@@ -13,8 +13,8 @@ namespace vinecopulib {
 //! @brief Instantiates the controls for fitting bivariate copula models.
 //!
 //! @param family_set The set of copula families to consider (if empty, then
-//!   the following families are included: indep, gaussian, student, clayton, 
-//!   gumbel, frank, joe, bb1, bb6, bb7, bb8, tll).
+//!   the following families are included: `indep`, `gaussian`, `student`, 
+//!   `clayton`, `gumbel`, `frank`, `joe`, `bb1`, `bb6`, `bb7`, `bb8`, `tll`).
 //! @param parametric_method The fit method for parametric families;
 //!     possible choices: `"mle"`, `"itau"`.
 //! @param nonparametric_method The fit method for the local-likelihood


### PR DESCRIPTION
We're probably at a point, where we don't want all families in the set by default. This PR keeps the pre 0.7.0-set.