### PR TITLE
CMake: Find Boost in CONFIG mode

### DIFF
--- a/cmake/templates/Config.cmake.in
+++ b/cmake/templates/Config.cmake.in
@@ -4,7 +4,7 @@
 include(CMakeFindDependencyMacro)
 find_dependency(Eigen3)
 find_dependency(wdm)
-find_dependency(Boost)
+find_dependency(Boost CONFIG)
 
 set_and_check(VINECOPULIB_INCLUDE_DIR "@PACKAGE_include_install_dir@")
 include("${CMAKE_CURRENT_LIST_DIR}/@targets_export_name@.cmake")


### PR DESCRIPTION
avoids the cmake warning:
```
CMake Warning (dev) at /usr/share/cmake/Modules/CMakeFindDependencyMacro.cmake:76 (find_package):
  Policy CMP0167 is not set: The FindBoost module is removed.  Run "cmake
  --help-policy CMP0167" for policy details.  Use the cmake_policy command to
  set the policy and suppress this warning
```