### PR TITLE
docs: //! comments on property getters / setters for the Python-binding surface

### DIFF
--- a/include/vinecopulib/bicop/class.hpp
+++ b/include/vinecopulib/bicop/class.hpp
@@ -70,30 +70,56 @@ public:
   void to_file(const std::string& filename) const;
 
   // Getters and setters
+
+  //! @return the copula family.
   BicopFamily get_family() const;
 
+  //! @return the human-readable name of the copula family.
   std::string get_family_name() const;
 
+  //! @return the copula rotation in degrees (one of `0`, `90`, `180`, `270`).
   int get_rotation() const;
 
+  //! @return the copula parameter(s) as a matrix (shape depends on the family).
   Eigen::MatrixXd get_parameters() const;
 
+  //! @return Kendall's tau implied by the current parameters.
   double get_tau() const;
 
+  //! @return the number of parameters in the copula model. For nonparametric
+  //! families, this is a conceptually similar effective-parameter count.
   double get_npars() const;
 
+  //! @return the log-likelihood of the data the copula was fitted to.
   double get_loglik() const;
+  //! @return the number of observations used to fit the copula (`0` until
+  //! `fit()` has been called).
   size_t get_nobs() const;
+  //! @return Akaike's information criterion at the fitted parameters.
   double get_aic() const;
+  //! @return the Bayesian information criterion at the fitted parameters.
   double get_bic() const;
+  //! @return the modified Bayesian information criterion at the fitted
+  //! parameters; `psi0` is the prior probability of a non-independence
+  //! copula.
   double get_mbic(const double psi0 = 0.9) const;
 
+  //! Sets the copula rotation.
+  //! @param rotation one of `0`, `90`, `180`, `270`.
   void set_rotation(const int rotation);
 
+  //! Sets the copula parameters.
+  //! @param parameters parameter matrix; shape must match the family's
+  //! expected parameter layout.
   void set_parameters(const Eigen::MatrixXd& parameters);
 
+  //! Sets the variable types.
+  //! @param var_types a length-2 vector with each entry either `"c"`
+  //! (continuous, default) or `"d"` (discrete).
   void set_var_types(const std::vector<std::string>& var_types = { "c", "c" });
 
+  //! @return the variable types of the two variables (each `"c"` for
+  //! continuous or `"d"` for discrete).
   std::vector<std::string> get_var_types() const;
 
   // Stats methods

--- a/include/vinecopulib/bicop/fit_controls.hpp
+++ b/include/vinecopulib/bicop/fit_controls.hpp
@@ -39,26 +39,46 @@ public:
   explicit FitControlsBicop(const FitControlsConfig& config);
 
   // Getters
+
+  //! @return the set of pair-copula families considered during selection.
   std::vector<BicopFamily> get_family_set() const;
 
+  //! @return the parametric estimator used for parametric families
+  //! (one of `"mle"`, `"itau"`).
   std::string get_parametric_method() const;
 
+  //! @return the nonparametric estimator used for the `tll` family
+  //! (one of `"constant"`, `"linear"`, `"quadratic"`).
   std::string get_nonparametric_method() const;
 
+  //! @return the bandwidth multiplier applied during nonparametric fits.
   double get_nonparametric_mult() const;
 
+  //! @return the grid size used during nonparametric fits (number of grid
+  //! points per axis).
   size_t get_nonparametric_grid_size() const;
 
+  //! @return the model-selection criterion (one of `"loglik"`, `"aic"`,
+  //! `"bic"`, `"mbic"`).
   std::string get_selection_criterion() const;
 
+  //! @return the per-observation weights used during fitting (empty when
+  //! observations are weighted equally).
   Eigen::VectorXd get_weights() const;
 
+  //! @return whether families are pre-screened by a quick fit before the
+  //! full criterion comparison.
   bool get_preselect_families() const;
 
+  //! @return the prior probability of a non-independence copula used by
+  //! the `mbic` criterion.
   double get_psi0() const;
 
+  //! @return the number of threads used during fitting.
   size_t get_num_threads() const;
 
+  //! @return whether non-zero copula rotations are considered during
+  //! family selection.
   bool get_allow_rotations() const;
 
   // Setters

--- a/include/vinecopulib/vinecop/class.hpp
+++ b/include/vinecopulib/vinecop/class.hpp
@@ -78,46 +78,83 @@ public:
     const FitControlsVinecop& controls = FitControlsVinecop());
 
   // Getters for a single pair copula
+
+  //! @return the pair copula at the given `(tree, edge)` position.
   Bicop get_pair_copula(size_t tree, size_t edge) const;
 
+  //! @return the family of the pair copula at the given `(tree, edge)`.
   BicopFamily get_family(size_t tree, size_t edge) const;
 
+  //! @return the rotation of the pair copula at the given `(tree, edge)`,
+  //! in degrees (one of `0`, `90`, `180`, `270`).
   int get_rotation(size_t tree, size_t edge) const;
 
+  //! @return the parameter matrix of the pair copula at the given
+  //! `(tree, edge)`.
   Eigen::MatrixXd get_parameters(size_t tree, size_t edge) const;
 
+  //! @return Kendall's tau of the pair copula at the given `(tree, edge)`.
   double get_tau(size_t tree, size_t edge) const;
 
+  //! @return the truncation level (number of fitted trees; pair copulas in
+  //! trees above this level are forced to independence).
   size_t get_trunc_lvl() const;
 
   // Getters for all pair copulas
+
+  //! @return all pair copulas, indexed as `[tree][edge]`.
   std::vector<std::vector<Bicop>> get_all_pair_copulas() const;
 
+  //! @return the families of all pair copulas, indexed as `[tree][edge]`.
   std::vector<std::vector<BicopFamily>> get_all_families() const;
 
+  //! @return the rotations of all pair copulas, indexed as `[tree][edge]`.
   std::vector<std::vector<int>> get_all_rotations() const;
 
+  //! @return the parameter matrices of all pair copulas, indexed as
+  //! `[tree][edge]`.
   std::vector<std::vector<Eigen::MatrixXd>> get_all_parameters() const;
 
+  //! @return Kendall's tau for every pair copula, indexed as `[tree][edge]`.
   std::vector<std::vector<double>> get_all_taus() const;
 
   // Getters for the structure
+
+  //! @return the dimension of the vine (number of variables).
   size_t get_dim() const;
 
+  //! @return the natural variable order in the first tree.
   std::vector<size_t> get_order() const;
 
+  //! @return the underlying R-vine structure.
   RVineStructure get_rvine_structure() const;
 
+  //! @return the R-vine structure as a square matrix
+  //! (cf. Joe, 2014, Section 6.13).
   Eigen::Matrix<size_t, Eigen::Dynamic, Eigen::Dynamic> get_matrix() const;
 
+  //! @return the R-vine structure as a triangular array.
+  //! @param natural_order whether to return the array in natural order or
+  //! original variable order.
   TriangularArray<size_t> get_struct_array(bool natural_order = false) const;
 
   // getters for fit statistics
+
+  //! @return the absolute-dependence threshold used during structure
+  //! selection (`0` if thresholding was disabled).
   double get_threshold() const;
+  //! @return the log-likelihood of the data the vine was fitted to.
   double get_loglik() const;
+  //! @return the number of observations used to fit the vine (`0` until
+  //! `fit()` has been called).
   size_t get_nobs() const;
+  //! @return Akaike's information criterion of the fitted vine.
   double get_aic() const;
+  //! @return the Bayesian information criterion of the fitted vine.
   double get_bic() const;
+  //! @return the modified Bayesian information criterion for vines at the
+  //! fitted parameters; `psi0` is the prior probability of a
+  //! non-independence pair copula.
   double get_mbicv(const double psi0 = 0.9) const;
 
   // Stats methods
@@ -141,13 +178,24 @@ public:
   Eigen::MatrixXd inverse_rosenblatt(const Eigen::MatrixXd& u,
                                      const size_t num_threads = 1) const;
 
+  //! Sets every pair copula in one shot.
+  //! @param pair_copulas nested list of `Bicop` instances, shaped like
+  //! `[tree][edge]` with `dim - 1 - tree` edges in tree `tree`.
   void set_all_pair_copulas(
     const std::vector<std::vector<Bicop>>& pair_copulas);
+  //! Sets the variable types.
+  //! @param var_types a length-`dim` vector with each entry either `"c"`
+  //! (continuous) or `"d"` (discrete).
   void set_var_types(const std::vector<std::string>& var_types);
 
+  //! @return the variable types of each variable (each `"c"` for
+  //! continuous or `"d"` for discrete).
   std::vector<std::string> get_var_types() const;
 
   // Fit statistics
+  //! @return the total number of parameters across all pair copulas.
+  //! For nonparametric families, this is a conceptually similar
+  //! effective-parameter count.
   double get_npars() const;
 
   double loglik(const Eigen::MatrixXd& u = Eigen::MatrixXd(),

--- a/include/vinecopulib/vinecop/fit_controls.hpp
+++ b/include/vinecopulib/vinecop/fit_controls.hpp
@@ -66,27 +66,48 @@ public:
 
   // Getters
   DEPRECATED size_t get_truncation_level() const;
+  //! @return the truncation level (the number of trees that will be fit;
+  //! pair copulas above this level are forced to independence).
   size_t get_trunc_lvl() const;
 
+  //! @return the edge-weighting criterion used to grow the structure
+  //! (one of `"tau"`, `"rho"`, `"hoeffd"`, `"mcor"`).
   std::string get_tree_criterion() const;
 
+  //! @return the absolute-dependence threshold below which pair copulas
+  //! are set to independence during structure selection (`0` disables).
   double get_threshold() const;
 
+  //! @return whether progress information is printed during fitting.
   bool get_show_trace() const;
 
   DEPRECATED bool get_select_truncation_level() const;
+  //! @return whether the truncation level is selected automatically via
+  //! the mBICv criterion during fitting.
   bool get_select_trunc_lvl() const;
 
+  //! @return whether the threshold is selected automatically during
+  //! fitting.
   bool get_select_threshold() const;
 
+  //! @return whether pair-copula families are selected during fitting
+  //! (when `false`, pre-specified families are used).
   bool get_select_families() const;
 
+  //! @return whether sparse selection (truncation or thresholding) is
+  //! enabled in the current configuration.
   bool needs_sparse_select() const;
 
+  //! @return the bicop fit controls used for each pair-copula fit.
   FitControlsBicop get_fit_controls_bicop() const;
 
+  //! @return the structure-selection algorithm (one of `"mst_prim"` for
+  //! Dissmann's greedy heuristic or `"random_weighted"` for Wilson-weighted
+  //! random spanning trees).
   std::string get_tree_algorithm() const;
 
+  //! @return the random seeds used by the structure-selection RNG (empty
+  //! to use a non-reproducible seed).
   std::vector<int> get_seeds() const;
 
   boost::random::mt19937 get_rng() const;

--- a/include/vinecopulib/vinecop/rvine_structure.hpp
+++ b/include/vinecopulib/vinecop/rvine_structure.hpp
@@ -113,8 +113,11 @@ public:
   nlohmann::json to_json() const;
   void to_file(const std::string& filename) const;
 
+  //! @return the dimension of the vine (number of variables).
   size_t get_dim() const;
+  //! @return the truncation level (the number of trees, at most `dim - 1`).
   size_t get_trunc_lvl() const;
+  //! @return the natural ordering of variables in the first tree.
   std::vector<size_t> get_order() const;
   TriangularArray<size_t> get_struct_array(bool natural_order = false) const;
   TriangularArray<size_t> get_min_array() const;


### PR DESCRIPTION
## Summary

Adds `//!` Doxygen comments to every property getter / setter currently exposed on the [pyvinecopulib](https://github.com/vinecopulib/pyvinecopulib) Python bindings as `def_prop_ro` / `def_prop_rw`. Each binding currently passes a hand-written string literal — the goal is to move that text into the C++ source so a single libclang extraction can populate both the Doxygen-built C++ docs and the Python `help()` output.

Touched files:

- `include/vinecopulib/bicop/class.hpp` — 7 getter/setter docs (`get_family`, `get_family_name`, `get_rotation`, `get_parameters`, `get_tau`, `get_npars`, `get_loglik`, `get_nobs`, `get_aic`, `get_bic`, `get_mbic`, `set_rotation`, `set_parameters`, `set_var_types`, `get_var_types`).
- `include/vinecopulib/bicop/fit_controls.hpp` — 11 fit-control getter docs.
- `include/vinecopulib/vinecop/class.hpp` — 18 vinecop getters across pair-copula access, structure, and fit statistics.
- `include/vinecopulib/vinecop/fit_controls.hpp` — 10 vinecop fit-control getter docs.
- `include/vinecopulib/vinecop/rvine_structure.hpp` — 3 structure getter docs (`get_dim`, `get_trunc_lvl`, `get_order`).

Comment-only; no behavioural change. Each comment is a single line (or single sentence) matching the canonical terse C++ style elsewhere in the codebase.

## Test plan

- [x] Re-extraction with pyvinecopulib's libclang pipeline produces the new text in `src/include/docstr.hpp`.
- [x] Doxygen build still succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)