### PR TITLE
Allow a custom tree_criterion function for vine structure selection

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,12 @@
 
 ### NEW FEATURES
 
+* Allow a user-supplied edge-weight function for vine structure selection via
+  `tree_criterion = "custom"` together with
+  `FitControlsVinecop::set_tree_criterion_function` (or
+  `FitControlsConfig::tree_criterion_function`), enabling custom dependence
+  criteria during Dissmann's algorithm (#764).
+
 * Add `Vinecop::hfuncs` to return intermediate h-function values (#669)
 
 * Add a grid size option for kernel bicop (#654)

--- a/include/vinecopulib/misc/fit_controls.hpp
+++ b/include/vinecopulib/misc/fit_controls.hpp
@@ -7,11 +7,19 @@
 #pragma once
 
 #include <Eigen/Dense>
+#include <functional>
 #include <string>
 #include <vector>
 #include <vinecopulib/misc/tools_optional.hpp>
 
 namespace vinecopulib {
+
+//! @brief A custom edge-weight function for vine structure selection.
+//!
+//! Maps a two-column matrix of pair-copula data and a vector of weights to a
+//! scalar dependence value. Used when `tree_criterion` is set to `"custom"`.
+using TreeCriterionFunction =
+  std::function<double(const Eigen::MatrixXd&, const Eigen::VectorXd&)>;
 
 //! Configuration options for initializing a FitControlsVinecop object.
 //!
@@ -61,6 +69,10 @@ struct FitControlsConfig
 
   //! The criterion for selecting the maximum spanning tree. Default: "tau".
   optional::optional<std::string> tree_criterion;
+
+  //! A custom edge-weight function for the spanning tree. Required when
+  //! `tree_criterion` is set to `"custom"`.
+  optional::optional<TreeCriterionFunction> tree_criterion_function;
 
   //! Threshold for thresholded vines. Default: 0.
   optional::optional<double> threshold;

--- a/include/vinecopulib/vinecop/fit_controls.hpp
+++ b/include/vinecopulib/vinecop/fit_controls.hpp
@@ -71,8 +71,12 @@ public:
   size_t get_trunc_lvl() const;
 
   //! @return the edge-weighting criterion used to grow the structure
-  //! (one of `"tau"`, `"rho"`, `"hoeffd"`, `"mcor"`).
+  //! (one of `"tau"`, `"rho"`, `"hoeffd"`, `"mcor"`, `"joe"`, `"custom"`).
   std::string get_tree_criterion() const;
+
+  //! @return the custom edge-weight function used when `tree_criterion` is
+  //! `"custom"` (empty otherwise).
+  TreeCriterionFunction get_tree_criterion_function() const;
 
   //! @return the absolute-dependence threshold below which pair copulas
   //! are set to independence during structure selection (`0` disables).
@@ -118,6 +122,13 @@ public:
 
   void set_tree_criterion(std::string tree_criterion);
 
+  //! Sets the custom edge-weight function used when `tree_criterion` is
+  //! `"custom"`.
+  //! @param tree_criterion_function a callable mapping a two-column matrix of
+  //! pair-copula data and a vector of weights to a scalar dependence value.
+  void set_tree_criterion_function(
+    TreeCriterionFunction tree_criterion_function);
+
   void set_threshold(double threshold);
 
   void set_show_trace(bool show_trace);
@@ -139,14 +150,18 @@ public:
   std::string str() const;
 
 private:
-  size_t trunc_lvl_;
-  std::string tree_criterion_;
-  double threshold_;
-  bool show_trace_;
-  bool select_trunc_lvl_;
-  bool select_threshold_;
-  bool select_families_;
-  std::string tree_algorithm_;
+  // In-class defaults so that construction from a partial `FitControlsConfig`
+  // (which only assigns the fields present in the config) leaves every member
+  // in a well-defined state.
+  size_t trunc_lvl_ = std::numeric_limits<size_t>::max();
+  std::string tree_criterion_ = "tau";
+  TreeCriterionFunction tree_criterion_function_ = {};
+  double threshold_ = 0.0;
+  bool show_trace_ = false;
+  bool select_trunc_lvl_ = false;
+  bool select_threshold_ = false;
+  bool select_families_ = true;
+  std::string tree_algorithm_ = "mst_prim";
   std::vector<int> seeds_;
   boost::random::mt19937 rng_;
 

--- a/include/vinecopulib/vinecop/implementation/fit_controls.ipp
+++ b/include/vinecopulib/vinecop/implementation/fit_controls.ipp
@@ -184,6 +184,10 @@ inline FitControlsVinecop::FitControlsVinecop(const FitControlsConfig& config)
   if (optional::has_value(config.tree_criterion)) {
     set_tree_criterion(optional::value(config.tree_criterion));
   }
+  if (optional::has_value(config.tree_criterion_function)) {
+    set_tree_criterion_function(
+      optional::value(config.tree_criterion_function));
+  }
   if (optional::has_value(config.threshold)) {
     set_threshold(optional::value(config.threshold));
   }
@@ -212,10 +216,11 @@ inline FitControlsVinecop::FitControlsVinecop(const FitControlsConfig& config)
 inline void
 FitControlsVinecop::check_tree_criterion(std::string tree_criterion)
 {
-  if (!tools_stl::is_member(tree_criterion,
-                            { "tau", "rho", "joe", "hoeffd", "mcor" })) {
+  if (!tools_stl::is_member(
+        tree_criterion, { "tau", "rho", "joe", "hoeffd", "mcor", "custom" })) {
     throw std::runtime_error("tree_criterion must be one of "
-                             "'tau', 'rho', 'hoeffd', 'mcor', or 'joe'");
+                             "'tau', 'rho', 'hoeffd', 'mcor', 'joe', or "
+                             "'custom'");
   }
 }
 
@@ -286,6 +291,21 @@ FitControlsVinecop::set_tree_criterion(std::string tree_criterion)
 {
   check_tree_criterion(tree_criterion);
   tree_criterion_ = tree_criterion;
+}
+
+//! @brief Gets the custom criterion function for tree selection.
+inline TreeCriterionFunction
+FitControlsVinecop::get_tree_criterion_function() const
+{
+  return tree_criterion_function_;
+}
+
+//! @brief Sets the custom criterion function for tree selection.
+inline void
+FitControlsVinecop::set_tree_criterion_function(
+  TreeCriterionFunction tree_criterion_function)
+{
+  tree_criterion_function_ = tree_criterion_function;
 }
 
 //! @brief Gets the threshold parameter.

--- a/include/vinecopulib/vinecop/implementation/tools_select.ipp
+++ b/include/vinecopulib/vinecop/implementation/tools_select.ipp
@@ -25,10 +25,13 @@ using namespace tools_stl;
 //! @param data Observations.
 //! @param tree_criterion The criterion.
 //! @param weights Vector of weights for each observation (can be empty).
+//! @param tree_criterion_function Custom criterion function, used when
+//!   `tree_criterion == "custom"`.
 inline double
 calculate_criterion(const Eigen::MatrixXd& data,
                     std::string tree_criterion,
-                    Eigen::VectorXd weights)
+                    Eigen::VectorXd weights,
+                    const TreeCriterionFunction& tree_criterion_function)
 {
   double w = 0.0;
   Eigen::MatrixXd data_no_nan = data;
@@ -36,7 +39,14 @@ calculate_criterion(const Eigen::MatrixXd& data,
   double freq =
     static_cast<double>(data_no_nan.rows()) / static_cast<double>(data.rows());
   if (data_no_nan.rows() > 10) {
-    if (tree_criterion == "mcor") {
+    if (tree_criterion == "custom") {
+      if (!tree_criterion_function) {
+        throw std::runtime_error(
+          "tree_criterion = \"custom\" requires a tree_criterion_function "
+          "callable");
+      }
+      w = tree_criterion_function(data_no_nan, weights);
+    } else if (tree_criterion == "mcor") {
       w = tools_stats::pairwise_mcor(data_no_nan, weights);
     } else if (tree_criterion == "joe") {
       // mutual information for Gaussian copula
@@ -51,32 +61,6 @@ calculate_criterion(const Eigen::MatrixXd& data,
     }
   }
   return std::fabs(w) * std::sqrt(freq);
-}
-
-//! @brief Evaluates maximal criterion for tree selection.
-//! @param data Observations.
-//! @param tree_criterion The criterion.
-//! @param weights Vector of weights for each observation (can be empty).
-inline Eigen::MatrixXd
-calculate_criterion_matrix(const Eigen::MatrixXd& data,
-                           const std::string& tree_criterion,
-                           const Eigen::VectorXd& weights)
-{
-  size_t n = data.rows();
-  size_t d = data.cols();
-  Eigen::MatrixXd mat(d, d);
-  mat.diagonal() = Eigen::VectorXd::Constant(d, 1.0);
-  Eigen::MatrixXd pair_data(n, 2);
-  for (size_t i = 1; i < d; ++i) {
-    for (size_t j = 0; j < i; ++j) {
-      pair_data.col(0) = data.col(i);
-      pair_data.col(1) = data.col(j);
-      Eigen::VectorXd pair_w = weights;
-      mat(i, j) = calculate_criterion(pair_data, tree_criterion, pair_w);
-      mat(j, i) = mat(i, j);
-    }
-  }
-  return mat;
 }
 
 //! computes
@@ -400,7 +384,10 @@ VinecopSelector::add_allowed_edges(VineTree& vine_tree)
 
       auto pc_data = get_pc_data(v0, v1, vine_tree);
       double crit =
-        calculate_criterion(pc_data, tree_criterion, controls_.get_weights());
+        calculate_criterion(pc_data,
+                            tree_criterion,
+                            controls_.get_weights(),
+                            controls_.get_tree_criterion_function());
       double w = 1.0 - static_cast<double>(crit >= threshold) * crit;
 
       {
@@ -424,8 +411,11 @@ VinecopSelector::add_allowed_edges(VineTree& vine_tree)
         size_t v1 = vine_struct_.min_array(tree, v0) - 1;
         Eigen::MatrixXd pc_data = get_pc_data(v0, v1, vine_tree);
         EdgeIterator e = boost::add_edge(v0, v1, 1.0, vine_tree).first;
-        double crit = calculate_criterion(
-          pc_data.leftCols(2), tree_criterion, controls_.get_weights());
+        double crit =
+          calculate_criterion(pc_data.leftCols(2),
+                              tree_criterion,
+                              controls_.get_weights(),
+                              controls_.get_tree_criterion_function());
         vine_tree[e].weight = 1.0;
         vine_tree[e].crit = crit;
       }

--- a/include/vinecopulib/vinecop/tools_select.hpp
+++ b/include/vinecopulib/vinecop/tools_select.hpp
@@ -35,12 +35,8 @@ namespace tools_select {
 double
 calculate_criterion(const Eigen::MatrixXd& data,
                     std::string tree_criterion,
-                    Eigen::VectorXd weights);
-
-Eigen::MatrixXd
-calculate_criterion_matrix(const Eigen::MatrixXd& data,
-                           const std::string& tree_criterion,
-                           const Eigen::VectorXd& weights);
+                    Eigen::VectorXd weights,
+                    const TreeCriterionFunction& tree_criterion_function = {});
 
 std::vector<size_t>
 get_disc_cols(std::vector<std::string> var_types);

--- a/test/src_test/include/test_vinecop_class.hpp
+++ b/test/src_test/include/test_vinecop_class.hpp
@@ -681,6 +681,39 @@ TEST_F(VinecopTest, select_finds_right_structure_kruskal)
   EXPECT_EQ(pairs_unequal, 0);
 }
 
+TEST_F(VinecopTest, tree_criterion_custom_works)
+{
+  auto tau_fn = [](const Eigen::MatrixXd& data,
+                   const Eigen::VectorXd& weights) {
+    return wdm::wdm(data, "tau", weights)(0, 1);
+  };
+
+  // setter path: a custom criterion equal to Kendall's tau must recover the
+  // same structure as the built-in "tau" (independence families so the
+  // structure is determined solely by the criterion).
+  Vinecop fit(7);
+  FitControlsVinecop controls({ BicopFamily::indep });
+  controls.set_tree_criterion("custom");
+  controls.set_tree_criterion_function(tau_fn);
+  fit.select(u, controls);
+  EXPECT_EQ(get_pairs_unequal(vc_matrix, fit.get_matrix(), 6), 0);
+
+  // FitControlsConfig construction path covers the new optional field.
+  FitControlsConfig cfg;
+  cfg.family_set = std::vector<BicopFamily>{ BicopFamily::indep };
+  cfg.tree_criterion = "custom";
+  cfg.tree_criterion_function = tau_fn;
+  Vinecop fit_cfg(7);
+  fit_cfg.select(u, FitControlsVinecop(cfg));
+  EXPECT_EQ(get_pairs_unequal(vc_matrix, fit_cfg.get_matrix(), 6), 0);
+
+  // "custom" without a callable must throw during selection.
+  FitControlsVinecop bad({ BicopFamily::indep });
+  bad.set_tree_criterion("custom");
+  Vinecop fit_bad(7);
+  EXPECT_ANY_THROW(fit_bad.select(u, bad));
+}
+
 TEST_F(VinecopTest, select_finds_different_structures_random)
 {
   // Initialize the controls


### PR DESCRIPTION
Add a "custom" tree_criterion to FitControlsVinecop that selects the vine structure with a user-supplied edge-weight function (std::function<double(const MatrixXd&, const VectorXd&)>) instead of only the built-in dependence measures. Reachable via
FitControlsVinecop::set_tree_criterion_function and FitControlsConfig::tree_criterion_function, and threaded through tools_select::calculate_criterion.

Extracted from #657 without the #656 controls refactor it was based on. Also give the FitControlsVinecop members in-class defaults so that construction from a partial FitControlsConfig no longer leaves them uninitialized.

Will allow us to close [this pyvinecopulib issue too](https://github.com/vinecopulib/pyvinecopulib/issues/203)