### PR TITLE
Evaluate bivariate copulas with per-row parameters

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,6 +20,11 @@
 
 ### BUG FIXES
 
+* Fix an out-of-bounds memory access in the bivariate h-inverse for mixed
+  discrete/continuous copulas whose inverse is computed numerically (e.g. Frank,
+  the BB families, Tawn): a continuous h-inverse re-entered the discrete
+  difference-quotient branch on a stripped two-column matrix (#675)
+
 * Fix CDF of TLL family (#667)
 
 * Fix discrete-discrete PDFs and adjust threshold for analytical derivatives (#664)
@@ -29,6 +34,10 @@
 * Fix Wilson correction implementation (#653)
 
 ### MAINTENANCE, BUILD, AND DOCS
+
+* Collapse the internal bivariate-copula evaluation leaves to a single
+  parameter-aware interface (removing the duplicated state-based primitives),
+  so each family implements its math once (#675)
 
 * Improve Python-binding API docs for property getters/setters (#670)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,11 @@
 
 ### NEW FEATURES
 
+* Add per-row-parameter overloads of `Bicop::pdf`, `cdf`, `hfunc1`, `hfunc2`, `hinv1`, `hinv2`,
+  and `loglik` that evaluate a bivariate copula at a different parameter set per row of `u` in a
+  single (optionally multi-threaded) call. The new overloads take an `n x p` matrix of parameters
+  (one row per observation) and are available for parametric families.
+
 * Add `Vinecop::hfuncs` to return intermediate h-function values (#669)
 
 * Add a grid size option for kernel bicop (#654)
@@ -33,7 +38,6 @@
 * Enforce clang-format in GitHub Actions and apply code analysis cleanups (#646, #649)
 
 * Remove an unused option (#662)
-
 
 ## vinecopulib 0.7.3 (April 23, 2025)
 

--- a/include/vinecopulib/bicop/abstract.hpp
+++ b/include/vinecopulib/bicop/abstract.hpp
@@ -67,7 +67,7 @@ protected:
   // following are virtual so they can be overriden by KernelBicop
   virtual Eigen::VectorXd pdf(const Eigen::MatrixXd& u);
 
-  virtual Eigen::VectorXd cdf(const Eigen::MatrixXd& u) = 0;
+  virtual Eigen::VectorXd cdf(const Eigen::MatrixXd& u);
 
   virtual Eigen::VectorXd hfunc1(const Eigen::MatrixXd& u);
 
@@ -77,23 +77,12 @@ protected:
 
   Eigen::VectorXd hinv2(const Eigen::MatrixXd& u);
 
-  virtual Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u) = 0;
-
-  virtual Eigen::VectorXd hfunc1_raw(const Eigen::MatrixXd& u) = 0;
-
-  virtual Eigen::VectorXd hfunc2_raw(const Eigen::MatrixXd& u) = 0;
-
-  virtual Eigen::VectorXd hinv1_raw(const Eigen::MatrixXd& u) = 0;
-
-  virtual Eigen::VectorXd hinv2_raw(const Eigen::MatrixXd& u) = 0;
-
-  // Parameter-aware overloads. `parameters` has shape p x m with m in {1, n}:
-  // column j holds the p parameters for observation j; a single column is
-  // broadcast to all rows. These let a copula be evaluated at a different
-  // parameter set per row of `u` without mutating object state. The leaves
-  // (pdf_raw, cdf, hfunc*_raw, hinv*_raw) default to ignoring `parameters` and
-  // using object state, so nonparametric families need no overrides;
-  // parametric families override them with the actual (stateless) math.
+  // Evaluation leaves. `parameters` has shape m x p with m in {1, n}: row i
+  // holds the p parameters for observation i; a single row is broadcast to all
+  // observations. The state-based dispatchers above call these with the stored
+  // parameters (a 1 x p broadcast row). This is the sole evaluation interface;
+  // every family implements the (stateless) math, and nonparametric families
+  // ignore `parameters` and read their interpolation grid instead.
   Eigen::VectorXd pdf(const Eigen::MatrixXd& u,
                       const Eigen::MatrixXd& parameters);
 
@@ -110,22 +99,22 @@ protected:
                         const Eigen::MatrixXd& parameters);
 
   virtual Eigen::VectorXd cdf(const Eigen::MatrixXd& u,
-                              const Eigen::MatrixXd& parameters);
+                              const Eigen::MatrixXd& parameters) = 0;
 
   virtual Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u,
-                                  const Eigen::MatrixXd& parameters);
+                                  const Eigen::MatrixXd& parameters) = 0;
 
   virtual Eigen::VectorXd hfunc1_raw(const Eigen::MatrixXd& u,
-                                     const Eigen::MatrixXd& parameters);
+                                     const Eigen::MatrixXd& parameters) = 0;
 
   virtual Eigen::VectorXd hfunc2_raw(const Eigen::MatrixXd& u,
-                                     const Eigen::MatrixXd& parameters);
+                                     const Eigen::MatrixXd& parameters) = 0;
 
   virtual Eigen::VectorXd hinv1_raw(const Eigen::MatrixXd& u,
-                                    const Eigen::MatrixXd& parameters);
+                                    const Eigen::MatrixXd& parameters) = 0;
 
   virtual Eigen::VectorXd hinv2_raw(const Eigen::MatrixXd& u,
-                                    const Eigen::MatrixXd& parameters);
+                                    const Eigen::MatrixXd& parameters) = 0;
 
   virtual Eigen::MatrixXd tau_to_parameters(const double& tau) = 0;
   Eigen::MatrixXd no_tau_to_parameters(const double&);
@@ -140,6 +129,15 @@ protected:
 
   Eigen::VectorXd hinv2_num(const Eigen::MatrixXd& u,
                             const Eigen::MatrixXd& parameters);
+
+  // continuous numeric inverses: invert the *_raw leaves (which ignore
+  // var_types_), used by the `_raw` primitives so a continuous inverse never
+  // routes through the discrete h-function dispatcher
+  Eigen::VectorXd hinv1_num_raw(const Eigen::MatrixXd& u,
+                                const Eigen::MatrixXd& parameters);
+
+  Eigen::VectorXd hinv2_num_raw(const Eigen::MatrixXd& u,
+                                const Eigen::MatrixXd& parameters);
 
   Eigen::VectorXd pdf_c_d(const Eigen::MatrixXd& u,
                           const Eigen::MatrixXd& parameters);

--- a/include/vinecopulib/bicop/abstract.hpp
+++ b/include/vinecopulib/bicop/abstract.hpp
@@ -135,10 +135,6 @@ protected:
 
   Eigen::VectorXd hinv2_num(const Eigen::MatrixXd& u);
 
-  Eigen::VectorXd pdf_c_d(const Eigen::MatrixXd& u);
-
-  Eigen::VectorXd pdf_d_d(const Eigen::MatrixXd& u);
-
   Eigen::VectorXd hinv1_num(const Eigen::MatrixXd& u,
                             const Eigen::MatrixXd& parameters);
 

--- a/include/vinecopulib/bicop/abstract.hpp
+++ b/include/vinecopulib/bicop/abstract.hpp
@@ -87,6 +87,46 @@ protected:
 
   virtual Eigen::VectorXd hinv2_raw(const Eigen::MatrixXd& u) = 0;
 
+  // Parameter-aware overloads. `parameters` has shape p x m with m in {1, n}:
+  // column j holds the p parameters for observation j; a single column is
+  // broadcast to all rows. These let a copula be evaluated at a different
+  // parameter set per row of `u` without mutating object state. The leaves
+  // (pdf_raw, cdf, hfunc*_raw, hinv*_raw) default to ignoring `parameters` and
+  // using object state, so nonparametric families need no overrides;
+  // parametric families override them with the actual (stateless) math.
+  Eigen::VectorXd pdf(const Eigen::MatrixXd& u,
+                      const Eigen::MatrixXd& parameters);
+
+  Eigen::VectorXd hfunc1(const Eigen::MatrixXd& u,
+                         const Eigen::MatrixXd& parameters);
+
+  Eigen::VectorXd hfunc2(const Eigen::MatrixXd& u,
+                         const Eigen::MatrixXd& parameters);
+
+  Eigen::VectorXd hinv1(const Eigen::MatrixXd& u,
+                        const Eigen::MatrixXd& parameters);
+
+  Eigen::VectorXd hinv2(const Eigen::MatrixXd& u,
+                        const Eigen::MatrixXd& parameters);
+
+  virtual Eigen::VectorXd cdf(const Eigen::MatrixXd& u,
+                              const Eigen::MatrixXd& parameters);
+
+  virtual Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u,
+                                  const Eigen::MatrixXd& parameters);
+
+  virtual Eigen::VectorXd hfunc1_raw(const Eigen::MatrixXd& u,
+                                     const Eigen::MatrixXd& parameters);
+
+  virtual Eigen::VectorXd hfunc2_raw(const Eigen::MatrixXd& u,
+                                     const Eigen::MatrixXd& parameters);
+
+  virtual Eigen::VectorXd hinv1_raw(const Eigen::MatrixXd& u,
+                                    const Eigen::MatrixXd& parameters);
+
+  virtual Eigen::VectorXd hinv2_raw(const Eigen::MatrixXd& u,
+                                    const Eigen::MatrixXd& parameters);
+
   virtual Eigen::MatrixXd tau_to_parameters(const double& tau) = 0;
   Eigen::MatrixXd no_tau_to_parameters(const double&);
 
@@ -98,6 +138,18 @@ protected:
   Eigen::VectorXd pdf_c_d(const Eigen::MatrixXd& u);
 
   Eigen::VectorXd pdf_d_d(const Eigen::MatrixXd& u);
+
+  Eigen::VectorXd hinv1_num(const Eigen::MatrixXd& u,
+                            const Eigen::MatrixXd& parameters);
+
+  Eigen::VectorXd hinv2_num(const Eigen::MatrixXd& u,
+                            const Eigen::MatrixXd& parameters);
+
+  Eigen::VectorXd pdf_c_d(const Eigen::MatrixXd& u,
+                          const Eigen::MatrixXd& parameters);
+
+  Eigen::VectorXd pdf_d_d(const Eigen::MatrixXd& u,
+                          const Eigen::MatrixXd& parameters);
 
   double loglik(const Eigen::MatrixXd& u,
                 const Eigen::VectorXd weights = Eigen::VectorXd());

--- a/include/vinecopulib/bicop/abstract.hpp
+++ b/include/vinecopulib/bicop/abstract.hpp
@@ -67,8 +67,6 @@ protected:
   // following are virtual so they can be overriden by KernelBicop
   virtual Eigen::VectorXd pdf(const Eigen::MatrixXd& u);
 
-  virtual Eigen::VectorXd cdf(const Eigen::MatrixXd& u);
-
   virtual Eigen::VectorXd hfunc1(const Eigen::MatrixXd& u);
 
   virtual Eigen::VectorXd hfunc2(const Eigen::MatrixXd& u);

--- a/include/vinecopulib/bicop/archimedean.hpp
+++ b/include/vinecopulib/bicop/archimedean.hpp
@@ -20,21 +20,8 @@ namespace vinecopulib {
 class ArchimedeanBicop : public ParBicop
 {
 private:
-  // cdf, hfunctions and inverses
-  // Eigen::VectorXd pdf(const Eigen::MatrixXd &u);
-
-  Eigen::VectorXd cdf(const Eigen::MatrixXd& u);
-
-  Eigen::VectorXd hfunc1_raw(const Eigen::MatrixXd& u);
-
-  Eigen::VectorXd hfunc2_raw(const Eigen::MatrixXd& u);
-
-  Eigen::VectorXd hinv1_raw(const Eigen::MatrixXd& u);
-
-  Eigen::VectorXd hinv2_raw(const Eigen::MatrixXd& u);
-
-  // parameter-aware overloads (`parameters` is p x m, m in {1, n}); the
-  // state-based versions above delegate to these passing the stored parameters
+  // cdf, hfunctions and inverses (`parameters` is m x p, m in {1, n}; a single
+  // row is broadcast to all observations)
   Eigen::VectorXd cdf(const Eigen::MatrixXd& u,
                       const Eigen::MatrixXd& parameters);
 

--- a/include/vinecopulib/bicop/archimedean.hpp
+++ b/include/vinecopulib/bicop/archimedean.hpp
@@ -33,12 +33,36 @@ private:
 
   Eigen::VectorXd hinv2_raw(const Eigen::MatrixXd& u);
 
-  // generator, its inverse and derivative
-  virtual double generator(const double& u) = 0;
+  // parameter-aware overloads (`parameters` is p x m, m in {1, n}); the
+  // state-based versions above delegate to these passing the stored parameters
+  Eigen::VectorXd cdf(const Eigen::MatrixXd& u,
+                      const Eigen::MatrixXd& parameters) override;
 
-  virtual double generator_inv(const double& u) = 0;
+  Eigen::VectorXd hfunc1_raw(const Eigen::MatrixXd& u,
+                             const Eigen::MatrixXd& parameters) override;
 
-  virtual double generator_derivative(const double& u) = 0;
+  Eigen::VectorXd hfunc2_raw(const Eigen::MatrixXd& u,
+                             const Eigen::MatrixXd& parameters) override;
+
+  Eigen::VectorXd hinv1_raw(const Eigen::MatrixXd& u,
+                            const Eigen::MatrixXd& parameters) override;
+
+  Eigen::VectorXd hinv2_raw(const Eigen::MatrixXd& u,
+                            const Eigen::MatrixXd& parameters) override;
+
+  // generator, its inverse and derivative; `parameters` is a single parameter
+  // set (a p x 1 column)
+  virtual double generator(
+    const double& u,
+    const Eigen::Ref<const Eigen::VectorXd>& parameters) = 0;
+
+  virtual double generator_inv(
+    const double& u,
+    const Eigen::Ref<const Eigen::VectorXd>& parameters) = 0;
+
+  virtual double generator_derivative(
+    const double& u,
+    const Eigen::Ref<const Eigen::VectorXd>& parameters) = 0;
 
   // virtual double generator_derivative2(const double &u) = 0;
 

--- a/include/vinecopulib/bicop/archimedean.hpp
+++ b/include/vinecopulib/bicop/archimedean.hpp
@@ -36,19 +36,19 @@ private:
   // parameter-aware overloads (`parameters` is p x m, m in {1, n}); the
   // state-based versions above delegate to these passing the stored parameters
   Eigen::VectorXd cdf(const Eigen::MatrixXd& u,
-                      const Eigen::MatrixXd& parameters) override;
+                      const Eigen::MatrixXd& parameters);
 
   Eigen::VectorXd hfunc1_raw(const Eigen::MatrixXd& u,
-                             const Eigen::MatrixXd& parameters) override;
+                             const Eigen::MatrixXd& parameters);
 
   Eigen::VectorXd hfunc2_raw(const Eigen::MatrixXd& u,
-                             const Eigen::MatrixXd& parameters) override;
+                             const Eigen::MatrixXd& parameters);
 
   Eigen::VectorXd hinv1_raw(const Eigen::MatrixXd& u,
-                            const Eigen::MatrixXd& parameters) override;
+                            const Eigen::MatrixXd& parameters);
 
   Eigen::VectorXd hinv2_raw(const Eigen::MatrixXd& u,
-                            const Eigen::MatrixXd& parameters) override;
+                            const Eigen::MatrixXd& parameters);
 
   // generator, its inverse and derivative; `parameters` is a single parameter
   // set (a p x 1 column)

--- a/include/vinecopulib/bicop/bb1.hpp
+++ b/include/vinecopulib/bicop/bb1.hpp
@@ -26,16 +26,23 @@ public:
 
 private:
   // generator, its inverse and derivatives for the archimedean copula
-  double generator(const double& u);
+  double generator(
+    const double& u,
+    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
 
-  double generator_inv(const double& u);
+  double generator_inv(
+    const double& u,
+    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
 
-  double generator_derivative(const double& u);
-
-  double generator_derivative2(const double& u);
+  double generator_derivative(
+    const double& u,
+    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
 
   // pdf
   Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u);
+
+  Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u,
+                          const Eigen::MatrixXd& parameters) override;
 
   // link between Kendall's tau and the par_bicop parameter
   double parameters_to_tau(const Eigen::MatrixXd& par);

--- a/include/vinecopulib/bicop/bb1.hpp
+++ b/include/vinecopulib/bicop/bb1.hpp
@@ -26,23 +26,21 @@ public:
 
 private:
   // generator, its inverse and derivatives for the archimedean copula
-  double generator(
-    const double& u,
-    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
+  double generator(const double& u,
+                   const Eigen::Ref<const Eigen::VectorXd>& parameters);
 
-  double generator_inv(
-    const double& u,
-    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
+  double generator_inv(const double& u,
+                       const Eigen::Ref<const Eigen::VectorXd>& parameters);
 
   double generator_derivative(
     const double& u,
-    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
+    const Eigen::Ref<const Eigen::VectorXd>& parameters);
 
   // pdf
   Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u);
 
   Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u,
-                          const Eigen::MatrixXd& parameters) override;
+                          const Eigen::MatrixXd& parameters);
 
   // link between Kendall's tau and the par_bicop parameter
   double parameters_to_tau(const Eigen::MatrixXd& par);

--- a/include/vinecopulib/bicop/bb1.hpp
+++ b/include/vinecopulib/bicop/bb1.hpp
@@ -37,8 +37,6 @@ private:
     const Eigen::Ref<const Eigen::VectorXd>& parameters);
 
   // pdf
-  Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u);
-
   Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u,
                           const Eigen::MatrixXd& parameters);
 

--- a/include/vinecopulib/bicop/bb6.hpp
+++ b/include/vinecopulib/bicop/bb6.hpp
@@ -25,16 +25,23 @@ public:
 
 private:
   // generator, its inverse and derivatives for the archimedean copula
-  double generator(const double& u);
+  double generator(
+    const double& u,
+    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
 
-  double generator_inv(const double& u);
+  double generator_inv(
+    const double& u,
+    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
 
-  double generator_derivative(const double& u);
-
-  double generator_derivative2(const double& u);
+  double generator_derivative(
+    const double& u,
+    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
 
   // pdf
   Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u);
+
+  Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u,
+                          const Eigen::MatrixXd& parameters) override;
 
   // link between Kendall's tau and the par_bicop parameter
   double parameters_to_tau(const Eigen::MatrixXd& par);

--- a/include/vinecopulib/bicop/bb6.hpp
+++ b/include/vinecopulib/bicop/bb6.hpp
@@ -25,23 +25,21 @@ public:
 
 private:
   // generator, its inverse and derivatives for the archimedean copula
-  double generator(
-    const double& u,
-    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
+  double generator(const double& u,
+                   const Eigen::Ref<const Eigen::VectorXd>& parameters);
 
-  double generator_inv(
-    const double& u,
-    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
+  double generator_inv(const double& u,
+                       const Eigen::Ref<const Eigen::VectorXd>& parameters);
 
   double generator_derivative(
     const double& u,
-    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
+    const Eigen::Ref<const Eigen::VectorXd>& parameters);
 
   // pdf
   Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u);
 
   Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u,
-                          const Eigen::MatrixXd& parameters) override;
+                          const Eigen::MatrixXd& parameters);
 
   // link between Kendall's tau and the par_bicop parameter
   double parameters_to_tau(const Eigen::MatrixXd& par);

--- a/include/vinecopulib/bicop/bb6.hpp
+++ b/include/vinecopulib/bicop/bb6.hpp
@@ -36,8 +36,6 @@ private:
     const Eigen::Ref<const Eigen::VectorXd>& parameters);
 
   // pdf
-  Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u);
-
   Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u,
                           const Eigen::MatrixXd& parameters);
 

--- a/include/vinecopulib/bicop/bb7.hpp
+++ b/include/vinecopulib/bicop/bb7.hpp
@@ -25,16 +25,23 @@ public:
 
 private:
   // generator, its inverse and derivatives for the archimedean copula
-  double generator(const double& u);
+  double generator(
+    const double& u,
+    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
 
-  double generator_inv(const double& u);
+  double generator_inv(
+    const double& u,
+    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
 
-  double generator_derivative(const double& u);
-
-  double generator_derivative2(const double& u);
+  double generator_derivative(
+    const double& u,
+    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
 
   // pdf
   Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u);
+
+  Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u,
+                          const Eigen::MatrixXd& parameters) override;
 
   // link between Kendall's tau and the par_bicop parameter
   double parameters_to_tau(const Eigen::MatrixXd& par);

--- a/include/vinecopulib/bicop/bb7.hpp
+++ b/include/vinecopulib/bicop/bb7.hpp
@@ -25,23 +25,21 @@ public:
 
 private:
   // generator, its inverse and derivatives for the archimedean copula
-  double generator(
-    const double& u,
-    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
+  double generator(const double& u,
+                   const Eigen::Ref<const Eigen::VectorXd>& parameters);
 
-  double generator_inv(
-    const double& u,
-    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
+  double generator_inv(const double& u,
+                       const Eigen::Ref<const Eigen::VectorXd>& parameters);
 
   double generator_derivative(
     const double& u,
-    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
+    const Eigen::Ref<const Eigen::VectorXd>& parameters);
 
   // pdf
   Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u);
 
   Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u,
-                          const Eigen::MatrixXd& parameters) override;
+                          const Eigen::MatrixXd& parameters);
 
   // link between Kendall's tau and the par_bicop parameter
   double parameters_to_tau(const Eigen::MatrixXd& par);

--- a/include/vinecopulib/bicop/bb7.hpp
+++ b/include/vinecopulib/bicop/bb7.hpp
@@ -36,8 +36,6 @@ private:
     const Eigen::Ref<const Eigen::VectorXd>& parameters);
 
   // pdf
-  Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u);
-
   Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u,
                           const Eigen::MatrixXd& parameters);
 

--- a/include/vinecopulib/bicop/bb8.hpp
+++ b/include/vinecopulib/bicop/bb8.hpp
@@ -25,16 +25,23 @@ public:
 
 private:
   // generator, its inverse and derivatives for the archimedean copula
-  double generator(const double& u);
+  double generator(
+    const double& u,
+    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
 
-  double generator_inv(const double& u);
+  double generator_inv(
+    const double& u,
+    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
 
-  double generator_derivative(const double& u);
-
-  double generator_derivative2(const double& u);
+  double generator_derivative(
+    const double& u,
+    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
 
   // pdf
   Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u);
+
+  Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u,
+                          const Eigen::MatrixXd& parameters) override;
 
   // link between Kendall's tau and the par_bicop parameter
   double parameters_to_tau(const Eigen::MatrixXd& par);

--- a/include/vinecopulib/bicop/bb8.hpp
+++ b/include/vinecopulib/bicop/bb8.hpp
@@ -25,23 +25,21 @@ public:
 
 private:
   // generator, its inverse and derivatives for the archimedean copula
-  double generator(
-    const double& u,
-    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
+  double generator(const double& u,
+                   const Eigen::Ref<const Eigen::VectorXd>& parameters);
 
-  double generator_inv(
-    const double& u,
-    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
+  double generator_inv(const double& u,
+                       const Eigen::Ref<const Eigen::VectorXd>& parameters);
 
   double generator_derivative(
     const double& u,
-    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
+    const Eigen::Ref<const Eigen::VectorXd>& parameters);
 
   // pdf
   Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u);
 
   Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u,
-                          const Eigen::MatrixXd& parameters) override;
+                          const Eigen::MatrixXd& parameters);
 
   // link between Kendall's tau and the par_bicop parameter
   double parameters_to_tau(const Eigen::MatrixXd& par);

--- a/include/vinecopulib/bicop/bb8.hpp
+++ b/include/vinecopulib/bicop/bb8.hpp
@@ -36,8 +36,6 @@ private:
     const Eigen::Ref<const Eigen::VectorXd>& parameters);
 
   // pdf
-  Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u);
-
   Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u,
                           const Eigen::MatrixXd& parameters);
 

--- a/include/vinecopulib/bicop/class.hpp
+++ b/include/vinecopulib/bicop/class.hpp
@@ -135,6 +135,35 @@ public:
 
   Eigen::VectorXd hinv2(const Eigen::MatrixXd& u) const;
 
+  // Stats methods with per-row parameters (parametric families only)
+  Eigen::VectorXd pdf(const Eigen::MatrixXd& u,
+                      const Eigen::MatrixXd& parameters,
+                      const size_t num_threads = 1) const;
+
+  Eigen::VectorXd cdf(const Eigen::MatrixXd& u,
+                      const Eigen::MatrixXd& parameters,
+                      const size_t num_threads = 1) const;
+
+  Eigen::VectorXd hfunc1(const Eigen::MatrixXd& u,
+                         const Eigen::MatrixXd& parameters,
+                         const size_t num_threads = 1) const;
+
+  Eigen::VectorXd hfunc2(const Eigen::MatrixXd& u,
+                         const Eigen::MatrixXd& parameters,
+                         const size_t num_threads = 1) const;
+
+  Eigen::VectorXd hinv1(const Eigen::MatrixXd& u,
+                        const Eigen::MatrixXd& parameters,
+                        const size_t num_threads = 1) const;
+
+  Eigen::VectorXd hinv2(const Eigen::MatrixXd& u,
+                        const Eigen::MatrixXd& parameters,
+                        const size_t num_threads = 1) const;
+
+  double loglik(const Eigen::MatrixXd& u,
+                const Eigen::MatrixXd& parameters,
+                const size_t num_threads) const;
+
   Eigen::MatrixXd simulate(
     const size_t& n,
     const bool qrng = false,
@@ -178,6 +207,16 @@ private:
   void rotate_data(Eigen::MatrixXd& u) const;
 
   Eigen::MatrixXd prep_for_abstract(const Eigen::MatrixXd& u) const;
+
+  Eigen::MatrixXd format_parameters(const Eigen::MatrixXd& u,
+                                    const Eigen::MatrixXd& parameters) const;
+
+  Eigen::VectorXd eval_in_batches(
+    const Eigen::MatrixXd& u,
+    const Eigen::MatrixXd& parameters_t,
+    const size_t num_threads,
+    const std::function<Eigen::VectorXd(const Eigen::MatrixXd&,
+                                        const Eigen::MatrixXd&)>& f) const;
 
   void check_rotation(int rotation) const;
 

--- a/include/vinecopulib/bicop/clayton.hpp
+++ b/include/vinecopulib/bicop/clayton.hpp
@@ -36,14 +36,10 @@ private:
     const Eigen::Ref<const Eigen::VectorXd>& parameters);
 
   // pdf
-  Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u);
-
   Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u,
                           const Eigen::MatrixXd& parameters);
 
   // inverse hfunction
-  Eigen::VectorXd hinv1_raw(const Eigen::MatrixXd& u);
-
   Eigen::VectorXd hinv1_raw(const Eigen::MatrixXd& u,
                             const Eigen::MatrixXd& parameters);
 

--- a/include/vinecopulib/bicop/clayton.hpp
+++ b/include/vinecopulib/bicop/clayton.hpp
@@ -25,29 +25,27 @@ public:
 
 private:
   // generator, its inverse and derivatives for the archimedean copula
-  double generator(
-    const double& u,
-    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
+  double generator(const double& u,
+                   const Eigen::Ref<const Eigen::VectorXd>& parameters);
 
-  double generator_inv(
-    const double& u,
-    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
+  double generator_inv(const double& u,
+                       const Eigen::Ref<const Eigen::VectorXd>& parameters);
 
   double generator_derivative(
     const double& u,
-    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
+    const Eigen::Ref<const Eigen::VectorXd>& parameters);
 
   // pdf
   Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u);
 
   Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u,
-                          const Eigen::MatrixXd& parameters) override;
+                          const Eigen::MatrixXd& parameters);
 
   // inverse hfunction
   Eigen::VectorXd hinv1_raw(const Eigen::MatrixXd& u);
 
   Eigen::VectorXd hinv1_raw(const Eigen::MatrixXd& u,
-                            const Eigen::MatrixXd& parameters) override;
+                            const Eigen::MatrixXd& parameters);
 
   // link between Kendall's tau and the par_bicop parameter
   Eigen::MatrixXd tau_to_parameters(const double& tau);

--- a/include/vinecopulib/bicop/clayton.hpp
+++ b/include/vinecopulib/bicop/clayton.hpp
@@ -25,19 +25,29 @@ public:
 
 private:
   // generator, its inverse and derivatives for the archimedean copula
-  double generator(const double& u);
+  double generator(
+    const double& u,
+    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
 
-  double generator_inv(const double& u);
+  double generator_inv(
+    const double& u,
+    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
 
-  double generator_derivative(const double& u);
-
-  double generator_derivative2(const double& u);
+  double generator_derivative(
+    const double& u,
+    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
 
   // pdf
   Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u);
 
+  Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u,
+                          const Eigen::MatrixXd& parameters) override;
+
   // inverse hfunction
   Eigen::VectorXd hinv1_raw(const Eigen::MatrixXd& u);
+
+  Eigen::VectorXd hinv1_raw(const Eigen::MatrixXd& u,
+                            const Eigen::MatrixXd& parameters) override;
 
   // link between Kendall's tau and the par_bicop parameter
   Eigen::MatrixXd tau_to_parameters(const double& tau);

--- a/include/vinecopulib/bicop/elliptical.hpp
+++ b/include/vinecopulib/bicop/elliptical.hpp
@@ -22,12 +22,7 @@ namespace vinecopulib {
 class EllipticalBicop : public ParBicop
 {
 private:
-  // hfunction and its inverse
-  Eigen::VectorXd hfunc2_raw(const Eigen::MatrixXd& u);
-
-  Eigen::VectorXd hinv2_raw(const Eigen::MatrixXd& u);
-
-  // parameter-aware overloads (thread `parameters` through the column swap)
+  // hfunction and its inverse (thread `parameters` through the column swap)
   Eigen::VectorXd hfunc2_raw(const Eigen::MatrixXd& u,
                              const Eigen::MatrixXd& parameters);
 

--- a/include/vinecopulib/bicop/elliptical.hpp
+++ b/include/vinecopulib/bicop/elliptical.hpp
@@ -29,10 +29,10 @@ private:
 
   // parameter-aware overloads (thread `parameters` through the column swap)
   Eigen::VectorXd hfunc2_raw(const Eigen::MatrixXd& u,
-                             const Eigen::MatrixXd& parameters) override;
+                             const Eigen::MatrixXd& parameters);
 
   Eigen::VectorXd hinv2_raw(const Eigen::MatrixXd& u,
-                            const Eigen::MatrixXd& parameters) override;
+                            const Eigen::MatrixXd& parameters);
 
   // link between Kendall's tau and the par_bicop parameter
   double parameters_to_tau(const Eigen::MatrixXd& parameters);

--- a/include/vinecopulib/bicop/elliptical.hpp
+++ b/include/vinecopulib/bicop/elliptical.hpp
@@ -27,6 +27,13 @@ private:
 
   Eigen::VectorXd hinv2_raw(const Eigen::MatrixXd& u);
 
+  // parameter-aware overloads (thread `parameters` through the column swap)
+  Eigen::VectorXd hfunc2_raw(const Eigen::MatrixXd& u,
+                             const Eigen::MatrixXd& parameters) override;
+
+  Eigen::VectorXd hinv2_raw(const Eigen::MatrixXd& u,
+                            const Eigen::MatrixXd& parameters) override;
+
   // link between Kendall's tau and the par_bicop parameter
   double parameters_to_tau(const Eigen::MatrixXd& parameters);
 };

--- a/include/vinecopulib/bicop/extreme_value.hpp
+++ b/include/vinecopulib/bicop/extreme_value.hpp
@@ -20,21 +20,8 @@ namespace vinecopulib {
 class ExtremeValueBicop : public ParBicop
 {
 private:
-  // pdf, cdf, hfunctions and inverses
-  Eigen::VectorXd cdf(const Eigen::MatrixXd& u);
-
-  Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u);
-
-  Eigen::VectorXd hfunc1_raw(const Eigen::MatrixXd& u);
-
-  Eigen::VectorXd hfunc2_raw(const Eigen::MatrixXd& u);
-
-  Eigen::VectorXd hinv1_raw(const Eigen::MatrixXd& u);
-
-  Eigen::VectorXd hinv2_raw(const Eigen::MatrixXd& u);
-
-  // parameter-aware overloads (`parameters` is p x m, m in {1, n}); the
-  // state-based versions above delegate to these passing the stored parameters
+  // pdf, cdf, hfunctions and inverses (`parameters` is m x p, m in {1, n}; a
+  // single row is broadcast to all observations)
   Eigen::VectorXd cdf(const Eigen::MatrixXd& u,
                       const Eigen::MatrixXd& parameters);
 

--- a/include/vinecopulib/bicop/extreme_value.hpp
+++ b/include/vinecopulib/bicop/extreme_value.hpp
@@ -33,12 +33,39 @@ private:
 
   Eigen::VectorXd hinv2_raw(const Eigen::MatrixXd& u);
 
-  // pickands dependence functions and its derivatives
-  virtual double pickands(const double& t) = 0;
+  // parameter-aware overloads (`parameters` is p x m, m in {1, n}); the
+  // state-based versions above delegate to these passing the stored parameters
+  Eigen::VectorXd cdf(const Eigen::MatrixXd& u,
+                      const Eigen::MatrixXd& parameters) override;
 
-  virtual double pickands_derivative(const double& t) = 0;
+  Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u,
+                          const Eigen::MatrixXd& parameters) override;
 
-  virtual double pickands_derivative2(const double& t) = 0;
+  Eigen::VectorXd hfunc1_raw(const Eigen::MatrixXd& u,
+                             const Eigen::MatrixXd& parameters) override;
+
+  Eigen::VectorXd hfunc2_raw(const Eigen::MatrixXd& u,
+                             const Eigen::MatrixXd& parameters) override;
+
+  Eigen::VectorXd hinv1_raw(const Eigen::MatrixXd& u,
+                            const Eigen::MatrixXd& parameters) override;
+
+  Eigen::VectorXd hinv2_raw(const Eigen::MatrixXd& u,
+                            const Eigen::MatrixXd& parameters) override;
+
+  // pickands dependence functions and its derivatives; `parameters` is a single
+  // parameter set (a p x 1 column)
+  virtual double pickands(
+    const double& t,
+    const Eigen::Ref<const Eigen::VectorXd>& parameters) = 0;
+
+  virtual double pickands_derivative(
+    const double& t,
+    const Eigen::Ref<const Eigen::VectorXd>& parameters) = 0;
+
+  virtual double pickands_derivative2(
+    const double& t,
+    const Eigen::Ref<const Eigen::VectorXd>& parameters) = 0;
 
   // link between Kendall's tau and the par_bicop parameter
   double parameters_to_tau(const Eigen::MatrixXd& par);

--- a/include/vinecopulib/bicop/extreme_value.hpp
+++ b/include/vinecopulib/bicop/extreme_value.hpp
@@ -36,22 +36,22 @@ private:
   // parameter-aware overloads (`parameters` is p x m, m in {1, n}); the
   // state-based versions above delegate to these passing the stored parameters
   Eigen::VectorXd cdf(const Eigen::MatrixXd& u,
-                      const Eigen::MatrixXd& parameters) override;
+                      const Eigen::MatrixXd& parameters);
 
   Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u,
-                          const Eigen::MatrixXd& parameters) override;
+                          const Eigen::MatrixXd& parameters);
 
   Eigen::VectorXd hfunc1_raw(const Eigen::MatrixXd& u,
-                             const Eigen::MatrixXd& parameters) override;
+                             const Eigen::MatrixXd& parameters);
 
   Eigen::VectorXd hfunc2_raw(const Eigen::MatrixXd& u,
-                             const Eigen::MatrixXd& parameters) override;
+                             const Eigen::MatrixXd& parameters);
 
   Eigen::VectorXd hinv1_raw(const Eigen::MatrixXd& u,
-                            const Eigen::MatrixXd& parameters) override;
+                            const Eigen::MatrixXd& parameters);
 
   Eigen::VectorXd hinv2_raw(const Eigen::MatrixXd& u,
-                            const Eigen::MatrixXd& parameters) override;
+                            const Eigen::MatrixXd& parameters);
 
   // pickands dependence functions and its derivatives; `parameters` is a single
   // parameter set (a p x 1 column)

--- a/include/vinecopulib/bicop/frank.hpp
+++ b/include/vinecopulib/bicop/frank.hpp
@@ -25,16 +25,23 @@ public:
 
 private:
   // generator, its inverse and derivatives for the archimedean copula
-  double generator(const double& u);
+  double generator(
+    const double& u,
+    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
 
-  double generator_inv(const double& u);
+  double generator_inv(
+    const double& u,
+    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
 
-  double generator_derivative(const double& u);
-
-  double generator_derivative2(const double& u);
+  double generator_derivative(
+    const double& u,
+    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
 
   // pdf
   Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u);
+
+  Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u,
+                          const Eigen::MatrixXd& parameters) override;
 
   // link between Kendall's tau and the par_bicop parameter
   Eigen::MatrixXd tau_to_parameters(const double& tau);

--- a/include/vinecopulib/bicop/frank.hpp
+++ b/include/vinecopulib/bicop/frank.hpp
@@ -25,23 +25,21 @@ public:
 
 private:
   // generator, its inverse and derivatives for the archimedean copula
-  double generator(
-    const double& u,
-    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
+  double generator(const double& u,
+                   const Eigen::Ref<const Eigen::VectorXd>& parameters);
 
-  double generator_inv(
-    const double& u,
-    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
+  double generator_inv(const double& u,
+                       const Eigen::Ref<const Eigen::VectorXd>& parameters);
 
   double generator_derivative(
     const double& u,
-    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
+    const Eigen::Ref<const Eigen::VectorXd>& parameters);
 
   // pdf
   Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u);
 
   Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u,
-                          const Eigen::MatrixXd& parameters) override;
+                          const Eigen::MatrixXd& parameters);
 
   // link between Kendall's tau and the par_bicop parameter
   Eigen::MatrixXd tau_to_parameters(const double& tau);

--- a/include/vinecopulib/bicop/frank.hpp
+++ b/include/vinecopulib/bicop/frank.hpp
@@ -36,8 +36,6 @@ private:
     const Eigen::Ref<const Eigen::VectorXd>& parameters);
 
   // pdf
-  Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u);
-
   Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u,
                           const Eigen::MatrixXd& parameters);
 

--- a/include/vinecopulib/bicop/gaussian.hpp
+++ b/include/vinecopulib/bicop/gaussian.hpp
@@ -36,6 +36,19 @@ private:
   // inverse hfunction
   Eigen::VectorXd hinv1_raw(const Eigen::MatrixXd& u);
 
+  // parameter-aware overloads (`parameters` is 1 x m, m in {1, n})
+  Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u,
+                          const Eigen::MatrixXd& parameters) override;
+
+  Eigen::VectorXd cdf(const Eigen::MatrixXd& u,
+                      const Eigen::MatrixXd& parameters) override;
+
+  Eigen::VectorXd hfunc1_raw(const Eigen::MatrixXd& u,
+                             const Eigen::MatrixXd& parameters) override;
+
+  Eigen::VectorXd hinv1_raw(const Eigen::MatrixXd& u,
+                            const Eigen::MatrixXd& parameters) override;
+
   Eigen::MatrixXd tau_to_parameters(const double& tau);
 
   Eigen::VectorXd get_start_parameters(const double tau);

--- a/include/vinecopulib/bicop/gaussian.hpp
+++ b/include/vinecopulib/bicop/gaussian.hpp
@@ -38,16 +38,16 @@ private:
 
   // parameter-aware overloads (`parameters` is 1 x m, m in {1, n})
   Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u,
-                          const Eigen::MatrixXd& parameters) override;
+                          const Eigen::MatrixXd& parameters);
 
   Eigen::VectorXd cdf(const Eigen::MatrixXd& u,
-                      const Eigen::MatrixXd& parameters) override;
+                      const Eigen::MatrixXd& parameters);
 
   Eigen::VectorXd hfunc1_raw(const Eigen::MatrixXd& u,
-                             const Eigen::MatrixXd& parameters) override;
+                             const Eigen::MatrixXd& parameters);
 
   Eigen::VectorXd hinv1_raw(const Eigen::MatrixXd& u,
-                            const Eigen::MatrixXd& parameters) override;
+                            const Eigen::MatrixXd& parameters);
 
   Eigen::MatrixXd tau_to_parameters(const double& tau);
 

--- a/include/vinecopulib/bicop/gaussian.hpp
+++ b/include/vinecopulib/bicop/gaussian.hpp
@@ -24,19 +24,7 @@ public:
   GaussianBicop();
 
 private:
-  // PDF
-  Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u);
-
-  // CDF
-  Eigen::VectorXd cdf(const Eigen::MatrixXd& u);
-
-  // hfunction
-  Eigen::VectorXd hfunc1_raw(const Eigen::MatrixXd& u);
-
-  // inverse hfunction
-  Eigen::VectorXd hinv1_raw(const Eigen::MatrixXd& u);
-
-  // parameter-aware overloads (`parameters` is 1 x m, m in {1, n})
+  // evaluation leaves (`parameters` is m x 1, m in {1, n})
   Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u,
                           const Eigen::MatrixXd& parameters);
 

--- a/include/vinecopulib/bicop/gumbel.hpp
+++ b/include/vinecopulib/bicop/gumbel.hpp
@@ -36,14 +36,10 @@ private:
     const Eigen::Ref<const Eigen::VectorXd>& parameters);
 
   // pdf
-  Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u);
-
   Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u,
                           const Eigen::MatrixXd& parameters);
 
   // inverse hfunction
-  Eigen::VectorXd hinv1_raw(const Eigen::MatrixXd& u);
-
   Eigen::VectorXd hinv1_raw(const Eigen::MatrixXd& u,
                             const Eigen::MatrixXd& parameters);
 

--- a/include/vinecopulib/bicop/gumbel.hpp
+++ b/include/vinecopulib/bicop/gumbel.hpp
@@ -25,29 +25,27 @@ public:
 
 private:
   // generator, its inverse and derivatives for the archimedean copula
-  double generator(
-    const double& u,
-    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
+  double generator(const double& u,
+                   const Eigen::Ref<const Eigen::VectorXd>& parameters);
 
-  double generator_inv(
-    const double& u,
-    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
+  double generator_inv(const double& u,
+                       const Eigen::Ref<const Eigen::VectorXd>& parameters);
 
   double generator_derivative(
     const double& u,
-    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
+    const Eigen::Ref<const Eigen::VectorXd>& parameters);
 
   // pdf
   Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u);
 
   Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u,
-                          const Eigen::MatrixXd& parameters) override;
+                          const Eigen::MatrixXd& parameters);
 
   // inverse hfunction
   Eigen::VectorXd hinv1_raw(const Eigen::MatrixXd& u);
 
   Eigen::VectorXd hinv1_raw(const Eigen::MatrixXd& u,
-                            const Eigen::MatrixXd& parameters) override;
+                            const Eigen::MatrixXd& parameters);
 
   // link between Kendall's tau and the par_bicop parameter
   Eigen::MatrixXd tau_to_parameters(const double& tau);

--- a/include/vinecopulib/bicop/gumbel.hpp
+++ b/include/vinecopulib/bicop/gumbel.hpp
@@ -25,19 +25,29 @@ public:
 
 private:
   // generator, its inverse and derivatives for the archimedean copula
-  double generator(const double& u);
+  double generator(
+    const double& u,
+    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
 
-  double generator_inv(const double& u);
+  double generator_inv(
+    const double& u,
+    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
 
-  double generator_derivative(const double& u);
-
-  double generator_derivative2(const double& u);
+  double generator_derivative(
+    const double& u,
+    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
 
   // pdf
   Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u);
 
+  Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u,
+                          const Eigen::MatrixXd& parameters) override;
+
   // inverse hfunction
   Eigen::VectorXd hinv1_raw(const Eigen::MatrixXd& u);
+
+  Eigen::VectorXd hinv1_raw(const Eigen::MatrixXd& u,
+                            const Eigen::MatrixXd& parameters) override;
 
   // link between Kendall's tau and the par_bicop parameter
   Eigen::MatrixXd tau_to_parameters(const double& tau);

--- a/include/vinecopulib/bicop/implementation/abstract.ipp
+++ b/include/vinecopulib/bicop/implementation/abstract.ipp
@@ -215,7 +215,7 @@ AbstractBicop::pdf_d_d(const Eigen::MatrixXd& u)
 inline Eigen::VectorXd
 AbstractBicop::hfunc1(const Eigen::MatrixXd& u)
 {
-  if (var_types_[0] == "d") {
+  if (var_types_[0] == "d" && u.cols() == 4) {
     auto uu = u;
     uu.col(3) = uu.col(1);
     auto u1diff = (uu.col(0) - uu.col(2)).cwiseAbs();
@@ -241,7 +241,7 @@ AbstractBicop::hfunc1(const Eigen::MatrixXd& u)
 inline Eigen::VectorXd
 AbstractBicop::hfunc2(const Eigen::MatrixXd& u)
 {
-  if (var_types_[1] == "d") {
+  if (var_types_[1] == "d" && u.cols() == 4) {
     auto uu = u;
     uu.col(2) = uu.col(0);
     auto u2diff = (uu.col(1) - uu.col(3)).cwiseAbs();
@@ -468,7 +468,7 @@ inline Eigen::VectorXd
 AbstractBicop::hfunc1(const Eigen::MatrixXd& u,
                       const Eigen::MatrixXd& parameters)
 {
-  if (var_types_[0] == "d") {
+  if (var_types_[0] == "d" && u.cols() == 4) {
     auto uu = u;
     uu.col(3) = uu.col(1);
     auto u1diff = (uu.col(0) - uu.col(2)).cwiseAbs();
@@ -496,7 +496,7 @@ inline Eigen::VectorXd
 AbstractBicop::hfunc2(const Eigen::MatrixXd& u,
                       const Eigen::MatrixXd& parameters)
 {
-  if (var_types_[1] == "d") {
+  if (var_types_[1] == "d" && u.cols() == 4) {
     auto uu = u;
     uu.col(2) = uu.col(0);
     auto u2diff = (uu.col(1) - uu.col(3)).cwiseAbs();

--- a/include/vinecopulib/bicop/implementation/abstract.ipp
+++ b/include/vinecopulib/bicop/implementation/abstract.ipp
@@ -330,4 +330,242 @@ AbstractBicop::hinv2_num(const Eigen::MatrixXd& u)
   return tools_eigen::invert_f(u.col(0), h1);
 }
 //! @}
+
+//! @name Parameter-aware overloads
+//!
+//! These mirror the state-based methods above but read the parameters from the
+//! `parameters` argument (shape p x m, m in {1, n}) instead of object state,
+//! enabling evaluation at a different parameter set per row of `u`.
+//! @{
+
+//! @brief Base-default parameter-aware leaves: ignore `parameters` and use
+//! object state. Parametric families override these with stateless math.
+inline Eigen::VectorXd
+AbstractBicop::pdf_raw(const Eigen::MatrixXd& u, const Eigen::MatrixXd&)
+{
+  return pdf_raw(u);
+}
+
+inline Eigen::VectorXd
+AbstractBicop::cdf(const Eigen::MatrixXd& u, const Eigen::MatrixXd&)
+{
+  return cdf(u);
+}
+
+inline Eigen::VectorXd
+AbstractBicop::hfunc1_raw(const Eigen::MatrixXd& u, const Eigen::MatrixXd&)
+{
+  return hfunc1_raw(u);
+}
+
+inline Eigen::VectorXd
+AbstractBicop::hfunc2_raw(const Eigen::MatrixXd& u, const Eigen::MatrixXd&)
+{
+  return hfunc2_raw(u);
+}
+
+inline Eigen::VectorXd
+AbstractBicop::hinv1_raw(const Eigen::MatrixXd& u, const Eigen::MatrixXd&)
+{
+  return hinv1_raw(u);
+}
+
+inline Eigen::VectorXd
+AbstractBicop::hinv2_raw(const Eigen::MatrixXd& u, const Eigen::MatrixXd&)
+{
+  return hinv2_raw(u);
+}
+
+inline Eigen::VectorXd
+AbstractBicop::pdf(const Eigen::MatrixXd& u, const Eigen::MatrixXd& parameters)
+{
+  Eigen::VectorXd pdf(u.rows());
+  if (var_types_ == std::vector<std::string>{ "c", "c" }) {
+    pdf = pdf_raw(u.leftCols(2), parameters);
+  } else if (var_types_ == std::vector<std::string>{ "d", "d" }) {
+    pdf = pdf_d_d(u, parameters);
+  } else {
+    pdf = pdf_c_d(u, parameters);
+  }
+  tools_eigen::trim(pdf, DBL_MIN, DBL_MAX);
+  return pdf;
+}
+
+inline Eigen::VectorXd
+AbstractBicop::pdf_c_d(const Eigen::MatrixXd& u,
+                       const Eigen::MatrixXd& parameters)
+{
+  Eigen::VectorXd pdf(u.rows());
+  Eigen::MatrixXd umax = u.leftCols(2);
+  Eigen::MatrixXd umin = u.rightCols(2);
+  Eigen::VectorXd udiff(u.rows());
+
+  if (var_types_[0] != "c") {
+    udiff = (u.col(0) - u.col(2)).cwiseAbs();
+  } else {
+    udiff = (u.col(1) - u.col(3)).cwiseAbs();
+  }
+
+  const bool bc = (parameters.cols() == 1);
+  for (Eigen::Index i = 0; i < u.rows(); i++) {
+    const Eigen::MatrixXd par_i = parameters.col(bc ? 0 : i);
+    if (udiff(i) > 5e-5) {
+      if (var_types_[0] != "c") {
+        pdf(i) =
+          (hfunc2_raw(umax.row(i), par_i) - hfunc2_raw(umin.row(i), par_i))(0);
+      } else {
+        pdf(i) =
+          (hfunc1_raw(umax.row(i), par_i) - hfunc1_raw(umin.row(i), par_i))(0);
+      }
+      pdf(i) /= udiff(i);
+    } else {
+      pdf(i) = pdf_raw((umax.row(i) + umin.row(i)) / 2, par_i)(0);
+    }
+  }
+  return pdf.cwiseAbs();
+}
+
+inline Eigen::VectorXd
+AbstractBicop::pdf_d_d(const Eigen::MatrixXd& u,
+                       const Eigen::MatrixXd& parameters)
+{
+  Eigen::VectorXd pdf(u.rows());
+  Eigen::MatrixXd umax = u.leftCols(2);
+  Eigen::MatrixXd umin = u.rightCols(2);
+  Eigen::MatrixXd udiff = (umax - umin).cwiseAbs();
+
+  const bool bc = (parameters.cols() == 1);
+  for (Eigen::Index i = 0; i < u.rows(); i++) {
+    const Eigen::MatrixXd par_i = parameters.col(bc ? 0 : i);
+    // the difference quotient can be instable, use derivative if denominator
+    // too small
+    if (udiff.row(i).maxCoeff() < 5e-5) {
+      pdf(i) = pdf_raw((umax.row(i) + umin.row(i)) / 2, par_i)(0);
+    } else if (udiff(i, 0) < 5e-5) {
+      umax(i, 0) = (umax(i, 0) + umin(i, 0)) / 2;
+      umin(i, 0) = (umax(i, 0) + umin(i, 0)) / 2;
+      pdf(i) = (hfunc1_raw(umax.row(i), par_i)(0) -
+                hfunc1_raw(umin.row(i), par_i)(0)) /
+               udiff(i, 1);
+    } else if (udiff(i, 1) < 5e-5) {
+      umax(i, 1) = (umax(i, 1) + umin(i, 1)) / 2;
+      umin(i, 1) = (umax(i, 1) + umin(i, 1)) / 2;
+      pdf(i) = (hfunc2_raw(umax.row(i), par_i)(0) -
+                hfunc2_raw(umin.row(i), par_i)(0)) /
+               udiff(i, 0);
+    } else {
+      pdf(i) = cdf(umax.row(i), par_i)(0) + cdf(umin.row(i), par_i)(0);
+      std::swap(umax(i, 0), umin(i, 0));
+      pdf(i) -= cdf(umax.row(i), par_i)(0) + cdf(umin.row(i), par_i)(0);
+      pdf(i) /= udiff(i, 0) * udiff(i, 1);
+    }
+  }
+
+  return pdf.cwiseAbs();
+}
+
+inline Eigen::VectorXd
+AbstractBicop::hfunc1(const Eigen::MatrixXd& u,
+                      const Eigen::MatrixXd& parameters)
+{
+  if (var_types_[0] == "d") {
+    auto uu = u;
+    uu.col(3) = uu.col(1);
+    auto u1diff = (uu.col(0) - uu.col(2)).cwiseAbs();
+    Eigen::VectorXd h(u.rows());
+
+    const bool bc = (parameters.cols() == 1);
+    for (Eigen::Index i = 0; i < u.rows(); i++) {
+      const Eigen::MatrixXd par_i = parameters.col(bc ? 0 : i);
+      if (std::abs(u1diff(i)) > 5e-5) {
+        h(i) = cdf(uu.row(i).leftCols(2), par_i)(0) -
+               cdf(uu.row(i).rightCols(2), par_i)(0);
+        h(i) /= u1diff(i);
+      } else {
+        uu(i, 0) = (uu(i, 0) + uu(i, 2)) / 2;
+        h(i) = hfunc1_raw(uu.row(i).leftCols(2), par_i)(0);
+      }
+    }
+    return h.cwiseAbs();
+  } else {
+    return hfunc1_raw(u.leftCols(2), parameters);
+  }
+}
+
+inline Eigen::VectorXd
+AbstractBicop::hfunc2(const Eigen::MatrixXd& u,
+                      const Eigen::MatrixXd& parameters)
+{
+  if (var_types_[1] == "d") {
+    auto uu = u;
+    uu.col(2) = uu.col(0);
+    auto u2diff = (uu.col(1) - uu.col(3)).cwiseAbs();
+    Eigen::VectorXd h(u.rows());
+
+    const bool bc = (parameters.cols() == 1);
+    for (Eigen::Index i = 0; i < u.rows(); i++) {
+      const Eigen::MatrixXd par_i = parameters.col(bc ? 0 : i);
+      if (u2diff(i) > 5e-5) {
+        h(i) = cdf(uu.row(i).leftCols(2), par_i)(0) -
+               cdf(uu.row(i).rightCols(2), par_i)(0);
+        h(i) /= u2diff(i);
+      } else {
+        uu(i, 1) = (uu(i, 1) + uu(i, 3)) / 2;
+        h(i) = hfunc2_raw(uu.row(i).leftCols(2), par_i)(0);
+      }
+    }
+    return h.cwiseAbs();
+  } else {
+    return hfunc2_raw(u.leftCols(2), parameters);
+  }
+}
+
+inline Eigen::VectorXd
+AbstractBicop::hinv1(const Eigen::MatrixXd& u,
+                     const Eigen::MatrixXd& parameters)
+{
+  if (var_types_[0] == "c") {
+    return hinv1_raw(u.leftCols(2), parameters);
+  } else {
+    return hinv1_num(u, parameters);
+  }
+}
+
+inline Eigen::VectorXd
+AbstractBicop::hinv2(const Eigen::MatrixXd& u,
+                     const Eigen::MatrixXd& parameters)
+{
+  if (var_types_[1] == "c") {
+    return hinv2_raw(u.leftCols(2), parameters);
+  } else {
+    return hinv2_num(u, parameters);
+  }
+}
+
+inline Eigen::VectorXd
+AbstractBicop::hinv1_num(const Eigen::MatrixXd& u,
+                         const Eigen::MatrixXd& parameters)
+{
+  Eigen::MatrixXd u_new = u;
+  auto h1 = [&](const Eigen::VectorXd& v) {
+    u_new.col(1) = v;
+    return hfunc1(u_new, parameters);
+  };
+
+  return tools_eigen::invert_f(u.col(1), h1);
+}
+
+inline Eigen::VectorXd
+AbstractBicop::hinv2_num(const Eigen::MatrixXd& u,
+                         const Eigen::MatrixXd& parameters)
+{
+  Eigen::MatrixXd u_new = u;
+  auto h1 = [&](const Eigen::VectorXd& x) {
+    u_new.col(0) = x;
+    return hfunc2(u_new, parameters);
+  };
+
+  return tools_eigen::invert_f(u.col(0), h1);
+}
+//! @}
 }

--- a/include/vinecopulib/bicop/implementation/abstract.ipp
+++ b/include/vinecopulib/bicop/implementation/abstract.ipp
@@ -138,130 +138,31 @@ AbstractBicop::set_var_types(const std::vector<std::string>& var_types)
 inline Eigen::VectorXd
 AbstractBicop::pdf(const Eigen::MatrixXd& u)
 {
-
-  Eigen::VectorXd pdf(u.rows());
-  if (var_types_ == std::vector<std::string>{ "c", "c" }) {
-    pdf = pdf_raw(u.leftCols(2));
-  } else if (var_types_ == std::vector<std::string>{ "d", "d" }) {
-    pdf = pdf_d_d(u);
-  } else {
-    pdf = pdf_c_d(u);
+  if (var_types_ != std::vector<std::string>{ "c", "c" }) {
+    // discrete margins go through the parameter-aware difference quotients
+    return pdf(u, get_parameters());
   }
+  Eigen::VectorXd pdf = pdf_raw(u.leftCols(2));
   tools_eigen::trim(pdf, DBL_MIN, DBL_MAX);
   return pdf;
-}
-
-inline Eigen::VectorXd
-AbstractBicop::pdf_c_d(const Eigen::MatrixXd& u)
-{
-  Eigen::VectorXd pdf(u.rows());
-  Eigen::MatrixXd umax = u.leftCols(2);
-  Eigen::MatrixXd umin = u.rightCols(2);
-  Eigen::VectorXd udiff(u.rows());
-
-  if (var_types_[0] != "c") {
-    udiff = (u.col(0) - u.col(2)).cwiseAbs();
-  } else {
-    udiff = (u.col(1) - u.col(3)).cwiseAbs();
-  }
-
-  for (Eigen::Index i = 0; i < u.rows(); i++) {
-    if (udiff(i) > 5e-5) {
-      if (var_types_[0] != "c") {
-        pdf(i) = (hfunc2_raw(umax.row(i)) - hfunc2_raw(umin.row(i)))(0);
-      } else {
-        pdf(i) = (hfunc1_raw(umax.row(i)) - hfunc1_raw(umin.row(i)))(0);
-      }
-      pdf(i) /= udiff(i);
-    } else {
-      pdf(i) = pdf_raw((umax.row(i) + umin.row(i)) / 2)(0);
-    }
-  }
-  return pdf.cwiseAbs();
-}
-
-inline Eigen::VectorXd
-AbstractBicop::pdf_d_d(const Eigen::MatrixXd& u)
-{
-  Eigen::VectorXd pdf(u.rows());
-  Eigen::MatrixXd umax = u.leftCols(2);
-  Eigen::MatrixXd umin = u.rightCols(2);
-  Eigen::MatrixXd udiff = (umax - umin).cwiseAbs();
-
-  for (Eigen::Index i = 0; i < u.rows(); i++) {
-    // the difference quotient can be instable, use derivative if denominator
-    // too small
-    if (udiff.row(i).maxCoeff() < 5e-5) {
-      pdf(i) = pdf_raw((umax.row(i) + umin.row(i)) / 2)(0);
-    } else if (udiff(i, 0) < 5e-5) {
-      umax(i, 0) = (umax(i, 0) + umin(i, 0)) / 2;
-      umin(i, 0) = (umax(i, 0) + umin(i, 0)) / 2;
-      pdf(i) = (hfunc1_raw(umax)(0) - hfunc1_raw(umin)(0)) / udiff(i, 1);
-    } else if (udiff(i, 1) < 5e-5) {
-      umax(i, 1) = (umax(i, 1) + umin(i, 1)) / 2;
-      umin(i, 1) = (umax(i, 1) + umin(i, 1)) / 2;
-      pdf(i) = (hfunc2_raw(umax)(0) - hfunc2_raw(umin)(0)) / udiff(i, 0);
-    } else {
-      pdf(i) = cdf(umax.row(i))(0) + cdf(umin.row(i))(0);
-      std::swap(umax(i, 0), umin(i, 0));
-      pdf(i) -= cdf(umax.row(i))(0) + cdf(umin.row(i))(0);
-      pdf(i) /= udiff(i, 0) * udiff(i, 1);
-    }
-  }
-
-  return pdf.cwiseAbs();
 }
 
 inline Eigen::VectorXd
 AbstractBicop::hfunc1(const Eigen::MatrixXd& u)
 {
   if (var_types_[0] == "d" && u.cols() == 4) {
-    auto uu = u;
-    uu.col(3) = uu.col(1);
-    auto u1diff = (uu.col(0) - uu.col(2)).cwiseAbs();
-    Eigen::VectorXd h(u.rows());
-
-    // the quotient can be instable, use analytical derivative if denominator
-    // too small
-    for (Eigen::Index i = 0; i < u.rows(); i++) {
-      if (std::abs(u1diff(i)) > 5e-5) {
-        h(i) = cdf(uu.row(i).leftCols(2))(0) - cdf(uu.row(i).rightCols(2))(0);
-        h(i) /= u1diff(i);
-      } else {
-        uu(i, 0) = (uu(i, 0) + uu(i, 2)) / 2;
-        h(i) = hfunc1_raw(uu.row(i).leftCols(2))(0);
-      }
-    }
-    return h.cwiseAbs();
-  } else {
-    return hfunc1_raw(u.leftCols(2));
+    return hfunc1(u, get_parameters());
   }
+  return hfunc1_raw(u.leftCols(2));
 }
 
 inline Eigen::VectorXd
 AbstractBicop::hfunc2(const Eigen::MatrixXd& u)
 {
   if (var_types_[1] == "d" && u.cols() == 4) {
-    auto uu = u;
-    uu.col(2) = uu.col(0);
-    auto u2diff = (uu.col(1) - uu.col(3)).cwiseAbs();
-    Eigen::VectorXd h(u.rows());
-
-    // the quotient can be instable, use analytical derivative if denominator
-    // too small
-    for (Eigen::Index i = 0; i < u.rows(); i++) {
-      if (u2diff(i) > 5e-5) {
-        h(i) = cdf(uu.row(i).leftCols(2))(0) - cdf(uu.row(i).rightCols(2))(0);
-        h(i) /= u2diff(i);
-      } else {
-        uu(i, 1) = (uu(i, 1) + uu(i, 3)) / 2;
-        h(i) = hfunc2_raw(uu.row(i).leftCols(2))(0);
-      }
-    }
-    return h.cwiseAbs();
-  } else {
-    return hfunc2_raw(u.leftCols(2));
+    return hfunc2(u, get_parameters());
   }
+  return hfunc2_raw(u.leftCols(2));
 }
 
 inline Eigen::VectorXd
@@ -309,25 +210,13 @@ AbstractBicop::loglik(const Eigen::MatrixXd& u, const Eigen::VectorXd weights)
 inline Eigen::VectorXd
 AbstractBicop::hinv1_num(const Eigen::MatrixXd& u)
 {
-  Eigen::MatrixXd u_new = u;
-  auto h1 = [&](const Eigen::VectorXd& v) {
-    u_new.col(1) = v;
-    return hfunc1(u_new);
-  };
-
-  return tools_eigen::invert_f(u.col(1), h1);
+  return hinv1_num(u, get_parameters());
 }
 
 inline Eigen::VectorXd
 AbstractBicop::hinv2_num(const Eigen::MatrixXd& u)
 {
-  Eigen::MatrixXd u_new = u;
-  auto h1 = [&](const Eigen::VectorXd& x) {
-    u_new.col(0) = x;
-    return hfunc2(u_new);
-  };
-
-  return tools_eigen::invert_f(u.col(0), h1);
+  return hinv2_num(u, get_parameters());
 }
 //! @}
 

--- a/include/vinecopulib/bicop/implementation/abstract.ipp
+++ b/include/vinecopulib/bicop/implementation/abstract.ipp
@@ -148,12 +148,6 @@ AbstractBicop::pdf(const Eigen::MatrixXd& u)
 }
 
 inline Eigen::VectorXd
-AbstractBicop::cdf(const Eigen::MatrixXd& u)
-{
-  return cdf(u.leftCols(2), get_parameters().transpose());
-}
-
-inline Eigen::VectorXd
 AbstractBicop::hfunc1(const Eigen::MatrixXd& u)
 {
   if (var_types_[0] == "d") {

--- a/include/vinecopulib/bicop/implementation/abstract.ipp
+++ b/include/vinecopulib/bicop/implementation/abstract.ipp
@@ -140,36 +140,42 @@ AbstractBicop::pdf(const Eigen::MatrixXd& u)
 {
   if (var_types_ != std::vector<std::string>{ "c", "c" }) {
     // discrete margins go through the parameter-aware difference quotients
-    return pdf(u, get_parameters());
+    return pdf(u, get_parameters().transpose());
   }
-  Eigen::VectorXd pdf = pdf_raw(u.leftCols(2));
+  Eigen::VectorXd pdf = pdf_raw(u.leftCols(2), get_parameters().transpose());
   tools_eigen::trim(pdf, DBL_MIN, DBL_MAX);
   return pdf;
 }
 
 inline Eigen::VectorXd
+AbstractBicop::cdf(const Eigen::MatrixXd& u)
+{
+  return cdf(u.leftCols(2), get_parameters().transpose());
+}
+
+inline Eigen::VectorXd
 AbstractBicop::hfunc1(const Eigen::MatrixXd& u)
 {
-  if (var_types_[0] == "d" && u.cols() == 4) {
-    return hfunc1(u, get_parameters());
+  if (var_types_[0] == "d") {
+    return hfunc1(u, get_parameters().transpose());
   }
-  return hfunc1_raw(u.leftCols(2));
+  return hfunc1_raw(u.leftCols(2), get_parameters().transpose());
 }
 
 inline Eigen::VectorXd
 AbstractBicop::hfunc2(const Eigen::MatrixXd& u)
 {
-  if (var_types_[1] == "d" && u.cols() == 4) {
-    return hfunc2(u, get_parameters());
+  if (var_types_[1] == "d") {
+    return hfunc2(u, get_parameters().transpose());
   }
-  return hfunc2_raw(u.leftCols(2));
+  return hfunc2_raw(u.leftCols(2), get_parameters().transpose());
 }
 
 inline Eigen::VectorXd
 AbstractBicop::hinv1(const Eigen::MatrixXd& u)
 {
   if (var_types_[0] == "c") {
-    return hinv1_raw(u.leftCols(2));
+    return hinv1_raw(u.leftCols(2), get_parameters().transpose());
   } else {
     return hinv1_num(u);
   }
@@ -179,7 +185,7 @@ inline Eigen::VectorXd
 AbstractBicop::hinv2(const Eigen::MatrixXd& u)
 {
   if (var_types_[1] == "c") {
-    return hinv2_raw(u.leftCols(2));
+    return hinv2_raw(u.leftCols(2), get_parameters().transpose());
   } else {
     return hinv2_num(u);
   }
@@ -210,60 +216,23 @@ AbstractBicop::loglik(const Eigen::MatrixXd& u, const Eigen::VectorXd weights)
 inline Eigen::VectorXd
 AbstractBicop::hinv1_num(const Eigen::MatrixXd& u)
 {
-  return hinv1_num(u, get_parameters());
+  return hinv1_num(u, get_parameters().transpose());
 }
 
 inline Eigen::VectorXd
 AbstractBicop::hinv2_num(const Eigen::MatrixXd& u)
 {
-  return hinv2_num(u, get_parameters());
+  return hinv2_num(u, get_parameters().transpose());
 }
 //! @}
 
-//! @name Parameter-aware overloads
+//! @name Parameter-aware leaves and dispatchers
 //!
-//! These mirror the state-based methods above but read the parameters from the
-//! `parameters` argument (shape p x m, m in {1, n}) instead of object state,
-//! enabling evaluation at a different parameter set per row of `u`.
+//! `parameters` has shape m x p with m in {1, n}: row i holds the p parameters
+//! for observation i; a single row is broadcast to all observations. These are
+//! the sole evaluation interface; the state-based methods above call them with
+//! the stored parameters as a 1 x p broadcast row.
 //! @{
-
-//! @brief Base-default parameter-aware leaves: ignore `parameters` and use
-//! object state. Parametric families override these with stateless math.
-inline Eigen::VectorXd
-AbstractBicop::pdf_raw(const Eigen::MatrixXd& u, const Eigen::MatrixXd&)
-{
-  return pdf_raw(u);
-}
-
-inline Eigen::VectorXd
-AbstractBicop::cdf(const Eigen::MatrixXd& u, const Eigen::MatrixXd&)
-{
-  return cdf(u);
-}
-
-inline Eigen::VectorXd
-AbstractBicop::hfunc1_raw(const Eigen::MatrixXd& u, const Eigen::MatrixXd&)
-{
-  return hfunc1_raw(u);
-}
-
-inline Eigen::VectorXd
-AbstractBicop::hfunc2_raw(const Eigen::MatrixXd& u, const Eigen::MatrixXd&)
-{
-  return hfunc2_raw(u);
-}
-
-inline Eigen::VectorXd
-AbstractBicop::hinv1_raw(const Eigen::MatrixXd& u, const Eigen::MatrixXd&)
-{
-  return hinv1_raw(u);
-}
-
-inline Eigen::VectorXd
-AbstractBicop::hinv2_raw(const Eigen::MatrixXd& u, const Eigen::MatrixXd&)
-{
-  return hinv2_raw(u);
-}
 
 inline Eigen::VectorXd
 AbstractBicop::pdf(const Eigen::MatrixXd& u, const Eigen::MatrixXd& parameters)
@@ -295,9 +264,9 @@ AbstractBicop::pdf_c_d(const Eigen::MatrixXd& u,
     udiff = (u.col(1) - u.col(3)).cwiseAbs();
   }
 
-  const bool bc = (parameters.cols() == 1);
+  const bool bc = (parameters.rows() == 1);
   for (Eigen::Index i = 0; i < u.rows(); i++) {
-    const Eigen::MatrixXd par_i = parameters.col(bc ? 0 : i);
+    const Eigen::MatrixXd par_i = parameters.row(bc ? 0 : i);
     if (udiff(i) > 5e-5) {
       if (var_types_[0] != "c") {
         pdf(i) =
@@ -323,9 +292,9 @@ AbstractBicop::pdf_d_d(const Eigen::MatrixXd& u,
   Eigen::MatrixXd umin = u.rightCols(2);
   Eigen::MatrixXd udiff = (umax - umin).cwiseAbs();
 
-  const bool bc = (parameters.cols() == 1);
+  const bool bc = (parameters.rows() == 1);
   for (Eigen::Index i = 0; i < u.rows(); i++) {
-    const Eigen::MatrixXd par_i = parameters.col(bc ? 0 : i);
+    const Eigen::MatrixXd par_i = parameters.row(bc ? 0 : i);
     // the difference quotient can be instable, use derivative if denominator
     // too small
     if (udiff.row(i).maxCoeff() < 5e-5) {
@@ -357,15 +326,15 @@ inline Eigen::VectorXd
 AbstractBicop::hfunc1(const Eigen::MatrixXd& u,
                       const Eigen::MatrixXd& parameters)
 {
-  if (var_types_[0] == "d" && u.cols() == 4) {
+  if (var_types_[0] == "d") {
     auto uu = u;
     uu.col(3) = uu.col(1);
     auto u1diff = (uu.col(0) - uu.col(2)).cwiseAbs();
     Eigen::VectorXd h(u.rows());
 
-    const bool bc = (parameters.cols() == 1);
+    const bool bc = (parameters.rows() == 1);
     for (Eigen::Index i = 0; i < u.rows(); i++) {
-      const Eigen::MatrixXd par_i = parameters.col(bc ? 0 : i);
+      const Eigen::MatrixXd par_i = parameters.row(bc ? 0 : i);
       if (std::abs(u1diff(i)) > 5e-5) {
         h(i) = cdf(uu.row(i).leftCols(2), par_i)(0) -
                cdf(uu.row(i).rightCols(2), par_i)(0);
@@ -385,15 +354,15 @@ inline Eigen::VectorXd
 AbstractBicop::hfunc2(const Eigen::MatrixXd& u,
                       const Eigen::MatrixXd& parameters)
 {
-  if (var_types_[1] == "d" && u.cols() == 4) {
+  if (var_types_[1] == "d") {
     auto uu = u;
     uu.col(2) = uu.col(0);
     auto u2diff = (uu.col(1) - uu.col(3)).cwiseAbs();
     Eigen::VectorXd h(u.rows());
 
-    const bool bc = (parameters.cols() == 1);
+    const bool bc = (parameters.rows() == 1);
     for (Eigen::Index i = 0; i < u.rows(); i++) {
-      const Eigen::MatrixXd par_i = parameters.col(bc ? 0 : i);
+      const Eigen::MatrixXd par_i = parameters.row(bc ? 0 : i);
       if (u2diff(i) > 5e-5) {
         h(i) = cdf(uu.row(i).leftCols(2), par_i)(0) -
                cdf(uu.row(i).rightCols(2), par_i)(0);
@@ -452,6 +421,32 @@ AbstractBicop::hinv2_num(const Eigen::MatrixXd& u,
   auto h1 = [&](const Eigen::VectorXd& x) {
     u_new.col(0) = x;
     return hfunc2(u_new, parameters);
+  };
+
+  return tools_eigen::invert_f(u.col(0), h1);
+}
+
+inline Eigen::VectorXd
+AbstractBicop::hinv1_num_raw(const Eigen::MatrixXd& u,
+                             const Eigen::MatrixXd& parameters)
+{
+  Eigen::MatrixXd u_new = u;
+  auto h1 = [&](const Eigen::VectorXd& v) {
+    u_new.col(1) = v;
+    return hfunc1_raw(u_new.leftCols(2), parameters);
+  };
+
+  return tools_eigen::invert_f(u.col(1), h1);
+}
+
+inline Eigen::VectorXd
+AbstractBicop::hinv2_num_raw(const Eigen::MatrixXd& u,
+                             const Eigen::MatrixXd& parameters)
+{
+  Eigen::MatrixXd u_new = u;
+  auto h1 = [&](const Eigen::VectorXd& x) {
+    u_new.col(0) = x;
+    return hfunc2_raw(u_new.leftCols(2), parameters);
   };
 
   return tools_eigen::invert_f(u.col(0), h1);

--- a/include/vinecopulib/bicop/implementation/archimedean.ipp
+++ b/include/vinecopulib/bicop/implementation/archimedean.ipp
@@ -23,12 +23,6 @@ namespace vinecopulib {
 //}
 
 inline Eigen::VectorXd
-ArchimedeanBicop::cdf(const Eigen::MatrixXd& u)
-{
-  return cdf(u, this->parameters_);
-}
-
-inline Eigen::VectorXd
 ArchimedeanBicop::cdf(const Eigen::MatrixXd& u,
                       const Eigen::MatrixXd& parameters)
 {
@@ -38,12 +32,6 @@ ArchimedeanBicop::cdf(const Eigen::MatrixXd& u,
     return generator_inv(generator(u1, par) + generator(u2, par), par);
   };
   return tools_eigen::binaryExpr_or_nan(u, parameters, f);
-}
-
-inline Eigen::VectorXd
-ArchimedeanBicop::hfunc1_raw(const Eigen::MatrixXd& u)
-{
-  return hfunc1_raw(u, this->parameters_);
 }
 
 inline Eigen::VectorXd
@@ -61,12 +49,6 @@ ArchimedeanBicop::hfunc1_raw(const Eigen::MatrixXd& u,
 }
 
 inline Eigen::VectorXd
-ArchimedeanBicop::hfunc2_raw(const Eigen::MatrixXd& u)
-{
-  return hfunc1_raw(tools_eigen::swap_cols(u));
-}
-
-inline Eigen::VectorXd
 ArchimedeanBicop::hfunc2_raw(const Eigen::MatrixXd& u,
                              const Eigen::MatrixXd& parameters)
 {
@@ -74,23 +56,10 @@ ArchimedeanBicop::hfunc2_raw(const Eigen::MatrixXd& u,
 }
 
 inline Eigen::VectorXd
-ArchimedeanBicop::hinv1_raw(const Eigen::MatrixXd& u)
-{
-  Eigen::VectorXd hinv = hinv1_num(u);
-  return hinv;
-}
-
-inline Eigen::VectorXd
 ArchimedeanBicop::hinv1_raw(const Eigen::MatrixXd& u,
                             const Eigen::MatrixXd& parameters)
 {
-  return hinv1_num(u, parameters);
-}
-
-inline Eigen::VectorXd
-ArchimedeanBicop::hinv2_raw(const Eigen::MatrixXd& u)
-{
-  return hinv1_raw(tools_eigen::swap_cols(u));
+  return hinv1_num_raw(u, parameters);
 }
 
 inline Eigen::VectorXd

--- a/include/vinecopulib/bicop/implementation/archimedean.ipp
+++ b/include/vinecopulib/bicop/implementation/archimedean.ipp
@@ -25,27 +25,52 @@ namespace vinecopulib {
 inline Eigen::VectorXd
 ArchimedeanBicop::cdf(const Eigen::MatrixXd& u)
 {
-  auto f = [this](const double& u1, const double& u2) {
-    return generator_inv(generator(u1) + generator(u2));
+  return cdf(u, this->parameters_);
+}
+
+inline Eigen::VectorXd
+ArchimedeanBicop::cdf(const Eigen::MatrixXd& u,
+                      const Eigen::MatrixXd& parameters)
+{
+  auto f = [this](const double& u1,
+                  const double& u2,
+                  const Eigen::Ref<const Eigen::VectorXd>& par) {
+    return generator_inv(generator(u1, par) + generator(u2, par), par);
   };
-  return tools_eigen::binaryExpr_or_nan(u, f);
+  return tools_eigen::binaryExpr_or_nan(u, parameters, f);
 }
 
 inline Eigen::VectorXd
 ArchimedeanBicop::hfunc1_raw(const Eigen::MatrixXd& u)
 {
-  auto f = [this](const double& u1, const double& u2) {
-    double temp = generator_inv(generator(u1) + generator(u2));
-    temp = generator_derivative(u1) / generator_derivative(temp);
+  return hfunc1_raw(u, this->parameters_);
+}
+
+inline Eigen::VectorXd
+ArchimedeanBicop::hfunc1_raw(const Eigen::MatrixXd& u,
+                             const Eigen::MatrixXd& parameters)
+{
+  auto f = [this](const double& u1,
+                  const double& u2,
+                  const Eigen::Ref<const Eigen::VectorXd>& par) {
+    double temp = generator_inv(generator(u1, par) + generator(u2, par), par);
+    temp = generator_derivative(u1, par) / generator_derivative(temp, par);
     return std::isnan(temp) ? u2 : std::min(temp, 1.0);
   };
-  return tools_eigen::binaryExpr_or_nan(u, f);
+  return tools_eigen::binaryExpr_or_nan(u, parameters, f);
 }
 
 inline Eigen::VectorXd
 ArchimedeanBicop::hfunc2_raw(const Eigen::MatrixXd& u)
 {
   return hfunc1_raw(tools_eigen::swap_cols(u));
+}
+
+inline Eigen::VectorXd
+ArchimedeanBicop::hfunc2_raw(const Eigen::MatrixXd& u,
+                             const Eigen::MatrixXd& parameters)
+{
+  return hfunc1_raw(tools_eigen::swap_cols(u), parameters);
 }
 
 inline Eigen::VectorXd
@@ -56,9 +81,23 @@ ArchimedeanBicop::hinv1_raw(const Eigen::MatrixXd& u)
 }
 
 inline Eigen::VectorXd
+ArchimedeanBicop::hinv1_raw(const Eigen::MatrixXd& u,
+                            const Eigen::MatrixXd& parameters)
+{
+  return hinv1_num(u, parameters);
+}
+
+inline Eigen::VectorXd
 ArchimedeanBicop::hinv2_raw(const Eigen::MatrixXd& u)
 {
   return hinv1_raw(tools_eigen::swap_cols(u));
+}
+
+inline Eigen::VectorXd
+ArchimedeanBicop::hinv2_raw(const Eigen::MatrixXd& u,
+                            const Eigen::MatrixXd& parameters)
+{
+  return hinv1_raw(tools_eigen::swap_cols(u), parameters);
 }
 
 inline Eigen::VectorXd

--- a/include/vinecopulib/bicop/implementation/bb1.ipp
+++ b/include/vinecopulib/bicop/implementation/bb1.ipp
@@ -37,16 +37,10 @@ Bb1Bicop::generator_derivative(
   const double& u,
   const Eigen::Ref<const Eigen::VectorXd>& parameters)
 {
-  double theta = double(parameters(0));
-  double delta = double(parameters(1));
+  double theta = parameters(0);
+  double delta = parameters(1);
   double res = -delta * theta * std::pow(u, -(1 + theta));
   return res * std::pow(std::pow(u, -theta) - 1, delta - 1);
-}
-
-inline Eigen::VectorXd
-Bb1Bicop::pdf_raw(const Eigen::MatrixXd& u)
-{
-  return pdf_raw(u, this->parameters_);
 }
 
 inline Eigen::VectorXd
@@ -55,8 +49,8 @@ Bb1Bicop::pdf_raw(const Eigen::MatrixXd& u, const Eigen::MatrixXd& parameters)
   auto f = [](const double& u1,
               const double& u2,
               const Eigen::Ref<const Eigen::VectorXd>& par) {
-    double theta = double(par(0));
-    double delta = double(par(1));
+    double theta = par(0);
+    double delta = par(1);
     double t1 = std::pow(u1, -theta);
     double t2 = t1 - 1.0;
     double t3 = std::pow(t2, delta);

--- a/include/vinecopulib/bicop/implementation/bb1.ipp
+++ b/include/vinecopulib/bicop/implementation/bb1.ipp
@@ -19,42 +19,44 @@ inline Bb1Bicop::Bb1Bicop()
 }
 
 inline double
-Bb1Bicop::generator(const double& u)
+Bb1Bicop::generator(const double& u,
+                    const Eigen::Ref<const Eigen::VectorXd>& parameters)
 {
-  return std::pow(std::pow(u, -parameters_(0)) - 1, parameters_(1));
+  return std::pow(std::pow(u, -parameters(0)) - 1, parameters(1));
 }
 
 inline double
-Bb1Bicop::generator_inv(const double& u)
+Bb1Bicop::generator_inv(const double& u,
+                        const Eigen::Ref<const Eigen::VectorXd>& parameters)
 {
-  return std::pow(std::pow(u, 1 / parameters_(1)) + 1, -1 / parameters_(0));
+  return std::pow(std::pow(u, 1 / parameters(1)) + 1, -1 / parameters(0));
 }
 
 inline double
-Bb1Bicop::generator_derivative(const double& u)
+Bb1Bicop::generator_derivative(
+  const double& u,
+  const Eigen::Ref<const Eigen::VectorXd>& parameters)
 {
-  double theta = double(parameters_(0));
-  double delta = double(parameters_(1));
+  double theta = double(parameters(0));
+  double delta = double(parameters(1));
   double res = -delta * theta * std::pow(u, -(1 + theta));
   return res * std::pow(std::pow(u, -theta) - 1, delta - 1);
 }
 
-// inline double Bb1Bicop::generator_derivative2(const double &u)
-//{
-//    double theta = double(parameters_(0));
-//    double delta = double(parameters_(1));
-//    double res = delta * theta * std::pow(std::pow(u, -theta) - 1, delta);
-//    res /= (std::pow(std::pow(u, theta) - 1, 2) * std::pow(u, 2));
-//    return res * (1 + delta * theta - (1 + theta) * std::pow(u, theta));
-//}
-
 inline Eigen::VectorXd
 Bb1Bicop::pdf_raw(const Eigen::MatrixXd& u)
 {
-  double theta = static_cast<double>(parameters_(0));
-  double delta = static_cast<double>(parameters_(1));
+  return pdf_raw(u, this->parameters_);
+}
 
-  auto f = [theta, delta](const double& u1, const double& u2) {
+inline Eigen::VectorXd
+Bb1Bicop::pdf_raw(const Eigen::MatrixXd& u, const Eigen::MatrixXd& parameters)
+{
+  auto f = [](const double& u1,
+              const double& u2,
+              const Eigen::Ref<const Eigen::VectorXd>& par) {
+    double theta = double(par(0));
+    double delta = double(par(1));
     double t1 = std::pow(u1, -theta);
     double t2 = t1 - 1.0;
     double t3 = std::pow(t2, delta);
@@ -87,7 +89,7 @@ Bb1Bicop::pdf_raw(const Eigen::MatrixXd& u)
            t13 * t3 * t38 * t17 * t33 * t20 * t6 * delta * t59 +
            t25 * t3 * t39 * t36 * t6 * t59;
   };
-  return tools_eigen::binaryExpr_or_nan(u, f);
+  return tools_eigen::binaryExpr_or_nan(u, parameters, f);
 }
 
 inline double

--- a/include/vinecopulib/bicop/implementation/bb6.ipp
+++ b/include/vinecopulib/bicop/implementation/bb6.ipp
@@ -41,17 +41,11 @@ Bb6Bicop::generator_derivative(
   const double& u,
   const Eigen::Ref<const Eigen::VectorXd>& parameters)
 {
-  double theta = double(parameters(0));
-  double delta = double(parameters(1));
+  double theta = parameters(0);
+  double delta = parameters(1);
   double res = tools_stl::log1p(-std::pow(1 - u, theta));
   res = delta * theta * std::pow((-1) * res, delta - 1);
   return res * std::pow(1 - u, theta - 1) / (std::pow(1 - u, theta) - 1);
-}
-
-inline Eigen::VectorXd
-Bb6Bicop::pdf_raw(const Eigen::MatrixXd& u)
-{
-  return pdf_raw(u, this->parameters_);
 }
 
 inline Eigen::VectorXd
@@ -60,8 +54,8 @@ Bb6Bicop::pdf_raw(const Eigen::MatrixXd& u, const Eigen::MatrixXd& parameters)
   auto f = [](const double& u1,
               const double& u2,
               const Eigen::Ref<const Eigen::VectorXd>& par) {
-    double theta = double(par(0));
-    double delta = double(par(1));
+    double theta = par(0);
+    double delta = par(1);
     double t12 = 1 / delta;
     double t16 = 1 / theta;
     double t32 = delta - 1.0;

--- a/include/vinecopulib/bicop/implementation/bb6.ipp
+++ b/include/vinecopulib/bicop/implementation/bb6.ipp
@@ -21,56 +21,53 @@ inline Bb6Bicop::Bb6Bicop()
 }
 
 inline double
-Bb6Bicop::generator(const double& u)
+Bb6Bicop::generator(const double& u,
+                    const Eigen::Ref<const Eigen::VectorXd>& parameters)
 {
-  double res = tools_stl::log1p(-std::pow(1 - u, parameters_(0)));
-  return std::pow((-1) * res, parameters_(1));
+  double res = tools_stl::log1p(-std::pow(1 - u, parameters(0)));
+  return std::pow((-1) * res, parameters(1));
 }
 
 inline double
-Bb6Bicop::generator_inv(const double& u)
+Bb6Bicop::generator_inv(const double& u,
+                        const Eigen::Ref<const Eigen::VectorXd>& parameters)
 {
-  double res = std::expm1(-std::pow(u, 1 / parameters_(1)));
-  return 1 - std::pow(-res, 1 / parameters_(0));
+  double res = std::expm1(-std::pow(u, 1 / parameters(1)));
+  return 1 - std::pow(-res, 1 / parameters(0));
 }
 
 inline double
-Bb6Bicop::generator_derivative(const double& u)
+Bb6Bicop::generator_derivative(
+  const double& u,
+  const Eigen::Ref<const Eigen::VectorXd>& parameters)
 {
-  double theta = double(parameters_(0));
-  double delta = double(parameters_(1));
+  double theta = double(parameters(0));
+  double delta = double(parameters(1));
   double res = tools_stl::log1p(-std::pow(1 - u, theta));
   res = delta * theta * std::pow((-1) * res, delta - 1);
   return res * std::pow(1 - u, theta - 1) / (std::pow(1 - u, theta) - 1);
 }
 
-// inline double Bb6Bicop::generator_derivative2(const double &u)
-//{
-//    double theta = double(parameters_(0));
-//    double delta = double(parameters_(1));
-//    double tmp = std::pow(1 - u, theta);
-//    double tmp2 = tools_stl::log1p(-tmp);
-//    double res = std::pow((-1) * tmp2, delta - 2);
-//    res *= ((delta - 1) * theta * tmp - (tmp + theta - 1) * tmp2);
-//    return res * delta * theta * std::pow(1 - u, theta - 2) /
-//           std::pow(tmp - 1, 2);
-//}
-
 inline Eigen::VectorXd
 Bb6Bicop::pdf_raw(const Eigen::MatrixXd& u)
 {
-  double theta = static_cast<double>(parameters_(0));
-  double delta = static_cast<double>(parameters_(1));
+  return pdf_raw(u, this->parameters_);
+}
 
-  double t12 = 1 / delta;
-  double t16 = 1 / theta;
-  double t32 = delta - 1.0;
-  double t38 = 2.0 * delta;
-  double t39 = -1.0 + t38;
-  double t47 = 3.0 * delta - 1.0;
-
-  auto f = [theta, delta, t12, t16, t32, t38, t39, t47](const double& u1,
-                                                        const double& u2) {
+inline Eigen::VectorXd
+Bb6Bicop::pdf_raw(const Eigen::MatrixXd& u, const Eigen::MatrixXd& parameters)
+{
+  auto f = [](const double& u1,
+              const double& u2,
+              const Eigen::Ref<const Eigen::VectorXd>& par) {
+    double theta = double(par(0));
+    double delta = double(par(1));
+    double t12 = 1 / delta;
+    double t16 = 1 / theta;
+    double t32 = delta - 1.0;
+    double t38 = 2.0 * delta;
+    double t39 = -1.0 + t38;
+    double t47 = 3.0 * delta - 1.0;
     double t1 = 1.0 - u1;
     double t2 = std::pow(t1, theta);
     double t3 = 1.0 - t2;
@@ -110,7 +107,7 @@ Bb6Bicop::pdf_raw(const Eigen::MatrixXd& u)
            t80 * t7 * t2 / t3 / t8 / t87 / (t90 + 2.0 * t5 * t10 + t93) / t1 /
            t6;
   };
-  return tools_eigen::binaryExpr_or_nan(u, f);
+  return tools_eigen::binaryExpr_or_nan(u, parameters, f);
 }
 
 inline double

--- a/include/vinecopulib/bicop/implementation/bb7.ipp
+++ b/include/vinecopulib/bicop/implementation/bb7.ipp
@@ -23,8 +23,8 @@ inline double
 Bb7Bicop::generator(const double& u,
                     const Eigen::Ref<const Eigen::VectorXd>& parameters)
 {
-  double theta = double(parameters(0));
-  double delta = double(parameters(1));
+  double theta = parameters(0);
+  double delta = parameters(1);
   return std::pow(1 - std::pow(1 - u, theta), -delta) - 1;
 }
 
@@ -32,8 +32,8 @@ inline double
 Bb7Bicop::generator_inv(const double& u,
                         const Eigen::Ref<const Eigen::VectorXd>& parameters)
 {
-  double theta = double(parameters(0));
-  double delta = double(parameters(1));
+  double theta = parameters(0);
+  double delta = parameters(1);
   return 1 - std::pow(1 - std::pow(1 + u, -1 / delta), 1 / theta);
 }
 
@@ -42,16 +42,10 @@ Bb7Bicop::generator_derivative(
   const double& u,
   const Eigen::Ref<const Eigen::VectorXd>& parameters)
 {
-  double theta = double(parameters(0));
-  double delta = double(parameters(1));
+  double theta = parameters(0);
+  double delta = parameters(1);
   double res = delta * theta * std::pow(1 - std::pow(1 - u, theta), -1 - delta);
   return -res * std::pow(1 - u, theta - 1);
-}
-
-inline Eigen::VectorXd
-Bb7Bicop::pdf_raw(const Eigen::MatrixXd& u)
-{
-  return pdf_raw(u, this->parameters_);
 }
 
 inline Eigen::VectorXd
@@ -60,8 +54,8 @@ Bb7Bicop::pdf_raw(const Eigen::MatrixXd& u, const Eigen::MatrixXd& parameters)
   auto f = [](const double& u1,
               const double& u2,
               const Eigen::Ref<const Eigen::VectorXd>& par) {
-    double theta = double(par(0));
-    double delta = double(par(1));
+    double theta = par(0);
+    double delta = par(1);
     constexpr double dbl_min = std::numeric_limits<double>::min();
     double t1 = std::max(1.0 - u1, dbl_min);
     double t2 = std::pow(t1, theta);

--- a/include/vinecopulib/bicop/implementation/bb7.ipp
+++ b/include/vinecopulib/bicop/implementation/bb7.ipp
@@ -20,47 +20,48 @@ inline Bb7Bicop::Bb7Bicop()
 }
 
 inline double
-Bb7Bicop::generator(const double& u)
+Bb7Bicop::generator(const double& u,
+                    const Eigen::Ref<const Eigen::VectorXd>& parameters)
 {
-  double theta = double(parameters_(0));
-  double delta = double(parameters_(1));
+  double theta = double(parameters(0));
+  double delta = double(parameters(1));
   return std::pow(1 - std::pow(1 - u, theta), -delta) - 1;
 }
 
 inline double
-Bb7Bicop::generator_inv(const double& u)
+Bb7Bicop::generator_inv(const double& u,
+                        const Eigen::Ref<const Eigen::VectorXd>& parameters)
 {
-  double theta = double(parameters_(0));
-  double delta = double(parameters_(1));
+  double theta = double(parameters(0));
+  double delta = double(parameters(1));
   return 1 - std::pow(1 - std::pow(1 + u, -1 / delta), 1 / theta);
 }
 
 inline double
-Bb7Bicop::generator_derivative(const double& u)
+Bb7Bicop::generator_derivative(
+  const double& u,
+  const Eigen::Ref<const Eigen::VectorXd>& parameters)
 {
-  double theta = double(parameters_(0));
-  double delta = double(parameters_(1));
+  double theta = double(parameters(0));
+  double delta = double(parameters(1));
   double res = delta * theta * std::pow(1 - std::pow(1 - u, theta), -1 - delta);
   return -res * std::pow(1 - u, theta - 1);
 }
 
-// inline double Bb7Bicop::generator_derivative2(const double &u)
-//{
-//    double theta = double(parameters_(0));
-//    double delta = double(parameters_(1));
-//    double tmp = std::pow(1 - u, theta);
-//    double res = delta * theta * std::pow(1 - tmp, -2 - delta) *
-//                 std::pow(1 - u, theta - 2);
-//    return res * (theta - 1 + (1 + delta * theta) * tmp);
-//}
-
 inline Eigen::VectorXd
 Bb7Bicop::pdf_raw(const Eigen::MatrixXd& u)
 {
-  double theta = static_cast<double>(parameters_(0));
-  double delta = static_cast<double>(parameters_(1));
+  return pdf_raw(u, this->parameters_);
+}
 
-  auto f = [theta, delta](const double& u1, const double& u2) {
+inline Eigen::VectorXd
+Bb7Bicop::pdf_raw(const Eigen::MatrixXd& u, const Eigen::MatrixXd& parameters)
+{
+  auto f = [](const double& u1,
+              const double& u2,
+              const Eigen::Ref<const Eigen::VectorXd>& par) {
+    double theta = double(par(0));
+    double delta = double(par(1));
     constexpr double dbl_min = std::numeric_limits<double>::min();
     double t1 = std::max(1.0 - u1, dbl_min);
     double t2 = std::pow(t1, theta);
@@ -95,7 +96,7 @@ Bb7Bicop::pdf_raw(const Eigen::MatrixXd& u)
            t35 * t4 * t30 * t31 * t24 * t42 * t8 * delta * t54 +
            t16 * t4 * t32 * t27 * t8 * t54;
   };
-  return tools_eigen::binaryExpr_or_nan(u, f);
+  return tools_eigen::binaryExpr_or_nan(u, parameters, f);
 }
 
 inline double

--- a/include/vinecopulib/bicop/implementation/bb8.ipp
+++ b/include/vinecopulib/bicop/implementation/bb8.ipp
@@ -23,8 +23,8 @@ inline double
 Bb8Bicop::generator(const double& u,
                     const Eigen::Ref<const Eigen::VectorXd>& parameters)
 {
-  double theta = double(parameters(0));
-  double delta = double(parameters(1));
+  double theta = parameters(0);
+  double delta = parameters(1);
   double res = (1 - std::pow(1 - delta * u, theta));
   return -std::log(res / (1 - std::pow(1 - delta, theta)));
 }
@@ -33,8 +33,8 @@ inline double
 Bb8Bicop::generator_inv(const double& u,
                         const Eigen::Ref<const Eigen::VectorXd>& parameters)
 {
-  double theta = double(parameters(0));
-  double delta = double(parameters(1));
+  double theta = parameters(0);
+  double delta = parameters(1);
   double res = std::exp(-u) * (std::pow(1 - delta, theta) - 1);
   return (1 - std::pow(1 + res, 1 / theta)) / delta;
 }
@@ -44,16 +44,10 @@ Bb8Bicop::generator_derivative(
   const double& u,
   const Eigen::Ref<const Eigen::VectorXd>& parameters)
 {
-  double theta = double(parameters(0));
-  double delta = double(parameters(1));
+  double theta = parameters(0);
+  double delta = parameters(1);
   double res = delta * theta * std::pow(1 - delta * u, theta - 1);
   return -res / (1 - std::pow(1 - delta * u, theta));
-}
-
-inline Eigen::VectorXd
-Bb8Bicop::pdf_raw(const Eigen::MatrixXd& u)
-{
-  return pdf_raw(u, this->parameters_);
 }
 
 inline Eigen::VectorXd
@@ -62,8 +56,8 @@ Bb8Bicop::pdf_raw(const Eigen::MatrixXd& u, const Eigen::MatrixXd& parameters)
   auto f = [](const double& u1,
               const double& u2,
               const Eigen::Ref<const Eigen::VectorXd>& par) {
-    double theta = double(par(0));
-    double delta = double(par(1));
+    double theta = par(0);
+    double delta = par(1);
     double t10 = 1.0 - delta;
     double t16 = 1.0 / theta;
     double t38 = 2.0 * theta;

--- a/include/vinecopulib/bicop/implementation/bb8.ipp
+++ b/include/vinecopulib/bicop/implementation/bb8.ipp
@@ -20,56 +20,55 @@ inline Bb8Bicop::Bb8Bicop()
 }
 
 inline double
-Bb8Bicop::generator(const double& u)
+Bb8Bicop::generator(const double& u,
+                    const Eigen::Ref<const Eigen::VectorXd>& parameters)
 {
-  double theta = double(parameters_(0));
-  double delta = double(parameters_(1));
+  double theta = double(parameters(0));
+  double delta = double(parameters(1));
   double res = (1 - std::pow(1 - delta * u, theta));
   return -std::log(res / (1 - std::pow(1 - delta, theta)));
 }
 
 inline double
-Bb8Bicop::generator_inv(const double& u)
+Bb8Bicop::generator_inv(const double& u,
+                        const Eigen::Ref<const Eigen::VectorXd>& parameters)
 {
-  double theta = double(parameters_(0));
-  double delta = double(parameters_(1));
+  double theta = double(parameters(0));
+  double delta = double(parameters(1));
   double res = std::exp(-u) * (std::pow(1 - delta, theta) - 1);
   return (1 - std::pow(1 + res, 1 / theta)) / delta;
 }
 
 inline double
-Bb8Bicop::generator_derivative(const double& u)
+Bb8Bicop::generator_derivative(
+  const double& u,
+  const Eigen::Ref<const Eigen::VectorXd>& parameters)
 {
-  double theta = double(parameters_(0));
-  double delta = double(parameters_(1));
+  double theta = double(parameters(0));
+  double delta = double(parameters(1));
   double res = delta * theta * std::pow(1 - delta * u, theta - 1);
   return -res / (1 - std::pow(1 - delta * u, theta));
 }
 
-// inline double Bb8Bicop::generator_derivative2(const double &u)
-//{
-//    double theta = double(parameters_(0));
-//    double delta = double(parameters_(1));
-//    double tmp = std::pow(1 - delta * u, theta);
-//    double res =
-//        std::pow(delta, 2) * theta * std::pow(1 - delta * u, theta - 2);
-//    return res * (theta - 1 + tmp) / std::pow(tmp - 1, 2);
-//}
-
 inline Eigen::VectorXd
 Bb8Bicop::pdf_raw(const Eigen::MatrixXd& u)
 {
-  double theta = static_cast<double>(parameters_(0));
-  double delta = static_cast<double>(parameters_(1));
+  return pdf_raw(u, this->parameters_);
+}
 
-  double t10 = 1.0 - delta;
-  double t16 = 1.0 / theta;
-  double t38 = 2.0 * theta;
-  double t39 = std::pow(t10, t38);
-  double t59 = std::pow(t10, 3.0 * theta);
-
-  auto f = [theta, delta, t10, t16, t38, t39, t59](const double& u1,
-                                                   const double& u2) {
+inline Eigen::VectorXd
+Bb8Bicop::pdf_raw(const Eigen::MatrixXd& u, const Eigen::MatrixXd& parameters)
+{
+  auto f = [](const double& u1,
+              const double& u2,
+              const Eigen::Ref<const Eigen::VectorXd>& par) {
+    double theta = double(par(0));
+    double delta = double(par(1));
+    double t10 = 1.0 - delta;
+    double t16 = 1.0 / theta;
+    double t38 = 2.0 * theta;
+    double t39 = std::pow(t10, t38);
+    double t59 = std::pow(t10, 3.0 * theta);
     double t2 = 1.0 - delta * u1;
     double t3 = std::pow(t2, theta);
     double t11 = std::pow(t10, theta);
@@ -94,7 +93,7 @@ Bb8Bicop::pdf_raw(const Eigen::MatrixXd& u)
 
     return -delta * t29 * t62 / t6 / t2 / t67 / t69;
   };
-  return tools_eigen::binaryExpr_or_nan(u, f);
+  return tools_eigen::binaryExpr_or_nan(u, parameters, f);
 }
 
 inline double

--- a/include/vinecopulib/bicop/implementation/class.ipp
+++ b/include/vinecopulib/bicop/implementation/class.ipp
@@ -4,13 +4,16 @@
 // the MIT license. For a copy, see the LICENSE file in the root directory of
 // vinecopulib or https://vinecopulib.github.io/vinecopulib/.
 
+#include <functional>
 #include <mutex>
 #include <vinecopulib/bicop/abstract.hpp>
 #include <vinecopulib/bicop/tools_select.hpp>
+#include <vinecopulib/misc/tools_batch.hpp>
 #include <vinecopulib/misc/tools_interface.hpp>
 #include <vinecopulib/misc/tools_serialization.hpp>
 #include <vinecopulib/misc/tools_stats.hpp>
 #include <vinecopulib/misc/tools_stl.hpp>
+#include <vinecopulib/misc/tools_thread.hpp>
 
 //! Tools for bivariate and vine copula modeling
 namespace vinecopulib {
@@ -393,6 +396,296 @@ Bicop::hinv2(const Eigen::MatrixXd& u) const
   return hi;
 }
 //! @}
+
+//! @name Stats methods with per-row parameters
+//!
+//! @details These overloads evaluate the copula at a *different* parameter set
+//! per row of `u`, in a single call, without mutating the object's stored
+//! parameters. The family, rotation, and variable types are taken from the
+//! object; only the parameter values vary by row. They are available for
+//! parametric families only (nonparametric families store an interpolation
+//! grid rather than a per-observation parameter vector).
+//!
+//! @param u An \f$ n \times (2 + k) \f$ matrix of observations (see the
+//!   single-argument overloads for the layout with discrete variables).
+//! @param parameters An \f$ n \times p \f$ matrix of parameters, where `p` is
+//!   the number of family parameters (`get_parameters().size()`) and row `i`
+//!   holds the parameter set used for row `i` of `u`. Parameters are given in
+//!   the family's natural (unrotated) parameterization, as for
+//!   `get_parameters()`.
+//! @param num_threads The number of threads to parallelize the evaluation over
+//!   rows.
+//! @{
+
+//! @brief Evaluates the copula density with per-row parameters.
+inline Eigen::VectorXd
+Bicop::pdf(const Eigen::MatrixXd& u,
+           const Eigen::MatrixXd& parameters,
+           const size_t num_threads) const
+{
+  Eigen::MatrixXd par_t = format_parameters(u, parameters);
+  return eval_in_batches(u,
+                         par_t,
+                         num_threads,
+                         [this](const Eigen::MatrixXd& ub,
+                                const Eigen::MatrixXd& pb) -> Eigen::VectorXd {
+                           return bicop_->pdf(prep_for_abstract(ub), pb);
+                         });
+}
+
+//! @brief Evaluates the copula distribution with per-row parameters.
+inline Eigen::VectorXd
+Bicop::cdf(const Eigen::MatrixXd& u,
+           const Eigen::MatrixXd& parameters,
+           const size_t num_threads) const
+{
+  Eigen::MatrixXd par_t = format_parameters(u, parameters);
+  return eval_in_batches(
+    u,
+    par_t,
+    num_threads,
+    [this](const Eigen::MatrixXd& ub,
+           const Eigen::MatrixXd& pb) -> Eigen::VectorXd {
+      Eigen::VectorXd p = bicop_->cdf(prep_for_abstract(ub).leftCols(2), pb);
+      switch (rotation_) {
+        case 90:
+          return ub.col(1) - p;
+        case 180:
+          return (p.array() - 1 + ub.leftCols(2).rowwise().sum().array())
+            .matrix();
+        case 270:
+          return ub.col(0) - p;
+        default:
+          return p;
+      }
+    });
+}
+
+//! @brief Evaluates the first h-function with per-row parameters.
+inline Eigen::VectorXd
+Bicop::hfunc1(const Eigen::MatrixXd& u,
+              const Eigen::MatrixXd& parameters,
+              const size_t num_threads) const
+{
+  Eigen::MatrixXd par_t = format_parameters(u, parameters);
+  return eval_in_batches(
+    u,
+    par_t,
+    num_threads,
+    [this](const Eigen::MatrixXd& ub,
+           const Eigen::MatrixXd& pb) -> Eigen::VectorXd {
+      Eigen::VectorXd h(ub.rows());
+      switch (rotation_) {
+        case 90:
+          h = bicop_->hfunc2(prep_for_abstract(ub), pb);
+          break;
+        case 180:
+          h = 1.0 - bicop_->hfunc1(prep_for_abstract(ub), pb).array();
+          break;
+        case 270:
+          h = 1.0 - bicop_->hfunc2(prep_for_abstract(ub), pb).array();
+          break;
+        default:
+          h = bicop_->hfunc1(prep_for_abstract(ub), pb);
+          break;
+      }
+      tools_eigen::trim(h, 0.0, 1.0);
+      return h;
+    });
+}
+
+//! @brief Evaluates the second h-function with per-row parameters.
+inline Eigen::VectorXd
+Bicop::hfunc2(const Eigen::MatrixXd& u,
+              const Eigen::MatrixXd& parameters,
+              const size_t num_threads) const
+{
+  Eigen::MatrixXd par_t = format_parameters(u, parameters);
+  return eval_in_batches(
+    u,
+    par_t,
+    num_threads,
+    [this](const Eigen::MatrixXd& ub,
+           const Eigen::MatrixXd& pb) -> Eigen::VectorXd {
+      Eigen::VectorXd h(ub.rows());
+      switch (rotation_) {
+        case 90:
+          h = 1.0 - bicop_->hfunc1(prep_for_abstract(ub), pb).array();
+          break;
+        case 180:
+          h = 1.0 - bicop_->hfunc2(prep_for_abstract(ub), pb).array();
+          break;
+        case 270:
+          h = bicop_->hfunc1(prep_for_abstract(ub), pb);
+          break;
+        default:
+          h = bicop_->hfunc2(prep_for_abstract(ub), pb);
+          break;
+      }
+      tools_eigen::trim(h, 0.0, 1.0);
+      return h;
+    });
+}
+
+//! @brief Evaluates the inverse of the first h-function with per-row
+//! parameters.
+inline Eigen::VectorXd
+Bicop::hinv1(const Eigen::MatrixXd& u,
+             const Eigen::MatrixXd& parameters,
+             const size_t num_threads) const
+{
+  Eigen::MatrixXd par_t = format_parameters(u, parameters);
+  return eval_in_batches(
+    u,
+    par_t,
+    num_threads,
+    [this](const Eigen::MatrixXd& ub,
+           const Eigen::MatrixXd& pb) -> Eigen::VectorXd {
+      Eigen::VectorXd hi(ub.rows());
+      switch (rotation_) {
+        case 90:
+          hi = bicop_->hinv2(prep_for_abstract(ub), pb);
+          break;
+        case 180:
+          hi = 1.0 - bicop_->hinv1(prep_for_abstract(ub), pb).array();
+          break;
+        case 270:
+          hi = 1.0 - bicop_->hinv2(prep_for_abstract(ub), pb).array();
+          break;
+        default:
+          hi = bicop_->hinv1(prep_for_abstract(ub), pb);
+          break;
+      }
+      tools_eigen::trim(hi, 0.0, 1.0);
+      return hi;
+    });
+}
+
+//! @brief Evaluates the inverse of the second h-function with per-row
+//! parameters.
+inline Eigen::VectorXd
+Bicop::hinv2(const Eigen::MatrixXd& u,
+             const Eigen::MatrixXd& parameters,
+             const size_t num_threads) const
+{
+  Eigen::MatrixXd par_t = format_parameters(u, parameters);
+  return eval_in_batches(
+    u,
+    par_t,
+    num_threads,
+    [this](const Eigen::MatrixXd& ub,
+           const Eigen::MatrixXd& pb) -> Eigen::VectorXd {
+      Eigen::VectorXd hi(ub.rows());
+      switch (rotation_) {
+        case 90:
+          hi = 1.0 - bicop_->hinv1(prep_for_abstract(ub), pb).array();
+          break;
+        case 180:
+          hi = 1.0 - bicop_->hinv2(prep_for_abstract(ub), pb).array();
+          break;
+        case 270:
+          hi = bicop_->hinv1(prep_for_abstract(ub), pb);
+          break;
+        default:
+          hi = bicop_->hinv2(prep_for_abstract(ub), pb);
+          break;
+      }
+      tools_eigen::trim(hi, 0.0, 1.0);
+      return hi;
+    });
+}
+
+//! @brief Evaluates the log-likelihood contributions with per-row parameters
+//! and returns their sum (NaNs are ignored).
+inline double
+Bicop::loglik(const Eigen::MatrixXd& u,
+              const Eigen::MatrixXd& parameters,
+              const size_t num_threads) const
+{
+  Eigen::VectorXd lpdf = pdf(u, parameters, num_threads).array().log();
+  double ll = 0.0;
+  for (Eigen::Index i = 0; i < lpdf.size(); ++i) {
+    if (!(std::isnan)(lpdf(i))) {
+      ll += lpdf(i);
+    }
+  }
+  return ll;
+}
+//! @}
+
+//! @brief Validates per-row parameters and returns them transposed to the
+//! internal `p x n` layout (one column per observation).
+inline Eigen::MatrixXd
+Bicop::format_parameters(const Eigen::MatrixXd& u,
+                         const Eigen::MatrixXd& parameters) const
+{
+  check_data(u);
+  if (!tools_stl::is_member(get_family(), bicop_families::parametric)) {
+    throw std::runtime_error(
+      "per-row parameters are only supported for parametric families; "
+      "nonparametric families store an interpolation grid rather than a "
+      "per-observation parameter vector.");
+  }
+  const Eigen::Index n = u.rows();
+  const Eigen::Index p = get_parameters().rows();
+  if (parameters.rows() != n) {
+    throw std::runtime_error("parameters must have one row per row of u "
+                             "(parameters.rows() must equal u.rows()).");
+  }
+  if (parameters.cols() != p) {
+    std::stringstream msg;
+    msg << "parameters has wrong number of columns; expected " << p
+        << " (the number of family parameters), actual " << parameters.cols()
+        << ".";
+    throw std::runtime_error(msg.str());
+  }
+  if (!parameters.allFinite()) {
+    throw std::runtime_error("parameters must not contain NaN or Inf.");
+  }
+  if (p > 0 && n > 0) {
+    Eigen::MatrixXd lb = get_parameters_lower_bounds();
+    Eigen::MatrixXd ub = get_parameters_upper_bounds();
+    for (Eigen::Index k = 0; k < p; ++k) {
+      if (parameters.col(k).minCoeff() < lb(k) ||
+          parameters.col(k).maxCoeff() > ub(k)) {
+        std::stringstream msg;
+        msg << "parameter " << k << " is out of bounds [" << lb(k) << ", "
+            << ub(k) << "].";
+        throw std::runtime_error(msg.str());
+      }
+    }
+  }
+  return parameters.transpose();
+}
+
+//! @brief Evaluates `f` over row-batches of `u`/`parameters_t`, possibly in
+//! parallel, and assembles the results.
+inline Eigen::VectorXd
+Bicop::eval_in_batches(
+  const Eigen::MatrixXd& u,
+  const Eigen::MatrixXd& parameters_t,
+  const size_t num_threads,
+  const std::function<Eigen::VectorXd(const Eigen::MatrixXd&,
+                                      const Eigen::MatrixXd&)>& f) const
+{
+  const size_t n = static_cast<size_t>(u.rows());
+  Eigen::VectorXd out(n);
+  if (n == 0) {
+    return out;
+  }
+  auto do_batch = [&](const tools_batch::Batch& b) {
+    out.segment(b.begin, b.size) = f(u.middleRows(b.begin, b.size),
+                                     parameters_t.middleCols(b.begin, b.size));
+  };
+  if (num_threads <= 1) {
+    do_batch(tools_batch::Batch{ 0, n });
+  } else {
+    tools_thread::ThreadPool pool(num_threads);
+    pool.map(do_batch, tools_batch::create_batches(n, num_threads));
+    pool.join();
+  }
+  return out;
+}
 
 //! @brief Simulates from a bivariate copula.
 //!

--- a/include/vinecopulib/bicop/implementation/class.ipp
+++ b/include/vinecopulib/bicop/implementation/class.ipp
@@ -613,8 +613,8 @@ Bicop::loglik(const Eigen::MatrixXd& u,
 }
 //! @}
 
-//! @brief Validates per-row parameters and returns them transposed to the
-//! internal `p x n` layout (one column per observation).
+//! @brief Validates per-row parameters (the internal leaves use the same
+//! `n x p` layout as the public API, one parameter set per row).
 inline Eigen::MatrixXd
 Bicop::format_parameters(const Eigen::MatrixXd& u,
                          const Eigen::MatrixXd& parameters) const
@@ -655,15 +655,15 @@ Bicop::format_parameters(const Eigen::MatrixXd& u,
       }
     }
   }
-  return parameters.transpose();
+  return parameters;
 }
 
-//! @brief Evaluates `f` over row-batches of `u`/`parameters_t`, possibly in
+//! @brief Evaluates `f` over row-batches of `u`/`parameters`, possibly in
 //! parallel, and assembles the results.
 inline Eigen::VectorXd
 Bicop::eval_in_batches(
   const Eigen::MatrixXd& u,
-  const Eigen::MatrixXd& parameters_t,
+  const Eigen::MatrixXd& parameters,
   const size_t num_threads,
   const std::function<Eigen::VectorXd(const Eigen::MatrixXd&,
                                       const Eigen::MatrixXd&)>& f) const
@@ -674,8 +674,8 @@ Bicop::eval_in_batches(
     return out;
   }
   auto do_batch = [&](const tools_batch::Batch& b) {
-    out.segment(b.begin, b.size) = f(u.middleRows(b.begin, b.size),
-                                     parameters_t.middleCols(b.begin, b.size));
+    out.segment(b.begin, b.size) =
+      f(u.middleRows(b.begin, b.size), parameters.middleRows(b.begin, b.size));
   };
   if (num_threads <= 1) {
     do_batch(tools_batch::Batch{ 0, n });

--- a/include/vinecopulib/bicop/implementation/class.ipp
+++ b/include/vinecopulib/bicop/implementation/class.ipp
@@ -204,7 +204,8 @@ inline Eigen::VectorXd
 Bicop::cdf(const Eigen::MatrixXd& u) const
 {
   check_data(u);
-  Eigen::VectorXd p = bicop_->cdf(prep_for_abstract(u).leftCols(2));
+  Eigen::VectorXd p = bicop_->cdf(prep_for_abstract(u).leftCols(2),
+                                  bicop_->get_parameters().transpose());
   switch (rotation_) {
     default:
       return p;

--- a/include/vinecopulib/bicop/implementation/clayton.ipp
+++ b/include/vinecopulib/bicop/implementation/clayton.ipp
@@ -19,66 +19,78 @@ inline ClaytonBicop::ClaytonBicop()
 }
 
 inline double
-ClaytonBicop::generator(const double& u)
+ClaytonBicop::generator(const double& u,
+                        const Eigen::Ref<const Eigen::VectorXd>& parameters)
 {
-  double theta = double(this->parameters_(0));
+  double theta = double(parameters(0));
   return (std::pow(u, -theta) - 1) / theta;
 }
 
 inline double
-ClaytonBicop::generator_inv(const double& u)
+ClaytonBicop::generator_inv(const double& u,
+                            const Eigen::Ref<const Eigen::VectorXd>& parameters)
 {
-  double theta = double(this->parameters_(0));
+  double theta = double(parameters(0));
   return std::pow(1 + theta * u, -1 / theta);
 }
 
 inline double
-ClaytonBicop::generator_derivative(const double& u)
+ClaytonBicop::generator_derivative(
+  const double& u,
+  const Eigen::Ref<const Eigen::VectorXd>& parameters)
 {
-  return (-1) * std::pow(u, -1 - this->parameters_(0));
+  return (-1) * std::pow(u, -1 - parameters(0));
 }
-
-// inline double ClaytonBicop::generator_derivative2(const double &u)
-//{
-//    double theta = double(this->parameters_(0));
-//    return (1 + theta) * std::pow(u, -2 - theta);
-//}
 
 inline Eigen::VectorXd
 ClaytonBicop::pdf_raw(const Eigen::MatrixXd& u)
 {
-  double theta = static_cast<double>(parameters_(0));
-  // avoid numerical issues when copula is too close to independence
-  if (theta < 1e-10) {
-    auto f = [](const double&, const double&) { return 1.0; };
-    return tools_eigen::binaryExpr_or_nan(u, f);
-  }
+  return pdf_raw(u, this->parameters_);
+}
 
-  auto f = [theta](const double& u1, const double& u2) {
+inline Eigen::VectorXd
+ClaytonBicop::pdf_raw(const Eigen::MatrixXd& u,
+                      const Eigen::MatrixXd& parameters)
+{
+  auto f = [](const double& u1,
+              const double& u2,
+              const Eigen::Ref<const Eigen::VectorXd>& par) {
+    double theta = double(par(0));
+    // avoid numerical issues when copula is too close to independence
+    if (theta < 1e-10) {
+      return 1.0;
+    }
     double temp = std::log1p(theta) - (1.0 + theta) * std::log(u1 * u2);
     temp = temp - (2.0 + 1.0 / (theta)) *
                     std::log(std::pow(u1, -theta) + std::pow(u2, -theta) - 1.0);
     return std::exp(temp);
   };
-  return tools_eigen::binaryExpr_or_nan(u, f);
+  return tools_eigen::binaryExpr_or_nan(u, parameters, f);
 }
 
 inline Eigen::VectorXd
 ClaytonBicop::hinv1_raw(const Eigen::MatrixXd& u)
 {
-  double theta = double(this->parameters_(0));
-  Eigen::VectorXd hinv = u.col(0).array().pow(theta + 1.0);
-  if (theta < 75) {
-    hinv = u.col(1).cwiseProduct(hinv);
-    hinv = hinv.array().pow(-theta / (theta + 1.0));
-    Eigen::VectorXd x = u.col(0);
-    x = x.array().pow(-theta);
-    hinv = hinv - x + Eigen::VectorXd::Ones(x.size());
-    hinv = hinv.array().pow(-1 / theta);
-  } else {
-    hinv = hinv1_num(u);
-  }
-  return hinv;
+  return hinv1_raw(u, this->parameters_);
+}
+
+inline Eigen::VectorXd
+ClaytonBicop::hinv1_raw(const Eigen::MatrixXd& u,
+                        const Eigen::MatrixXd& parameters)
+{
+  // theta is bounded above by 28 < 75, so the closed form is always used
+  const Eigen::Index n = u.rows();
+  Eigen::ArrayXd theta =
+    tools_eigen::parameter_as_vector(parameters, 0, n).array();
+  Eigen::ArrayXd u0 = u.col(0).array();
+  Eigen::ArrayXd u1 = u.col(1).array();
+  Eigen::ArrayXd hinv = u0.pow(theta + 1.0);
+  hinv = u1 * hinv;
+  hinv = hinv.pow(-theta / (theta + 1.0));
+  Eigen::ArrayXd x = u0.pow(-theta);
+  hinv = hinv - x + 1.0;
+  hinv = hinv.pow(-1.0 / theta);
+  return hinv.matrix();
 }
 
 inline Eigen::MatrixXd

--- a/include/vinecopulib/bicop/implementation/clayton.ipp
+++ b/include/vinecopulib/bicop/implementation/clayton.ipp
@@ -22,7 +22,7 @@ inline double
 ClaytonBicop::generator(const double& u,
                         const Eigen::Ref<const Eigen::VectorXd>& parameters)
 {
-  double theta = double(parameters(0));
+  double theta = parameters(0);
   return (std::pow(u, -theta) - 1) / theta;
 }
 
@@ -30,7 +30,7 @@ inline double
 ClaytonBicop::generator_inv(const double& u,
                             const Eigen::Ref<const Eigen::VectorXd>& parameters)
 {
-  double theta = double(parameters(0));
+  double theta = parameters(0);
   return std::pow(1 + theta * u, -1 / theta);
 }
 
@@ -43,19 +43,13 @@ ClaytonBicop::generator_derivative(
 }
 
 inline Eigen::VectorXd
-ClaytonBicop::pdf_raw(const Eigen::MatrixXd& u)
-{
-  return pdf_raw(u, this->parameters_);
-}
-
-inline Eigen::VectorXd
 ClaytonBicop::pdf_raw(const Eigen::MatrixXd& u,
                       const Eigen::MatrixXd& parameters)
 {
   auto f = [](const double& u1,
               const double& u2,
               const Eigen::Ref<const Eigen::VectorXd>& par) {
-    double theta = double(par(0));
+    double theta = par(0);
     // avoid numerical issues when copula is too close to independence
     if (theta < 1e-10) {
       return 1.0;
@@ -66,12 +60,6 @@ ClaytonBicop::pdf_raw(const Eigen::MatrixXd& u,
     return std::exp(temp);
   };
   return tools_eigen::binaryExpr_or_nan(u, parameters, f);
-}
-
-inline Eigen::VectorXd
-ClaytonBicop::hinv1_raw(const Eigen::MatrixXd& u)
-{
-  return hinv1_raw(u, this->parameters_);
 }
 
 inline Eigen::VectorXd

--- a/include/vinecopulib/bicop/implementation/elliptical.ipp
+++ b/include/vinecopulib/bicop/implementation/elliptical.ipp
@@ -21,6 +21,20 @@ EllipticalBicop::hinv2_raw(const Eigen::MatrixXd& u)
   return hinv1_raw(tools_eigen::swap_cols(u));
 }
 
+inline Eigen::VectorXd
+EllipticalBicop::hfunc2_raw(const Eigen::MatrixXd& u,
+                            const Eigen::MatrixXd& parameters)
+{
+  return hfunc1_raw(tools_eigen::swap_cols(u), parameters);
+}
+
+inline Eigen::VectorXd
+EllipticalBicop::hinv2_raw(const Eigen::MatrixXd& u,
+                           const Eigen::MatrixXd& parameters)
+{
+  return hinv1_raw(tools_eigen::swap_cols(u), parameters);
+}
+
 inline double
 EllipticalBicop::parameters_to_tau(const Eigen::MatrixXd& parameters)
 {

--- a/include/vinecopulib/bicop/implementation/elliptical.ipp
+++ b/include/vinecopulib/bicop/implementation/elliptical.ipp
@@ -10,18 +10,6 @@
 namespace vinecopulib {
 
 inline Eigen::VectorXd
-EllipticalBicop::hfunc2_raw(const Eigen::MatrixXd& u)
-{
-  return hfunc1_raw(tools_eigen::swap_cols(u));
-}
-
-inline Eigen::VectorXd
-EllipticalBicop::hinv2_raw(const Eigen::MatrixXd& u)
-{
-  return hinv1_raw(tools_eigen::swap_cols(u));
-}
-
-inline Eigen::VectorXd
 EllipticalBicop::hfunc2_raw(const Eigen::MatrixXd& u,
                             const Eigen::MatrixXd& parameters)
 {

--- a/include/vinecopulib/bicop/implementation/extreme_value.ipp
+++ b/include/vinecopulib/bicop/implementation/extreme_value.ipp
@@ -9,12 +9,6 @@
 
 namespace vinecopulib {
 inline Eigen::VectorXd
-ExtremeValueBicop::cdf(const Eigen::MatrixXd& u)
-{
-  return cdf(u, this->parameters_);
-}
-
-inline Eigen::VectorXd
 ExtremeValueBicop::cdf(const Eigen::MatrixXd& u,
                        const Eigen::MatrixXd& parameters)
 {
@@ -27,12 +21,6 @@ ExtremeValueBicop::cdf(const Eigen::MatrixXd& u,
     return std::exp(t);
   };
   return tools_eigen::binaryExpr_or_nan(u, parameters, f);
-}
-
-inline Eigen::VectorXd
-ExtremeValueBicop::pdf_raw(const Eigen::MatrixXd& u)
-{
-  return pdf_raw(u, this->parameters_);
 }
 
 inline Eigen::VectorXd
@@ -57,12 +45,6 @@ ExtremeValueBicop::pdf_raw(const Eigen::MatrixXd& u,
 }
 
 inline Eigen::VectorXd
-ExtremeValueBicop::hfunc1_raw(const Eigen::MatrixXd& u)
-{
-  return hfunc1_raw(u, this->parameters_);
-}
-
-inline Eigen::VectorXd
 ExtremeValueBicop::hfunc1_raw(const Eigen::MatrixXd& u,
                               const Eigen::MatrixXd& parameters)
 {
@@ -78,12 +60,6 @@ ExtremeValueBicop::hfunc1_raw(const Eigen::MatrixXd& u,
     return std::exp(t2) * t3 / u1;
   };
   return tools_eigen::binaryExpr_or_nan(u, parameters, f);
-}
-
-inline Eigen::VectorXd
-ExtremeValueBicop::hfunc2_raw(const Eigen::MatrixXd& u)
-{
-  return hfunc2_raw(u, this->parameters_);
 }
 
 inline Eigen::VectorXd
@@ -105,31 +81,17 @@ ExtremeValueBicop::hfunc2_raw(const Eigen::MatrixXd& u,
 }
 
 inline Eigen::VectorXd
-ExtremeValueBicop::hinv1_raw(const Eigen::MatrixXd& u)
-{
-  Eigen::VectorXd hinv = hinv1_num(u);
-  return hinv;
-}
-
-inline Eigen::VectorXd
 ExtremeValueBicop::hinv1_raw(const Eigen::MatrixXd& u,
                              const Eigen::MatrixXd& parameters)
 {
-  return hinv1_num(u, parameters);
-}
-
-inline Eigen::VectorXd
-ExtremeValueBicop::hinv2_raw(const Eigen::MatrixXd& u)
-{
-  Eigen::VectorXd hinv = hinv2_num(u);
-  return hinv;
+  return hinv1_num_raw(u, parameters);
 }
 
 inline Eigen::VectorXd
 ExtremeValueBicop::hinv2_raw(const Eigen::MatrixXd& u,
                              const Eigen::MatrixXd& parameters)
 {
-  return hinv2_num(u, parameters);
+  return hinv2_num_raw(u, parameters);
 }
 
 inline double

--- a/include/vinecopulib/bicop/implementation/extreme_value.ipp
+++ b/include/vinecopulib/bicop/implementation/extreme_value.ipp
@@ -11,23 +11,41 @@ namespace vinecopulib {
 inline Eigen::VectorXd
 ExtremeValueBicop::cdf(const Eigen::MatrixXd& u)
 {
-  auto f = [this](const double& u1, const double& u2) {
+  return cdf(u, this->parameters_);
+}
+
+inline Eigen::VectorXd
+ExtremeValueBicop::cdf(const Eigen::MatrixXd& u,
+                       const Eigen::MatrixXd& parameters)
+{
+  auto f = [this](const double& u1,
+                  const double& u2,
+                  const Eigen::Ref<const Eigen::VectorXd>& par) {
     double t = std::log(u2) / std::log(u1 * u2);
-    t = pickands(t);
+    t = pickands(t, par);
     t = (std::log(u1) + std::log(u2)) * t;
     return std::exp(t);
   };
-  return tools_eigen::binaryExpr_or_nan(u, f);
+  return tools_eigen::binaryExpr_or_nan(u, parameters, f);
 }
 
 inline Eigen::VectorXd
 ExtremeValueBicop::pdf_raw(const Eigen::MatrixXd& u)
 {
-  auto f = [this](const double& u1, const double& u2) {
+  return pdf_raw(u, this->parameters_);
+}
+
+inline Eigen::VectorXd
+ExtremeValueBicop::pdf_raw(const Eigen::MatrixXd& u,
+                           const Eigen::MatrixXd& parameters)
+{
+  auto f = [this](const double& u1,
+                  const double& u2,
+                  const Eigen::Ref<const Eigen::VectorXd>& par) {
     double t = std::log(u2) / std::log(u1 * u2);
-    double t2 = pickands(t);
-    double t3 = pickands_derivative(t);
-    double t4 = pickands_derivative2(t);
+    double t2 = pickands(t, par);
+    double t3 = pickands_derivative(t, par);
+    double t4 = pickands_derivative2(t, par);
 
     t3 = std::pow(t2, 2) + (1 - 2 * t) * t3 * t2 -
          (1 - t) * t * (std::pow(t3, 2) + t4 / std::log(u1 * u2));
@@ -35,37 +53,55 @@ ExtremeValueBicop::pdf_raw(const Eigen::MatrixXd& u)
 
     return std::exp(t2) * t3 / (u1 * u2);
   };
-  return tools_eigen::binaryExpr_or_nan(u, f);
+  return tools_eigen::binaryExpr_or_nan(u, parameters, f);
 }
 
 inline Eigen::VectorXd
 ExtremeValueBicop::hfunc1_raw(const Eigen::MatrixXd& u)
 {
-  auto f = [this](const double& u1, const double& u2) {
+  return hfunc1_raw(u, this->parameters_);
+}
+
+inline Eigen::VectorXd
+ExtremeValueBicop::hfunc1_raw(const Eigen::MatrixXd& u,
+                              const Eigen::MatrixXd& parameters)
+{
+  auto f = [this](const double& u1,
+                  const double& u2,
+                  const Eigen::Ref<const Eigen::VectorXd>& par) {
     double t = std::log(u2) / std::log(u1 * u2);
-    double t2 = pickands(t);
-    double t3 = pickands_derivative(t);
+    double t2 = pickands(t, par);
+    double t3 = pickands_derivative(t, par);
     t3 = t2 - t * t3;
     t2 = (std::log(u1) + std::log(u2)) * t2;
 
     return std::exp(t2) * t3 / u1;
   };
-  return tools_eigen::binaryExpr_or_nan(u, f);
+  return tools_eigen::binaryExpr_or_nan(u, parameters, f);
 }
 
 inline Eigen::VectorXd
 ExtremeValueBicop::hfunc2_raw(const Eigen::MatrixXd& u)
 {
-  auto f = [this](const double& u1, const double& u2) {
+  return hfunc2_raw(u, this->parameters_);
+}
+
+inline Eigen::VectorXd
+ExtremeValueBicop::hfunc2_raw(const Eigen::MatrixXd& u,
+                              const Eigen::MatrixXd& parameters)
+{
+  auto f = [this](const double& u1,
+                  const double& u2,
+                  const Eigen::Ref<const Eigen::VectorXd>& par) {
     double t = std::log(u2) / std::log(u1 * u2);
-    double t2 = pickands(t);
-    double t3 = pickands_derivative(t);
+    double t2 = pickands(t, par);
+    double t3 = pickands_derivative(t, par);
     t3 = t2 + (1 - t) * t3;
     t2 = (std::log(u1) + std::log(u2)) * t2;
 
     return std::exp(t2) * t3 / u2;
   };
-  return tools_eigen::binaryExpr_or_nan(u, f);
+  return tools_eigen::binaryExpr_or_nan(u, parameters, f);
 }
 
 inline Eigen::VectorXd
@@ -76,24 +112,34 @@ ExtremeValueBicop::hinv1_raw(const Eigen::MatrixXd& u)
 }
 
 inline Eigen::VectorXd
+ExtremeValueBicop::hinv1_raw(const Eigen::MatrixXd& u,
+                             const Eigen::MatrixXd& parameters)
+{
+  return hinv1_num(u, parameters);
+}
+
+inline Eigen::VectorXd
 ExtremeValueBicop::hinv2_raw(const Eigen::MatrixXd& u)
 {
   Eigen::VectorXd hinv = hinv2_num(u);
   return hinv;
 }
 
+inline Eigen::VectorXd
+ExtremeValueBicop::hinv2_raw(const Eigen::MatrixXd& u,
+                             const Eigen::MatrixXd& parameters)
+{
+  return hinv2_num(u, parameters);
+}
+
 inline double
 ExtremeValueBicop::parameters_to_tau(const Eigen::MatrixXd& par)
 {
-  auto old_par = this->parameters_;
-  this->set_parameters(par);
-  auto f = [this](const double t) {
-    double A = pickands(t);
-    double A2 = pickands_derivative2(t);
+  auto f = [this, &par](const double t) {
+    double A = pickands(t, par.col(0));
+    double A2 = pickands_derivative2(t, par.col(0));
     return t * (1 - t) * A2 / A;
   };
-  double tau = tools_integration::integrate_zero_to_one(f);
-  this->parameters_ = old_par;
-  return tau;
+  return tools_integration::integrate_zero_to_one(f);
 }
 }

--- a/include/vinecopulib/bicop/implementation/frank.ipp
+++ b/include/vinecopulib/bicop/implementation/frank.ipp
@@ -23,7 +23,7 @@ inline double
 FrankBicop::generator(const double& u,
                       const Eigen::Ref<const Eigen::VectorXd>& parameters)
 {
-  double theta = double(parameters(0));
+  double theta = parameters(0);
   return -std::log(std::expm1(-theta * u) / std::expm1(-theta));
 }
 
@@ -31,7 +31,7 @@ inline double
 FrankBicop::generator_inv(const double& u,
                           const Eigen::Ref<const Eigen::VectorXd>& parameters)
 {
-  double theta = double(parameters(0));
+  double theta = parameters(0);
   return -std::log1p(std::expm1(-theta) * std::exp(-u)) / theta;
 }
 
@@ -40,14 +40,8 @@ FrankBicop::generator_derivative(
   const double& u,
   const Eigen::Ref<const Eigen::VectorXd>& parameters)
 {
-  double theta = double(parameters(0));
+  double theta = parameters(0);
   return -theta / std::expm1(theta * u);
-}
-
-inline Eigen::VectorXd
-FrankBicop::pdf_raw(const Eigen::MatrixXd& u)
-{
-  return pdf_raw(u, this->parameters_);
 }
 
 inline Eigen::VectorXd
@@ -56,7 +50,7 @@ FrankBicop::pdf_raw(const Eigen::MatrixXd& u, const Eigen::MatrixXd& parameters)
   auto f = [](const double& u1,
               const double& u2,
               const Eigen::Ref<const Eigen::VectorXd>& par) {
-    double theta = double(par(0));
+    double theta = par(0);
     return (theta * std::expm1(theta) *
             std::exp(theta * u2 + theta * u1 + theta)) /
            std::pow(std::exp(theta * u2 + theta * u1) -

--- a/include/vinecopulib/bicop/implementation/frank.ipp
+++ b/include/vinecopulib/bicop/implementation/frank.ipp
@@ -20,39 +20,43 @@ inline FrankBicop::FrankBicop()
 }
 
 inline double
-FrankBicop::generator(const double& u)
+FrankBicop::generator(const double& u,
+                      const Eigen::Ref<const Eigen::VectorXd>& parameters)
 {
-  double theta = double(this->parameters_(0));
+  double theta = double(parameters(0));
   return -std::log(std::expm1(-theta * u) / std::expm1(-theta));
 }
 
 inline double
-FrankBicop::generator_inv(const double& u)
+FrankBicop::generator_inv(const double& u,
+                          const Eigen::Ref<const Eigen::VectorXd>& parameters)
 {
-  double theta = double(this->parameters_(0));
+  double theta = double(parameters(0));
   return -std::log1p(std::expm1(-theta) * std::exp(-u)) / theta;
 }
 
 inline double
-FrankBicop::generator_derivative(const double& u)
+FrankBicop::generator_derivative(
+  const double& u,
+  const Eigen::Ref<const Eigen::VectorXd>& parameters)
 {
-  double theta = double(this->parameters_(0));
+  double theta = double(parameters(0));
   return -theta / std::expm1(theta * u);
 }
-
-// inline double FrankBicop::generator_derivative2(const double &u)
-//{
-//    double theta = double(this->parameters_(0));
-//    return std::pow(theta, 2) /
-//           std::pow(std::expm1(theta * u) * std::exp(-theta * u / 2),
-//           2);
-//}
 
 inline Eigen::VectorXd
 FrankBicop::pdf_raw(const Eigen::MatrixXd& u)
 {
-  double theta = static_cast<double>(parameters_(0));
-  auto f = [theta](const double& u1, const double& u2) {
+  return pdf_raw(u, this->parameters_);
+}
+
+inline Eigen::VectorXd
+FrankBicop::pdf_raw(const Eigen::MatrixXd& u, const Eigen::MatrixXd& parameters)
+{
+  auto f = [](const double& u1,
+              const double& u2,
+              const Eigen::Ref<const Eigen::VectorXd>& par) {
+    double theta = double(par(0));
     return (theta * std::expm1(theta) *
             std::exp(theta * u2 + theta * u1 + theta)) /
            std::pow(std::exp(theta * u2 + theta * u1) -
@@ -60,7 +64,7 @@ FrankBicop::pdf_raw(const Eigen::MatrixXd& u)
                       std::exp(theta * u1 + theta) + std::exp(theta),
                     2.0);
   };
-  return tools_eigen::binaryExpr_or_nan(u, f);
+  return tools_eigen::binaryExpr_or_nan(u, parameters, f);
 }
 
 inline Eigen::MatrixXd

--- a/include/vinecopulib/bicop/implementation/gaussian.ipp
+++ b/include/vinecopulib/bicop/implementation/gaussian.ipp
@@ -20,57 +20,28 @@ inline GaussianBicop::GaussianBicop()
 }
 
 inline Eigen::VectorXd
-GaussianBicop::pdf_raw(const Eigen::MatrixXd& u)
-{
-  // Inverse Cholesky of the correlation matrix
-  double rho = double(this->parameters_(0));
-  Eigen::Matrix2d L;
-  L(0, 0) = 1;
-  L(1, 1) = 1 / sqrt(1.0 - pow(rho, 2.0));
-  L(0, 1) = -rho * L(1, 1);
-  L(1, 0) = 0;
-
-  // Compute copula density
-  Eigen::VectorXd f = Eigen::VectorXd::Ones(u.rows());
-  Eigen::MatrixXd tmp = tools_stats::qnorm(u);
-  f = f.cwiseQuotient(tools_stats::dnorm(tmp).rowwise().prod());
-  tmp = tmp * L;
-  f = f.cwiseProduct(tools_stats::dnorm(tmp).rowwise().prod());
-  return f / sqrt(1.0 - pow(rho, 2.0));
-}
-
-inline Eigen::VectorXd
-GaussianBicop::cdf(const Eigen::MatrixXd& u)
-{
-  return tools_stats::pbvnorm(tools_stats::qnorm(u),
-                              double(this->parameters_(0)));
-}
-
-inline Eigen::VectorXd
-GaussianBicop::hfunc1_raw(const Eigen::MatrixXd& u)
-{
-  double rho = double(this->parameters_(0));
-  Eigen::VectorXd h = Eigen::VectorXd::Zero(u.rows());
-  Eigen::MatrixXd tmp = tools_stats::qnorm(u);
-  h = (tmp.col(1) - rho * tmp.col(0)) / sqrt(1.0 - pow(rho, 2.0));
-  return tools_stats::pnorm(h);
-}
-
-inline Eigen::VectorXd
-GaussianBicop::hinv1_raw(const Eigen::MatrixXd& u)
-{
-  double rho = double(this->parameters_(0));
-  Eigen::VectorXd hinv = Eigen::VectorXd::Zero(u.rows());
-  Eigen::MatrixXd tmp = tools_stats::qnorm(u);
-  hinv = tmp.col(1) * sqrt(1.0 - pow(rho, 2.0)) + rho * tmp.col(0);
-  return tools_stats::pnorm(hinv);
-}
-
-inline Eigen::VectorXd
 GaussianBicop::pdf_raw(const Eigen::MatrixXd& u,
                        const Eigen::MatrixXd& parameters)
 {
   const Eigen::Index n = u.rows();
+  if (parameters.rows() == 1) {
+    // broadcast: scalar inverse-Cholesky form (bit-identical to the historical
+    // state-based path)
+    double rho = parameters(0, 0);
+    Eigen::Matrix2d L;
+    L(0, 0) = 1;
+    L(1, 1) = 1 / sqrt(1.0 - pow(rho, 2.0));
+    L(0, 1) = -rho * L(1, 1);
+    L(1, 0) = 0;
+
+    Eigen::VectorXd f = Eigen::VectorXd::Ones(n);
+    Eigen::MatrixXd tmp = tools_stats::qnorm(u);
+    f = f.cwiseQuotient(tools_stats::dnorm(tmp).rowwise().prod());
+    tmp = tmp * L;
+    f = f.cwiseProduct(tools_stats::dnorm(tmp).rowwise().prod());
+    return f / sqrt(1.0 - pow(rho, 2.0));
+  }
+
   Eigen::ArrayXd rho =
     tools_eigen::parameter_as_vector(parameters, 0, n).array();
   Eigen::ArrayXd s = (1.0 - rho.square()).sqrt(); // sqrt(1 - rho^2)
@@ -90,13 +61,13 @@ inline Eigen::VectorXd
 GaussianBicop::cdf(const Eigen::MatrixXd& u, const Eigen::MatrixXd& parameters)
 {
   Eigen::MatrixXd z = tools_stats::qnorm(u);
-  if (parameters.cols() == 1) {
-    return tools_stats::pbvnorm(z, double(parameters(0, 0)));
+  if (parameters.rows() == 1) {
+    return tools_stats::pbvnorm(z, parameters(0, 0));
   }
   const Eigen::Index n = u.rows();
   Eigen::VectorXd p(n);
   for (Eigen::Index i = 0; i < n; ++i) {
-    p(i) = tools_stats::pbvnorm(z.row(i), double(parameters(0, i)))(0);
+    p(i) = tools_stats::pbvnorm(z.row(i), parameters(i, 0))(0);
   }
   return p;
 }

--- a/include/vinecopulib/bicop/implementation/gaussian.ipp
+++ b/include/vinecopulib/bicop/implementation/gaussian.ipp
@@ -76,10 +76,17 @@ inline Eigen::VectorXd
 GaussianBicop::hfunc1_raw(const Eigen::MatrixXd& u,
                           const Eigen::MatrixXd& parameters)
 {
+  Eigen::MatrixXd z = tools_stats::qnorm(u);
+  if (parameters.rows() == 1) {
+    // broadcast: scalar form (computes sqrt(1 - rho^2) once; bit-identical to
+    // the historical state-based path)
+    double rho = parameters(0, 0);
+    Eigen::VectorXd h = (z.col(1) - rho * z.col(0)) / sqrt(1.0 - pow(rho, 2.0));
+    return tools_stats::pnorm(h);
+  }
   const Eigen::Index n = u.rows();
   Eigen::ArrayXd rho =
     tools_eigen::parameter_as_vector(parameters, 0, n).array();
-  Eigen::MatrixXd z = tools_stats::qnorm(u);
   Eigen::VectorXd h =
     ((z.col(1).array() - rho * z.col(0).array()) / (1.0 - rho.square()).sqrt())
       .matrix();
@@ -90,10 +97,16 @@ inline Eigen::VectorXd
 GaussianBicop::hinv1_raw(const Eigen::MatrixXd& u,
                          const Eigen::MatrixXd& parameters)
 {
+  Eigen::MatrixXd z = tools_stats::qnorm(u);
+  if (parameters.rows() == 1) {
+    double rho = parameters(0, 0);
+    Eigen::VectorXd hinv =
+      z.col(1) * sqrt(1.0 - pow(rho, 2.0)) + rho * z.col(0);
+    return tools_stats::pnorm(hinv);
+  }
   const Eigen::Index n = u.rows();
   Eigen::ArrayXd rho =
     tools_eigen::parameter_as_vector(parameters, 0, n).array();
-  Eigen::MatrixXd z = tools_stats::qnorm(u);
   Eigen::VectorXd hinv =
     (z.col(1).array() * (1.0 - rho.square()).sqrt() + rho * z.col(0).array())
       .matrix();

--- a/include/vinecopulib/bicop/implementation/gaussian.ipp
+++ b/include/vinecopulib/bicop/implementation/gaussian.ipp
@@ -4,6 +4,7 @@
 // the MIT license. For a copy, see the LICENSE file in the root directory of
 // vinecopulib or https://vinecopulib.github.io/vinecopulib/.
 
+#include <vinecopulib/misc/tools_eigen.hpp>
 #include <vinecopulib/misc/tools_stats.hpp>
 
 namespace vinecopulib {
@@ -62,6 +63,69 @@ GaussianBicop::hinv1_raw(const Eigen::MatrixXd& u)
   Eigen::VectorXd hinv = Eigen::VectorXd::Zero(u.rows());
   Eigen::MatrixXd tmp = tools_stats::qnorm(u);
   hinv = tmp.col(1) * sqrt(1.0 - pow(rho, 2.0)) + rho * tmp.col(0);
+  return tools_stats::pnorm(hinv);
+}
+
+inline Eigen::VectorXd
+GaussianBicop::pdf_raw(const Eigen::MatrixXd& u,
+                       const Eigen::MatrixXd& parameters)
+{
+  const Eigen::Index n = u.rows();
+  Eigen::ArrayXd rho =
+    tools_eigen::parameter_as_vector(parameters, 0, n).array();
+  Eigen::ArrayXd s = (1.0 - rho.square()).sqrt(); // sqrt(1 - rho^2)
+
+  Eigen::MatrixXd z = tools_stats::qnorm(u);
+  Eigen::MatrixXd zL(n, 2);
+  zL.col(0) = z.col(0);
+  zL.col(1) = (z.col(1).array() - rho * z.col(0).array()) / s;
+
+  Eigen::VectorXd f = tools_stats::dnorm(zL).rowwise().prod();
+  f = f.cwiseQuotient(tools_stats::dnorm(z).rowwise().prod());
+  f = (f.array() / s).matrix();
+  return f;
+}
+
+inline Eigen::VectorXd
+GaussianBicop::cdf(const Eigen::MatrixXd& u, const Eigen::MatrixXd& parameters)
+{
+  Eigen::MatrixXd z = tools_stats::qnorm(u);
+  if (parameters.cols() == 1) {
+    return tools_stats::pbvnorm(z, double(parameters(0, 0)));
+  }
+  const Eigen::Index n = u.rows();
+  Eigen::VectorXd p(n);
+  for (Eigen::Index i = 0; i < n; ++i) {
+    p(i) = tools_stats::pbvnorm(z.row(i), double(parameters(0, i)))(0);
+  }
+  return p;
+}
+
+inline Eigen::VectorXd
+GaussianBicop::hfunc1_raw(const Eigen::MatrixXd& u,
+                          const Eigen::MatrixXd& parameters)
+{
+  const Eigen::Index n = u.rows();
+  Eigen::ArrayXd rho =
+    tools_eigen::parameter_as_vector(parameters, 0, n).array();
+  Eigen::MatrixXd z = tools_stats::qnorm(u);
+  Eigen::VectorXd h =
+    ((z.col(1).array() - rho * z.col(0).array()) / (1.0 - rho.square()).sqrt())
+      .matrix();
+  return tools_stats::pnorm(h);
+}
+
+inline Eigen::VectorXd
+GaussianBicop::hinv1_raw(const Eigen::MatrixXd& u,
+                         const Eigen::MatrixXd& parameters)
+{
+  const Eigen::Index n = u.rows();
+  Eigen::ArrayXd rho =
+    tools_eigen::parameter_as_vector(parameters, 0, n).array();
+  Eigen::MatrixXd z = tools_stats::qnorm(u);
+  Eigen::VectorXd hinv =
+    (z.col(1).array() * (1.0 - rho.square()).sqrt() + rho * z.col(0).array())
+      .matrix();
   return tools_stats::pnorm(hinv);
 }
 

--- a/include/vinecopulib/bicop/implementation/gumbel.ipp
+++ b/include/vinecopulib/bicop/implementation/gumbel.ipp
@@ -38,14 +38,8 @@ GumbelBicop::generator_derivative(
   const double& u,
   const Eigen::Ref<const Eigen::VectorXd>& parameters)
 {
-  double theta = double(parameters(0));
+  double theta = parameters(0);
   return std::pow(std::log(1 / u), theta - 1) * (-theta / u);
-}
-
-inline Eigen::VectorXd
-GumbelBicop::pdf_raw(const Eigen::MatrixXd& u)
-{
-  return pdf_raw(u, this->parameters_);
 }
 
 inline Eigen::VectorXd
@@ -55,7 +49,7 @@ GumbelBicop::pdf_raw(const Eigen::MatrixXd& u,
   auto f = [](const double& u1,
               const double& u2,
               const Eigen::Ref<const Eigen::VectorXd>& par) {
-    double theta = double(par(0));
+    double theta = par(0);
     double thetha1 = 1.0 / theta;
     double t1 = std::pow(-std::log(u1), theta) + std::pow(-std::log(u2), theta);
     double temp = -std::pow(t1, thetha1) + (2 * thetha1 - 2.0) * std::log(t1) +
@@ -65,12 +59,6 @@ GumbelBicop::pdf_raw(const Eigen::MatrixXd& u,
     return std::exp(temp);
   };
   return tools_eigen::binaryExpr_or_nan(u, parameters, f);
-}
-
-inline Eigen::VectorXd
-GumbelBicop::hinv1_raw(const Eigen::MatrixXd& u)
-{
-  return hinv1_raw(u, this->parameters_);
 }
 
 inline Eigen::VectorXd

--- a/include/vinecopulib/bicop/implementation/gumbel.ipp
+++ b/include/vinecopulib/bicop/implementation/gumbel.ipp
@@ -20,37 +20,43 @@ inline GumbelBicop::GumbelBicop()
 }
 
 inline double
-GumbelBicop::generator(const double& u)
+GumbelBicop::generator(const double& u,
+                       const Eigen::Ref<const Eigen::VectorXd>& parameters)
 {
-  return std::pow(std::log(1 / u), this->parameters_(0));
+  return std::pow(std::log(1 / u), parameters(0));
 }
 
 inline double
-GumbelBicop::generator_inv(const double& u)
+GumbelBicop::generator_inv(const double& u,
+                           const Eigen::Ref<const Eigen::VectorXd>& parameters)
 {
-  return std::exp(-std::pow(u, 1 / this->parameters_(0)));
+  return std::exp(-std::pow(u, 1 / parameters(0)));
 }
 
 inline double
-GumbelBicop::generator_derivative(const double& u)
+GumbelBicop::generator_derivative(
+  const double& u,
+  const Eigen::Ref<const Eigen::VectorXd>& parameters)
 {
-  double theta = double(this->parameters_(0));
+  double theta = double(parameters(0));
   return std::pow(std::log(1 / u), theta - 1) * (-theta / u);
 }
-
-// inline double GumbelBicop::generator_derivative2(const double &u)
-//{
-//    double theta = double(this->parameters_(0));
-//    return (theta - 1 - std::log(u)) * std::pow(std::log(1 / u), theta - 2) *
-//           (theta / std::pow(u, 2));
-//}
 
 inline Eigen::VectorXd
 GumbelBicop::pdf_raw(const Eigen::MatrixXd& u)
 {
-  double theta = static_cast<double>(parameters_(0));
-  double thetha1 = 1.0 / theta;
-  auto f = [theta, thetha1](const double& u1, const double& u2) {
+  return pdf_raw(u, this->parameters_);
+}
+
+inline Eigen::VectorXd
+GumbelBicop::pdf_raw(const Eigen::MatrixXd& u,
+                     const Eigen::MatrixXd& parameters)
+{
+  auto f = [](const double& u1,
+              const double& u2,
+              const Eigen::Ref<const Eigen::VectorXd>& par) {
+    double theta = double(par(0));
+    double thetha1 = 1.0 / theta;
     double t1 = std::pow(-std::log(u1), theta) + std::pow(-std::log(u2), theta);
     double temp = -std::pow(t1, thetha1) + (2 * thetha1 - 2.0) * std::log(t1) +
                   (theta - 1.0) * std::log(std::log(u1) * std::log(u2)) -
@@ -58,21 +64,26 @@ GumbelBicop::pdf_raw(const Eigen::MatrixXd& u)
                   std::log1p((theta - 1.0) * std::pow(t1, -thetha1));
     return std::exp(temp);
   };
-  return tools_eigen::binaryExpr_or_nan(u, f);
+  return tools_eigen::binaryExpr_or_nan(u, parameters, f);
 }
 
 inline Eigen::VectorXd
 GumbelBicop::hinv1_raw(const Eigen::MatrixXd& u)
 {
-  double theta = double(this->parameters_(0));
+  return hinv1_raw(u, this->parameters_);
+}
 
-  // Define the lambda function for qcondgum
-  auto qcondgum_func = [&theta](const double& u1, const double& u2) -> double {
-    return qcondgum(u2, u1, theta);
+inline Eigen::VectorXd
+GumbelBicop::hinv1_raw(const Eigen::MatrixXd& u,
+                       const Eigen::MatrixXd& parameters)
+{
+  auto qcondgum_func =
+    [](const double& u1,
+       const double& u2,
+       const Eigen::Ref<const Eigen::VectorXd>& par) -> double {
+    return qcondgum(u2, u1, par(0));
   };
-
-  // Use binaryExpr_or_nan to compute hinv
-  return tools_eigen::binaryExpr_or_nan(u, qcondgum_func);
+  return tools_eigen::binaryExpr_or_nan(u, parameters, qcondgum_func);
 }
 
 inline Eigen::MatrixXd

--- a/include/vinecopulib/bicop/implementation/indep.ipp
+++ b/include/vinecopulib/bicop/implementation/indep.ipp
@@ -15,41 +15,41 @@ inline IndepBicop::IndepBicop()
 }
 
 inline Eigen::VectorXd
-IndepBicop::pdf_raw(const Eigen::MatrixXd& u)
+IndepBicop::pdf_raw(const Eigen::MatrixXd& u, const Eigen::MatrixXd&)
 {
   auto f = [](double, double) { return 1.0; };
   return tools_eigen::binaryExpr_or_nan(u, f);
 }
 
 inline Eigen::VectorXd
-IndepBicop::cdf(const Eigen::MatrixXd& u)
+IndepBicop::cdf(const Eigen::MatrixXd& u, const Eigen::MatrixXd&)
 {
   return u.rowwise().prod();
 }
 
 inline Eigen::VectorXd
-IndepBicop::hfunc1_raw(const Eigen::MatrixXd& u)
+IndepBicop::hfunc1_raw(const Eigen::MatrixXd& u, const Eigen::MatrixXd&)
 {
   auto f = [](double, double u2) { return u2; };
   return tools_eigen::binaryExpr_or_nan(u, f);
 }
 
 inline Eigen::VectorXd
-IndepBicop::hfunc2_raw(const Eigen::MatrixXd& u)
+IndepBicop::hfunc2_raw(const Eigen::MatrixXd& u, const Eigen::MatrixXd&)
 {
   auto f = [](double u1, double) { return u1; };
   return tools_eigen::binaryExpr_or_nan(u, f);
 }
 
 inline Eigen::VectorXd
-IndepBicop::hinv1_raw(const Eigen::MatrixXd& u)
+IndepBicop::hinv1_raw(const Eigen::MatrixXd& u, const Eigen::MatrixXd&)
 {
   auto f = [](double, double u2) { return u2; };
   return tools_eigen::binaryExpr_or_nan(u, f);
 }
 
 inline Eigen::VectorXd
-IndepBicop::hinv2_raw(const Eigen::MatrixXd& u)
+IndepBicop::hinv2_raw(const Eigen::MatrixXd& u, const Eigen::MatrixXd&)
 {
   auto f = [](double u1, double) { return u1; };
   return tools_eigen::binaryExpr_or_nan(u, f);

--- a/include/vinecopulib/bicop/implementation/joe.ipp
+++ b/include/vinecopulib/bicop/implementation/joe.ipp
@@ -39,14 +39,8 @@ JoeBicop::generator_derivative(
   const double& u,
   const Eigen::Ref<const Eigen::VectorXd>& parameters)
 {
-  double theta = double(parameters(0));
+  double theta = parameters(0);
   return (-theta) * std::pow(1 - u, theta - 1) / (1 - std::pow(1 - u, theta));
-}
-
-inline Eigen::VectorXd
-JoeBicop::pdf_raw(const Eigen::MatrixXd& u)
-{
-  return pdf_raw(u, this->parameters_);
 }
 
 inline Eigen::VectorXd
@@ -55,7 +49,7 @@ JoeBicop::pdf_raw(const Eigen::MatrixXd& u, const Eigen::MatrixXd& parameters)
   auto f = [](const double& u1,
               const double& u2,
               const Eigen::Ref<const Eigen::VectorXd>& par) {
-    double theta = double(par(0));
+    double theta = par(0);
     double t1 = std::pow(1 - u1, theta);
     double t2 = std::pow(1 - u2, theta);
     return std::pow(t1 + t2 - t1 * t2, 1 / theta - 2) *
@@ -66,12 +60,6 @@ JoeBicop::pdf_raw(const Eigen::MatrixXd& u, const Eigen::MatrixXd& parameters)
 }
 
 // inverse h-function
-inline Eigen::VectorXd
-JoeBicop::hinv1_raw(const Eigen::MatrixXd& u)
-{
-  return hinv1_raw(u, this->parameters_);
-}
-
 inline Eigen::VectorXd
 JoeBicop::hinv1_raw(const Eigen::MatrixXd& u, const Eigen::MatrixXd& parameters)
 {

--- a/include/vinecopulib/bicop/implementation/joe.ipp
+++ b/include/vinecopulib/bicop/implementation/joe.ipp
@@ -21,59 +21,67 @@ inline JoeBicop::JoeBicop()
 }
 
 inline double
-JoeBicop::generator(const double& u)
+JoeBicop::generator(const double& u,
+                    const Eigen::Ref<const Eigen::VectorXd>& parameters)
 {
-  return (-1) * std::log1p(-std::pow(1 - u, parameters_(0)));
+  return (-1) * std::log1p(-std::pow(1 - u, parameters(0)));
 }
 
 inline double
-JoeBicop::generator_inv(const double& u)
+JoeBicop::generator_inv(const double& u,
+                        const Eigen::Ref<const Eigen::VectorXd>& parameters)
 {
-  return 1 - std::pow(-std::expm1(-u), 1 / parameters_(0));
+  return 1 - std::pow(-std::expm1(-u), 1 / parameters(0));
 }
 
 inline double
-JoeBicop::generator_derivative(const double& u)
+JoeBicop::generator_derivative(
+  const double& u,
+  const Eigen::Ref<const Eigen::VectorXd>& parameters)
 {
-  double theta = double(parameters_(0));
+  double theta = double(parameters(0));
   return (-theta) * std::pow(1 - u, theta - 1) / (1 - std::pow(1 - u, theta));
 }
-
-// inline double JoeBicop::generator_derivative2(const double &u)
-//{
-//    double theta = double(parameters_(0));
-//    double res = theta * (theta - 1 + std::pow(1 - u, theta));
-//    return res * std::pow(1 - u, theta - 2) /
-//           std::pow(-1 + std::pow(1 - u, theta), 2);
-//}
 
 inline Eigen::VectorXd
 JoeBicop::pdf_raw(const Eigen::MatrixXd& u)
 {
-  double theta = static_cast<double>(parameters_(0));
-  auto f = [theta](const double& u1, const double& u2) {
+  return pdf_raw(u, this->parameters_);
+}
+
+inline Eigen::VectorXd
+JoeBicop::pdf_raw(const Eigen::MatrixXd& u, const Eigen::MatrixXd& parameters)
+{
+  auto f = [](const double& u1,
+              const double& u2,
+              const Eigen::Ref<const Eigen::VectorXd>& par) {
+    double theta = double(par(0));
     double t1 = std::pow(1 - u1, theta);
     double t2 = std::pow(1 - u2, theta);
     return std::pow(t1 + t2 - t1 * t2, 1 / theta - 2) *
            std::pow(1 - u1, theta - 1) * std::pow(1 - u2, theta - 1) *
            (theta - 1 + t1 + t2 - t1 * t2);
   };
-  return tools_eigen::binaryExpr_or_nan(u, f);
+  return tools_eigen::binaryExpr_or_nan(u, parameters, f);
 }
 
 // inverse h-function
 inline Eigen::VectorXd
 JoeBicop::hinv1_raw(const Eigen::MatrixXd& u)
 {
-  double theta = double(parameters_(0));
+  return hinv1_raw(u, this->parameters_);
+}
 
-  // Define the lambda function for qcondjoe
-  auto qcondjoe_func = [&theta](const double& u1, const double& u2) -> double {
-    return qcondjoe(u2, u1, theta);
+inline Eigen::VectorXd
+JoeBicop::hinv1_raw(const Eigen::MatrixXd& u, const Eigen::MatrixXd& parameters)
+{
+  auto qcondjoe_func =
+    [](const double& u1,
+       const double& u2,
+       const Eigen::Ref<const Eigen::VectorXd>& par) -> double {
+    return qcondjoe(u2, u1, par(0));
   };
-
-  // Use binaryExpr_or_nan to compute hinv
-  return tools_eigen::binaryExpr_or_nan(u, qcondjoe_func);
+  return tools_eigen::binaryExpr_or_nan(u, parameters, qcondjoe_func);
 }
 
 // link between Kendall's tau and the par_bicop parameter

--- a/include/vinecopulib/bicop/implementation/kernel.ipp
+++ b/include/vinecopulib/bicop/implementation/kernel.ipp
@@ -23,7 +23,7 @@ inline KernelBicop::KernelBicop()
 }
 
 inline Eigen::VectorXd
-KernelBicop::pdf_raw(const Eigen::MatrixXd& u)
+KernelBicop::pdf_raw(const Eigen::MatrixXd& u, const Eigen::MatrixXd&)
 {
   auto pdf = interp_grid_->interpolate(u);
   tools_eigen::trim(pdf, 1e-20, DBL_MAX);
@@ -35,25 +35,26 @@ KernelBicop::pdf(const Eigen::MatrixXd& u)
 {
   if (u.cols() == 4) {
     // evaluate jittered density at mid rank for stability
-    return pdf_raw((u.leftCols(2) + u.rightCols(2)).array() / 2.0);
+    return pdf_raw((u.leftCols(2) + u.rightCols(2)).array() / 2.0,
+                   Eigen::MatrixXd());
   }
-  return pdf_raw(u);
+  return pdf_raw(u, Eigen::MatrixXd());
 }
 
 inline Eigen::VectorXd
-KernelBicop::cdf(const Eigen::MatrixXd& u)
+KernelBicop::cdf(const Eigen::MatrixXd& u, const Eigen::MatrixXd&)
 {
   return interp_grid_->integrate_2d(u);
 }
 
 inline Eigen::VectorXd
-KernelBicop::hfunc1_raw(const Eigen::MatrixXd& u)
+KernelBicop::hfunc1_raw(const Eigen::MatrixXd& u, const Eigen::MatrixXd&)
 {
   return interp_grid_->integrate_1d(u, 1);
 }
 
 inline Eigen::VectorXd
-KernelBicop::hfunc2_raw(const Eigen::MatrixXd& u)
+KernelBicop::hfunc2_raw(const Eigen::MatrixXd& u, const Eigen::MatrixXd&)
 {
   return interp_grid_->integrate_1d(u, 2);
 }
@@ -64,9 +65,9 @@ KernelBicop::hfunc1(const Eigen::MatrixXd& u)
   if (u.cols() == 4) {
     auto u_avg = u;
     u_avg.col(0) = (u.col(0) + u.col(2)).array() / 2.0;
-    return hfunc1_raw(u_avg.leftCols(2));
+    return hfunc1_raw(u_avg.leftCols(2), Eigen::MatrixXd());
   }
-  return hfunc1_raw(u);
+  return hfunc1_raw(u, Eigen::MatrixXd());
 }
 
 inline Eigen::VectorXd
@@ -75,21 +76,23 @@ KernelBicop::hfunc2(const Eigen::MatrixXd& u)
   if (u.cols() == 4) {
     auto u_avg = u;
     u_avg.col(1) = (u.col(1) + u.col(3)).array() / 2.0;
-    return hfunc2_raw(u_avg.leftCols(2));
+    return hfunc2_raw(u_avg.leftCols(2), Eigen::MatrixXd());
   }
-  return hfunc2_raw(u);
+  return hfunc2_raw(u, Eigen::MatrixXd());
 }
 
 inline Eigen::VectorXd
-KernelBicop::hinv1_raw(const Eigen::MatrixXd& u)
+KernelBicop::hinv1_raw(const Eigen::MatrixXd& u,
+                       const Eigen::MatrixXd& parameters)
 {
-  return hinv1_num(u);
+  return hinv1_num_raw(u, parameters);
 }
 
 inline Eigen::VectorXd
-KernelBicop::hinv2_raw(const Eigen::MatrixXd& u)
+KernelBicop::hinv2_raw(const Eigen::MatrixXd& u,
+                       const Eigen::MatrixXd& parameters)
 {
-  return hinv2_num(u);
+  return hinv2_num_raw(u, parameters);
 }
 
 inline double
@@ -104,7 +107,7 @@ KernelBicop::parameters_to_tau(const Eigen::MatrixXd& parameters)
     204967043, 733593603, 184618802, 399707801, 290266245
   };
   auto u = tools_stats::ghalton(1000, 2, seeds);
-  u.col(1) = hinv1_raw(u);
+  u.col(1) = hinv1_raw(u, Eigen::MatrixXd());
 
   this->set_parameters(oldpars);
   var_types_ = old_types;

--- a/include/vinecopulib/bicop/implementation/student.ipp
+++ b/include/vinecopulib/bicop/implementation/student.ipp
@@ -19,10 +19,8 @@ inline StudentBicop::StudentBicop()
 }
 
 inline Eigen::VectorXd
-StudentBicop::pdf_raw(const Eigen::MatrixXd& u)
+StudentBicop::pdf_impl(const Eigen::MatrixXd& u, double rho, double nu)
 {
-  double rho = double(this->parameters_(0));
-  double nu = double(this->parameters_(1));
   Eigen::VectorXd f = Eigen::VectorXd::Ones(u.rows());
   Eigen::MatrixXd tmp = tools_stats::qt(u, nu);
 
@@ -39,12 +37,9 @@ StudentBicop::pdf_raw(const Eigen::MatrixXd& u)
 }
 
 inline Eigen::VectorXd
-StudentBicop::cdf(const Eigen::MatrixXd& u)
+StudentBicop::cdf_impl(const Eigen::MatrixXd& u, double rho, double nu)
 {
   using namespace tools_stats;
-
-  double rho = double(this->parameters_(0));
-  double nu = double(this->parameters_(1));
 
   // for integer nu, just use pbvt
   // otherwise, interpolate linearly between floor(nu) and ceil(nu)
@@ -62,10 +57,8 @@ StudentBicop::cdf(const Eigen::MatrixXd& u)
 }
 
 inline Eigen::VectorXd
-StudentBicop::hfunc1_raw(const Eigen::MatrixXd& u)
+StudentBicop::hfunc1_impl(const Eigen::MatrixXd& u, double rho, double nu)
 {
-  double rho = double(this->parameters_(0));
-  double nu = double(this->parameters_(1));
   Eigen::VectorXd h = Eigen::VectorXd::Ones(u.rows());
   Eigen::MatrixXd tmp = tools_stats::qt(u, nu);
   h = nu * h + tmp.col(0).cwiseAbs2();
@@ -77,10 +70,8 @@ StudentBicop::hfunc1_raw(const Eigen::MatrixXd& u)
 }
 
 inline Eigen::VectorXd
-StudentBicop::hinv1_raw(const Eigen::MatrixXd& u)
+StudentBicop::hinv1_impl(const Eigen::MatrixXd& u, double rho, double nu)
 {
-  double rho = double(this->parameters_(0));
-  double nu = double(this->parameters_(1));
   Eigen::VectorXd hinv = Eigen::VectorXd::Ones(u.rows());
   Eigen::VectorXd tmp = u.col(1);
   Eigen::VectorXd tmp2 = u.col(0);
@@ -93,6 +84,93 @@ StudentBicop::hinv1_raw(const Eigen::MatrixXd& u)
   hinv = tools_stats::pt(hinv, nu);
 
   return hinv;
+}
+
+inline Eigen::VectorXd
+StudentBicop::pdf_raw(const Eigen::MatrixXd& u)
+{
+  return pdf_impl(
+    u, double(this->parameters_(0)), double(this->parameters_(1)));
+}
+
+inline Eigen::VectorXd
+StudentBicop::cdf(const Eigen::MatrixXd& u)
+{
+  return cdf_impl(
+    u, double(this->parameters_(0)), double(this->parameters_(1)));
+}
+
+inline Eigen::VectorXd
+StudentBicop::hfunc1_raw(const Eigen::MatrixXd& u)
+{
+  return hfunc1_impl(
+    u, double(this->parameters_(0)), double(this->parameters_(1)));
+}
+
+inline Eigen::VectorXd
+StudentBicop::hinv1_raw(const Eigen::MatrixXd& u)
+{
+  return hinv1_impl(
+    u, double(this->parameters_(0)), double(this->parameters_(1)));
+}
+
+inline Eigen::VectorXd
+StudentBicop::pdf_raw(const Eigen::MatrixXd& u,
+                      const Eigen::MatrixXd& parameters)
+{
+  if (parameters.cols() == 1) {
+    return pdf_impl(u, double(parameters(0, 0)), double(parameters(1, 0)));
+  }
+  Eigen::VectorXd out(u.rows());
+  for (Eigen::Index i = 0; i < u.rows(); ++i) {
+    out(i) =
+      pdf_impl(u.row(i), double(parameters(0, i)), double(parameters(1, i)))(0);
+  }
+  return out;
+}
+
+inline Eigen::VectorXd
+StudentBicop::cdf(const Eigen::MatrixXd& u, const Eigen::MatrixXd& parameters)
+{
+  if (parameters.cols() == 1) {
+    return cdf_impl(u, double(parameters(0, 0)), double(parameters(1, 0)));
+  }
+  Eigen::VectorXd out(u.rows());
+  for (Eigen::Index i = 0; i < u.rows(); ++i) {
+    out(i) =
+      cdf_impl(u.row(i), double(parameters(0, i)), double(parameters(1, i)))(0);
+  }
+  return out;
+}
+
+inline Eigen::VectorXd
+StudentBicop::hfunc1_raw(const Eigen::MatrixXd& u,
+                         const Eigen::MatrixXd& parameters)
+{
+  if (parameters.cols() == 1) {
+    return hfunc1_impl(u, double(parameters(0, 0)), double(parameters(1, 0)));
+  }
+  Eigen::VectorXd out(u.rows());
+  for (Eigen::Index i = 0; i < u.rows(); ++i) {
+    out(i) = hfunc1_impl(
+      u.row(i), double(parameters(0, i)), double(parameters(1, i)))(0);
+  }
+  return out;
+}
+
+inline Eigen::VectorXd
+StudentBicop::hinv1_raw(const Eigen::MatrixXd& u,
+                        const Eigen::MatrixXd& parameters)
+{
+  if (parameters.cols() == 1) {
+    return hinv1_impl(u, double(parameters(0, 0)), double(parameters(1, 0)));
+  }
+  Eigen::VectorXd out(u.rows());
+  for (Eigen::Index i = 0; i < u.rows(); ++i) {
+    out(i) = hinv1_impl(
+      u.row(i), double(parameters(0, i)), double(parameters(1, i)))(0);
+  }
+  return out;
 }
 
 inline Eigen::VectorXd

--- a/include/vinecopulib/bicop/implementation/student.ipp
+++ b/include/vinecopulib/bicop/implementation/student.ipp
@@ -87,44 +87,15 @@ StudentBicop::hinv1_impl(const Eigen::MatrixXd& u, double rho, double nu)
 }
 
 inline Eigen::VectorXd
-StudentBicop::pdf_raw(const Eigen::MatrixXd& u)
-{
-  return pdf_impl(
-    u, double(this->parameters_(0)), double(this->parameters_(1)));
-}
-
-inline Eigen::VectorXd
-StudentBicop::cdf(const Eigen::MatrixXd& u)
-{
-  return cdf_impl(
-    u, double(this->parameters_(0)), double(this->parameters_(1)));
-}
-
-inline Eigen::VectorXd
-StudentBicop::hfunc1_raw(const Eigen::MatrixXd& u)
-{
-  return hfunc1_impl(
-    u, double(this->parameters_(0)), double(this->parameters_(1)));
-}
-
-inline Eigen::VectorXd
-StudentBicop::hinv1_raw(const Eigen::MatrixXd& u)
-{
-  return hinv1_impl(
-    u, double(this->parameters_(0)), double(this->parameters_(1)));
-}
-
-inline Eigen::VectorXd
 StudentBicop::pdf_raw(const Eigen::MatrixXd& u,
                       const Eigen::MatrixXd& parameters)
 {
-  if (parameters.cols() == 1) {
-    return pdf_impl(u, double(parameters(0, 0)), double(parameters(1, 0)));
+  if (parameters.rows() == 1) {
+    return pdf_impl(u, parameters(0, 0), parameters(0, 1));
   }
   Eigen::VectorXd out(u.rows());
   for (Eigen::Index i = 0; i < u.rows(); ++i) {
-    out(i) =
-      pdf_impl(u.row(i), double(parameters(0, i)), double(parameters(1, i)))(0);
+    out(i) = pdf_impl(u.row(i), parameters(i, 0), parameters(i, 1))(0);
   }
   return out;
 }
@@ -132,13 +103,12 @@ StudentBicop::pdf_raw(const Eigen::MatrixXd& u,
 inline Eigen::VectorXd
 StudentBicop::cdf(const Eigen::MatrixXd& u, const Eigen::MatrixXd& parameters)
 {
-  if (parameters.cols() == 1) {
-    return cdf_impl(u, double(parameters(0, 0)), double(parameters(1, 0)));
+  if (parameters.rows() == 1) {
+    return cdf_impl(u, parameters(0, 0), parameters(0, 1));
   }
   Eigen::VectorXd out(u.rows());
   for (Eigen::Index i = 0; i < u.rows(); ++i) {
-    out(i) =
-      cdf_impl(u.row(i), double(parameters(0, i)), double(parameters(1, i)))(0);
+    out(i) = cdf_impl(u.row(i), parameters(i, 0), parameters(i, 1))(0);
   }
   return out;
 }
@@ -147,13 +117,12 @@ inline Eigen::VectorXd
 StudentBicop::hfunc1_raw(const Eigen::MatrixXd& u,
                          const Eigen::MatrixXd& parameters)
 {
-  if (parameters.cols() == 1) {
-    return hfunc1_impl(u, double(parameters(0, 0)), double(parameters(1, 0)));
+  if (parameters.rows() == 1) {
+    return hfunc1_impl(u, parameters(0, 0), parameters(0, 1));
   }
   Eigen::VectorXd out(u.rows());
   for (Eigen::Index i = 0; i < u.rows(); ++i) {
-    out(i) = hfunc1_impl(
-      u.row(i), double(parameters(0, i)), double(parameters(1, i)))(0);
+    out(i) = hfunc1_impl(u.row(i), parameters(i, 0), parameters(i, 1))(0);
   }
   return out;
 }
@@ -162,13 +131,12 @@ inline Eigen::VectorXd
 StudentBicop::hinv1_raw(const Eigen::MatrixXd& u,
                         const Eigen::MatrixXd& parameters)
 {
-  if (parameters.cols() == 1) {
-    return hinv1_impl(u, double(parameters(0, 0)), double(parameters(1, 0)));
+  if (parameters.rows() == 1) {
+    return hinv1_impl(u, parameters(0, 0), parameters(0, 1));
   }
   Eigen::VectorXd out(u.rows());
   for (Eigen::Index i = 0; i < u.rows(); ++i) {
-    out(i) = hinv1_impl(
-      u.row(i), double(parameters(0, i)), double(parameters(1, i)))(0);
+    out(i) = hinv1_impl(u.row(i), parameters(i, 0), parameters(i, 1))(0);
   }
   return out;
 }

--- a/include/vinecopulib/bicop/implementation/tawn.ipp
+++ b/include/vinecopulib/bicop/implementation/tawn.ipp
@@ -20,22 +20,25 @@ inline TawnBicop::TawnBicop()
 }
 
 inline double
-TawnBicop::pickands(const double& t)
+TawnBicop::pickands(const double& t,
+                    const Eigen::Ref<const Eigen::VectorXd>& parameters)
 {
-  double psi1 = this->parameters_(0);
-  double psi2 = this->parameters_(1);
-  double theta = this->parameters_(2);
+  double psi1 = parameters(0);
+  double psi2 = parameters(1);
+  double theta = parameters(2);
 
   double temp = std::pow(psi2 * t, theta) + std::pow(psi1 * (1 - t), theta);
   return (1 - psi1) * (1 - t) + (1 - psi2) * t + std::pow(temp, 1 / theta);
 }
 
 inline double
-TawnBicop::pickands_derivative(const double& t)
+TawnBicop::pickands_derivative(
+  const double& t,
+  const Eigen::Ref<const Eigen::VectorXd>& parameters)
 {
-  double psi1 = this->parameters_(0);
-  double psi2 = this->parameters_(1);
-  double theta = this->parameters_(2);
+  double psi1 = parameters(0);
+  double psi2 = parameters(1);
+  double theta = parameters(2);
 
   double temp = std::pow(psi2 * t, theta) + std::pow(psi1 * (1 - t), theta);
   double temp2 = psi2 * std::pow(psi2 * t, theta - 1) -
@@ -44,11 +47,13 @@ TawnBicop::pickands_derivative(const double& t)
 }
 
 inline double
-TawnBicop::pickands_derivative2(const double& t)
+TawnBicop::pickands_derivative2(
+  const double& t,
+  const Eigen::Ref<const Eigen::VectorXd>& parameters)
 {
-  double psi1 = this->parameters_(0);
-  double psi2 = this->parameters_(1);
-  double theta = this->parameters_(2);
+  double psi1 = parameters(0);
+  double psi2 = parameters(1);
+  double theta = parameters(2);
 
   double temp = std::pow(psi2 * t, theta) + std::pow(psi1 * (1 - t), theta);
   double temp2 = psi2 * std::pow(psi2 * t, theta - 1) -

--- a/include/vinecopulib/bicop/indep.hpp
+++ b/include/vinecopulib/bicop/indep.hpp
@@ -39,6 +39,16 @@ private:
 
   Eigen::VectorXd hinv2_raw(const Eigen::MatrixXd& u);
 
+  // bring the base class' parameter-aware overloads into scope (the
+  // independence copula has no parameters, so they reduce to the no-arg
+  // versions); this silences -Woverloaded-virtual.
+  using AbstractBicop::cdf;
+  using AbstractBicop::hfunc1_raw;
+  using AbstractBicop::hfunc2_raw;
+  using AbstractBicop::hinv1_raw;
+  using AbstractBicop::hinv2_raw;
+  using AbstractBicop::pdf_raw;
+
   Eigen::MatrixXd tau_to_parameters(const double&);
 
   double parameters_to_tau(const Eigen::MatrixXd&);

--- a/include/vinecopulib/bicop/indep.hpp
+++ b/include/vinecopulib/bicop/indep.hpp
@@ -24,30 +24,25 @@ public:
   IndepBicop();
 
 private:
-  // PDF
-  Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u);
+  // evaluation leaves; the independence copula has no parameters, so they
+  // ignore `parameters`
+  Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u,
+                          const Eigen::MatrixXd& parameters);
 
-  // PDF
-  Eigen::VectorXd cdf(const Eigen::MatrixXd& u);
+  Eigen::VectorXd cdf(const Eigen::MatrixXd& u,
+                      const Eigen::MatrixXd& parameters);
 
-  // hfunctions and their inverses
-  Eigen::VectorXd hfunc1_raw(const Eigen::MatrixXd& u);
+  Eigen::VectorXd hfunc1_raw(const Eigen::MatrixXd& u,
+                             const Eigen::MatrixXd& parameters);
 
-  Eigen::VectorXd hfunc2_raw(const Eigen::MatrixXd& u);
+  Eigen::VectorXd hfunc2_raw(const Eigen::MatrixXd& u,
+                             const Eigen::MatrixXd& parameters);
 
-  Eigen::VectorXd hinv1_raw(const Eigen::MatrixXd& u);
+  Eigen::VectorXd hinv1_raw(const Eigen::MatrixXd& u,
+                            const Eigen::MatrixXd& parameters);
 
-  Eigen::VectorXd hinv2_raw(const Eigen::MatrixXd& u);
-
-  // bring the base class' parameter-aware overloads into scope (the
-  // independence copula has no parameters, so they reduce to the no-arg
-  // versions); this silences -Woverloaded-virtual.
-  using AbstractBicop::cdf;
-  using AbstractBicop::hfunc1_raw;
-  using AbstractBicop::hfunc2_raw;
-  using AbstractBicop::hinv1_raw;
-  using AbstractBicop::hinv2_raw;
-  using AbstractBicop::pdf_raw;
+  Eigen::VectorXd hinv2_raw(const Eigen::MatrixXd& u,
+                            const Eigen::MatrixXd& parameters);
 
   Eigen::MatrixXd tau_to_parameters(const double&);
 

--- a/include/vinecopulib/bicop/joe.hpp
+++ b/include/vinecopulib/bicop/joe.hpp
@@ -36,14 +36,10 @@ private:
     const Eigen::Ref<const Eigen::VectorXd>& parameters);
 
   // pdf
-  Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u);
-
   Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u,
                           const Eigen::MatrixXd& parameters);
 
   // inverse hfunction
-  Eigen::VectorXd hinv1_raw(const Eigen::MatrixXd& u);
-
   Eigen::VectorXd hinv1_raw(const Eigen::MatrixXd& u,
                             const Eigen::MatrixXd& parameters);
 

--- a/include/vinecopulib/bicop/joe.hpp
+++ b/include/vinecopulib/bicop/joe.hpp
@@ -25,29 +25,27 @@ public:
 
 private:
   // generator, its inverse and derivatives for the archimedean copula
-  double generator(
-    const double& u,
-    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
+  double generator(const double& u,
+                   const Eigen::Ref<const Eigen::VectorXd>& parameters);
 
-  double generator_inv(
-    const double& u,
-    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
+  double generator_inv(const double& u,
+                       const Eigen::Ref<const Eigen::VectorXd>& parameters);
 
   double generator_derivative(
     const double& u,
-    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
+    const Eigen::Ref<const Eigen::VectorXd>& parameters);
 
   // pdf
   Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u);
 
   Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u,
-                          const Eigen::MatrixXd& parameters) override;
+                          const Eigen::MatrixXd& parameters);
 
   // inverse hfunction
   Eigen::VectorXd hinv1_raw(const Eigen::MatrixXd& u);
 
   Eigen::VectorXd hinv1_raw(const Eigen::MatrixXd& u,
-                            const Eigen::MatrixXd& parameters) override;
+                            const Eigen::MatrixXd& parameters);
 
   // link between Kendall's tau and the par_bicop parameter
   Eigen::MatrixXd tau_to_parameters(const double& tau);

--- a/include/vinecopulib/bicop/joe.hpp
+++ b/include/vinecopulib/bicop/joe.hpp
@@ -25,19 +25,29 @@ public:
 
 private:
   // generator, its inverse and derivatives for the archimedean copula
-  double generator(const double& u);
+  double generator(
+    const double& u,
+    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
 
-  double generator_inv(const double& u);
+  double generator_inv(
+    const double& u,
+    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
 
-  double generator_derivative(const double& u);
-
-  double generator_derivative2(const double& u);
+  double generator_derivative(
+    const double& u,
+    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
 
   // pdf
   Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u);
 
+  Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u,
+                          const Eigen::MatrixXd& parameters) override;
+
   // inverse hfunction
   Eigen::VectorXd hinv1_raw(const Eigen::MatrixXd& u);
+
+  Eigen::VectorXd hinv1_raw(const Eigen::MatrixXd& u,
+                            const Eigen::MatrixXd& parameters) override;
 
   // link between Kendall's tau and the par_bicop parameter
   Eigen::MatrixXd tau_to_parameters(const double& tau);

--- a/include/vinecopulib/bicop/kernel.hpp
+++ b/include/vinecopulib/bicop/kernel.hpp
@@ -32,34 +32,32 @@ public:
   KernelBicop();
 
 protected:
-  Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u) override;
+  // evaluation leaves; kernel estimators store an interpolation grid rather
+  // than a per-row parameter vector, so they ignore `parameters`
+  Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u,
+                          const Eigen::MatrixXd& parameters) override;
 
+  Eigen::VectorXd cdf(const Eigen::MatrixXd& u,
+                      const Eigen::MatrixXd& parameters) override;
+
+  Eigen::VectorXd hfunc1_raw(const Eigen::MatrixXd& u,
+                             const Eigen::MatrixXd& parameters) override;
+
+  Eigen::VectorXd hfunc2_raw(const Eigen::MatrixXd& u,
+                             const Eigen::MatrixXd& parameters) override;
+
+  Eigen::VectorXd hinv1_raw(const Eigen::MatrixXd& u,
+                            const Eigen::MatrixXd& parameters) override;
+
+  Eigen::VectorXd hinv2_raw(const Eigen::MatrixXd& u,
+                            const Eigen::MatrixXd& parameters) override;
+
+  // state-based dispatchers (overridden for grid-specific jitter handling)
   Eigen::VectorXd pdf(const Eigen::MatrixXd& u) override;
-
-  Eigen::VectorXd cdf(const Eigen::MatrixXd& u) override;
-
-  Eigen::VectorXd hfunc1_raw(const Eigen::MatrixXd& u) override;
-
-  Eigen::VectorXd hfunc2_raw(const Eigen::MatrixXd& u) override;
 
   Eigen::VectorXd hfunc1(const Eigen::MatrixXd& u) override;
 
   Eigen::VectorXd hfunc2(const Eigen::MatrixXd& u) override;
-
-  Eigen::VectorXd hinv1_raw(const Eigen::MatrixXd& u) override;
-
-  Eigen::VectorXd hinv2_raw(const Eigen::MatrixXd& u) override;
-
-  // bring the base class' parameter-aware overloads into scope (kernel
-  // estimators store an interpolation grid rather than a per-row parameter
-  // vector, so they reduce to the no-arg versions); silences
-  // -Woverloaded-virtual.
-  using AbstractBicop::cdf;
-  using AbstractBicop::hfunc1_raw;
-  using AbstractBicop::hfunc2_raw;
-  using AbstractBicop::hinv1_raw;
-  using AbstractBicop::hinv2_raw;
-  using AbstractBicop::pdf_raw;
 
   double get_npars() const override;
 

--- a/include/vinecopulib/bicop/kernel.hpp
+++ b/include/vinecopulib/bicop/kernel.hpp
@@ -50,6 +50,17 @@ protected:
 
   Eigen::VectorXd hinv2_raw(const Eigen::MatrixXd& u) override;
 
+  // bring the base class' parameter-aware overloads into scope (kernel
+  // estimators store an interpolation grid rather than a per-row parameter
+  // vector, so they reduce to the no-arg versions); silences
+  // -Woverloaded-virtual.
+  using AbstractBicop::cdf;
+  using AbstractBicop::hfunc1_raw;
+  using AbstractBicop::hfunc2_raw;
+  using AbstractBicop::hinv1_raw;
+  using AbstractBicop::hinv2_raw;
+  using AbstractBicop::pdf_raw;
+
   double get_npars() const override;
 
   void set_npars(const double& npars) override;

--- a/include/vinecopulib/bicop/student.hpp
+++ b/include/vinecopulib/bicop/student.hpp
@@ -39,16 +39,16 @@ private:
   // parameter-aware overloads (`parameters` is 2 x m, m in {1, n}); these loop
   // per row because the t-distribution helpers take scalar parameters
   Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u,
-                          const Eigen::MatrixXd& parameters) override;
+                          const Eigen::MatrixXd& parameters);
 
   Eigen::VectorXd cdf(const Eigen::MatrixXd& u,
-                      const Eigen::MatrixXd& parameters) override;
+                      const Eigen::MatrixXd& parameters);
 
   Eigen::VectorXd hfunc1_raw(const Eigen::MatrixXd& u,
-                             const Eigen::MatrixXd& parameters) override;
+                             const Eigen::MatrixXd& parameters);
 
   Eigen::VectorXd hinv1_raw(const Eigen::MatrixXd& u,
-                            const Eigen::MatrixXd& parameters) override;
+                            const Eigen::MatrixXd& parameters);
 
   // single source of truth for the math (shared by the state-based and
   // parameter-aware leaves)

--- a/include/vinecopulib/bicop/student.hpp
+++ b/include/vinecopulib/bicop/student.hpp
@@ -36,6 +36,35 @@ private:
   // inverse hfunction
   Eigen::VectorXd hinv1_raw(const Eigen::MatrixXd& u);
 
+  // parameter-aware overloads (`parameters` is 2 x m, m in {1, n}); these loop
+  // per row because the t-distribution helpers take scalar parameters
+  Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u,
+                          const Eigen::MatrixXd& parameters) override;
+
+  Eigen::VectorXd cdf(const Eigen::MatrixXd& u,
+                      const Eigen::MatrixXd& parameters) override;
+
+  Eigen::VectorXd hfunc1_raw(const Eigen::MatrixXd& u,
+                             const Eigen::MatrixXd& parameters) override;
+
+  Eigen::VectorXd hinv1_raw(const Eigen::MatrixXd& u,
+                            const Eigen::MatrixXd& parameters) override;
+
+  // single source of truth for the math (shared by the state-based and
+  // parameter-aware leaves)
+  static Eigen::VectorXd pdf_impl(const Eigen::MatrixXd& u,
+                                  double rho,
+                                  double nu);
+  static Eigen::VectorXd cdf_impl(const Eigen::MatrixXd& u,
+                                  double rho,
+                                  double nu);
+  static Eigen::VectorXd hfunc1_impl(const Eigen::MatrixXd& u,
+                                     double rho,
+                                     double nu);
+  static Eigen::VectorXd hinv1_impl(const Eigen::MatrixXd& u,
+                                    double rho,
+                                    double nu);
+
   Eigen::MatrixXd tau_to_parameters(const double& tau);
 
   Eigen::VectorXd get_start_parameters(const double tau);

--- a/include/vinecopulib/bicop/student.hpp
+++ b/include/vinecopulib/bicop/student.hpp
@@ -24,20 +24,8 @@ public:
   StudentBicop();
 
 private:
-  // PDF
-  Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u);
-
-  // CDF
-  Eigen::VectorXd cdf(const Eigen::MatrixXd& u);
-
-  // hfunction
-  Eigen::VectorXd hfunc1_raw(const Eigen::MatrixXd& u);
-
-  // inverse hfunction
-  Eigen::VectorXd hinv1_raw(const Eigen::MatrixXd& u);
-
-  // parameter-aware overloads (`parameters` is 2 x m, m in {1, n}); these loop
-  // per row because the t-distribution helpers take scalar parameters
+  // evaluation leaves (`parameters` is m x 2, m in {1, n}); these loop per row
+  // because the t-distribution helpers take scalar parameters
   Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u,
                           const Eigen::MatrixXd& parameters);
 

--- a/include/vinecopulib/bicop/tawn.hpp
+++ b/include/vinecopulib/bicop/tawn.hpp
@@ -25,11 +25,16 @@ public:
 
 private:
   // pickands dependence functions and its derivatives
-  double pickands(const double& t) override;
+  double pickands(const double& t,
+                  const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
 
-  double pickands_derivative(const double& t) override;
+  double pickands_derivative(
+    const double& t,
+    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
 
-  double pickands_derivative2(const double& t) override;
+  double pickands_derivative2(
+    const double& t,
+    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
 
   Eigen::MatrixXd tau_to_parameters(const double& tau) override;
 

--- a/include/vinecopulib/misc/tools_eigen.hpp
+++ b/include/vinecopulib/misc/tools_eigen.hpp
@@ -61,14 +61,21 @@ binaryExpr_or_nan(const Eigen::MatrixXd& u,
 {
   const Eigen::Index n = u.rows();
   const bool broadcast = (parameters.rows() == 1);
+  // hoist the broadcast parameter set out of the loop so the common
+  // single-parameter (state-based) path does not rebuild it on every row
+  const Eigen::VectorXd par0 =
+    broadcast ? parameters.row(0).transpose() : Eigen::VectorXd();
   Eigen::VectorXd out(n);
   for (Eigen::Index i = 0; i < n; ++i) {
     const double u1 = u(i, 0);
     const double u2 = u(i, 1);
     if ((std::isnan)(u1) || (std::isnan)(u2)) {
       out(i) = std::numeric_limits<double>::quiet_NaN();
+    } else if (broadcast) {
+      out(i) = func(u1, u2, par0);
     } else {
-      out(i) = func(u1, u2, parameters.row(broadcast ? 0 : i).transpose());
+      const Eigen::VectorXd par_i = parameters.row(i).transpose();
+      out(i) = func(u1, u2, par_i);
     }
   }
   return out;

--- a/include/vinecopulib/misc/tools_eigen.hpp
+++ b/include/vinecopulib/misc/tools_eigen.hpp
@@ -47,9 +47,9 @@ binaryExpr_or_nan(const Eigen::MatrixXd& u, const T& func)
 //! parameters, propagating NaNs.
 //!
 //! @param u An \f$ n \times 2 \f$ matrix of evaluation points.
-//! @param parameters A \f$ p \times m \f$ matrix of parameters with
-//!   \f$ m \in \{1, n\} \f$. Column \f$ j \f$ holds the \f$ p \f$ parameters
-//!   for observation \f$ j \f$; a single column is broadcast to all rows.
+//! @param parameters An \f$ m \times p \f$ matrix of parameters with
+//!   \f$ m \in \{1, n\} \f$. Row \f$ i \f$ holds the \f$ p \f$ parameters
+//!   for observation \f$ i \f$; a single row is broadcast to all observations.
 //! @param func A callable
 //!   `(double u1, double u2, const Eigen::Ref<const Eigen::VectorXd>& par) ->
 //!   double`.
@@ -60,7 +60,7 @@ binaryExpr_or_nan(const Eigen::MatrixXd& u,
                   const T& func)
 {
   const Eigen::Index n = u.rows();
-  const bool broadcast = (parameters.cols() == 1);
+  const bool broadcast = (parameters.rows() == 1);
   Eigen::VectorXd out(n);
   for (Eigen::Index i = 0; i < n; ++i) {
     const double u1 = u(i, 0);
@@ -68,7 +68,7 @@ binaryExpr_or_nan(const Eigen::MatrixXd& u,
     if ((std::isnan)(u1) || (std::isnan)(u2)) {
       out(i) = std::numeric_limits<double>::quiet_NaN();
     } else {
-      out(i) = func(u1, u2, parameters.col(broadcast ? 0 : i));
+      out(i) = func(u1, u2, parameters.row(broadcast ? 0 : i).transpose());
     }
   }
   return out;
@@ -77,7 +77,7 @@ binaryExpr_or_nan(const Eigen::MatrixXd& u,
 //! @brief Returns the `k`-th parameter as a length-`n` vector, broadcasting
 //! a single parameter set.
 //!
-//! @param parameters A \f$ p \times m \f$ matrix of parameters with
+//! @param parameters An \f$ m \times p \f$ matrix of parameters with
 //!   \f$ m \in \{1, n\} \f$ (see `binaryExpr_or_nan`).
 //! @param k The index of the parameter to extract.
 //! @param n The desired output length.
@@ -86,10 +86,10 @@ parameter_as_vector(const Eigen::MatrixXd& parameters,
                     const Eigen::Index k,
                     const Eigen::Index n)
 {
-  if (parameters.cols() == 1) {
-    return Eigen::VectorXd::Constant(n, parameters(k, 0));
+  if (parameters.rows() == 1) {
+    return Eigen::VectorXd::Constant(n, parameters(0, k));
   }
-  return parameters.row(k).transpose();
+  return parameters.col(k);
 }
 
 void

--- a/include/vinecopulib/misc/tools_eigen.hpp
+++ b/include/vinecopulib/misc/tools_eigen.hpp
@@ -43,6 +43,55 @@ binaryExpr_or_nan(const Eigen::MatrixXd& u, const T& func)
   return u.col(0).binaryExpr(u.col(1), func_or_nan);
 }
 
+//! @brief Applies a bivariate function row-wise with per-observation
+//! parameters, propagating NaNs.
+//!
+//! @param u An \f$ n \times 2 \f$ matrix of evaluation points.
+//! @param parameters A \f$ p \times m \f$ matrix of parameters with
+//!   \f$ m \in \{1, n\} \f$. Column \f$ j \f$ holds the \f$ p \f$ parameters
+//!   for observation \f$ j \f$; a single column is broadcast to all rows.
+//! @param func A callable
+//!   `(double u1, double u2, const Eigen::Ref<const Eigen::VectorXd>& par) ->
+//!   double`.
+template<typename T>
+Eigen::VectorXd
+binaryExpr_or_nan(const Eigen::MatrixXd& u,
+                  const Eigen::MatrixXd& parameters,
+                  const T& func)
+{
+  const Eigen::Index n = u.rows();
+  const bool broadcast = (parameters.cols() == 1);
+  Eigen::VectorXd out(n);
+  for (Eigen::Index i = 0; i < n; ++i) {
+    const double u1 = u(i, 0);
+    const double u2 = u(i, 1);
+    if ((std::isnan)(u1) || (std::isnan)(u2)) {
+      out(i) = std::numeric_limits<double>::quiet_NaN();
+    } else {
+      out(i) = func(u1, u2, parameters.col(broadcast ? 0 : i));
+    }
+  }
+  return out;
+}
+
+//! @brief Returns the `k`-th parameter as a length-`n` vector, broadcasting
+//! a single parameter set.
+//!
+//! @param parameters A \f$ p \times m \f$ matrix of parameters with
+//!   \f$ m \in \{1, n\} \f$ (see `binaryExpr_or_nan`).
+//! @param k The index of the parameter to extract.
+//! @param n The desired output length.
+inline Eigen::VectorXd
+parameter_as_vector(const Eigen::MatrixXd& parameters,
+                    const Eigen::Index k,
+                    const Eigen::Index n)
+{
+  if (parameters.cols() == 1) {
+    return Eigen::VectorXd::Constant(n, parameters(k, 0));
+  }
+  return parameters.row(k).transpose();
+}
+
 void
 remove_nans(Eigen::MatrixXd& x);
 

--- a/test/src_test/include/test_bicop_kernel.hpp
+++ b/test/src_test/include/test_bicop_kernel.hpp
@@ -8,9 +8,11 @@
 
 #include "kernel_test.hpp"
 #include "rscript.hpp"
+#include "test_utils.hpp"
 
 namespace test_bicop_kernel {
 using namespace vinecopulib;
+using test_utils::all_close;
 
 TEST_P(TrafokernelTest, sanity_checks)
 {
@@ -58,7 +60,8 @@ TEST_P(TrafokernelTest, serialization)
   EXPECT_EQ(bicop_.get_family_name(), pc.get_family_name());
   EXPECT_EQ(bicop_.get_var_types(), pc.get_var_types());
   EXPECT_EQ(bicop_.get_npars(), pc.get_npars());
-  ASSERT_TRUE(bicop_.get_parameters().isApprox(pc.get_parameters(), 1e-4));
+  ASSERT_TRUE(
+    all_close(bicop_.get_parameters(), pc.get_parameters(), 1e-4, 1e-4));
 }
 
 TEST_P(TrafokernelTest, eval_funcs)
@@ -110,7 +113,7 @@ TEST_P(TrafokernelTest, flip)
   u.col(0).swap(u.col(1));
   bicop_.flip();
   auto pdf_flipped = bicop_.pdf(u);
-  EXPECT_TRUE(pdf.isApprox(pdf_flipped, 1e-10));
+  EXPECT_TRUE(all_close(pdf, pdf_flipped, 1e-10, 1e-10));
 }
 
 TEST_P(TrafokernelTest, tau)

--- a/test/src_test/include/test_bicop_parametric.hpp
+++ b/test/src_test/include/test_bicop_parametric.hpp
@@ -8,6 +8,7 @@
 
 #include "parbicop_test.hpp"
 #include "rscript.hpp"
+#include <cmath>
 
 namespace test_bicop_parametric {
 using namespace vinecopulib;
@@ -201,6 +202,113 @@ TEST_P(ParBicopTest, bicop_select_itau_bic_is_correct)
         << bicop.bic(data) << " " << bicop_.bic(data);
     }
   }
+}
+
+// Test that per-row-parameter evaluation matches a row-by-row loop over
+// single-parameter Bicop objects (the unchanged, state-based path).
+TEST_P(ParBicopTest, per_row_parameters_match_loop)
+{
+  if (!needs_check_)
+    return;
+  // per-row parameters are meaningless for the parameterless independence
+  // copula
+  if (bicop_.get_parameters().size() == 0)
+    return;
+
+  auto family = bicop_.get_family();
+  auto rotation = bicop_.get_rotation();
+  auto var_types = bicop_.get_var_types();
+  Eigen::Index n = 100;
+  Eigen::MatrixXd u = bicop_.simulate(n);
+
+  // build n distinct, in-bounds parameter sets (one per row)
+  Eigen::VectorXd lb = bicop_.get_parameters_lower_bounds();
+  Eigen::VectorXd ub = bicop_.get_parameters_upper_bounds();
+  Eigen::Index p = lb.size();
+  Eigen::VectorXd a = lb + 0.2 * (ub - lb);
+  Eigen::VectorXd c = lb + 0.6 * (ub - lb);
+  Eigen::MatrixXd P(n, p);
+  for (Eigen::Index i = 0; i < n; ++i) {
+    double w = static_cast<double>(i % 5) / 4.0;
+    P.row(i) = ((1 - w) * a + w * c).transpose();
+  }
+
+  // ground truth: loop over single-parameter Bicops (state-based path)
+  Eigen::VectorXd ref_pdf(n), ref_cdf(n), ref_h1(n), ref_h2(n), ref_i1(n),
+    ref_i2(n);
+  for (Eigen::Index i = 0; i < n; ++i) {
+    Bicop bi(family, rotation, P.row(i).transpose().eval(), var_types);
+    Eigen::MatrixXd ui = u.row(i);
+    ref_pdf(i) = bi.pdf(ui)(0);
+    ref_cdf(i) = bi.cdf(ui)(0);
+    ref_h1(i) = bi.hfunc1(ui)(0);
+    ref_h2(i) = bi.hfunc2(ui)(0);
+    ref_i1(i) = bi.hinv1(ui)(0);
+    ref_i2(i) = bi.hinv2(ui)(0);
+  }
+
+  ASSERT_TRUE(bicop_.pdf(u, P).isApprox(ref_pdf, 1e-8)) << bicop_.str();
+  ASSERT_TRUE(bicop_.cdf(u, P).isApprox(ref_cdf, 1e-8)) << bicop_.str();
+  ASSERT_TRUE(bicop_.hfunc1(u, P).isApprox(ref_h1, 1e-8)) << bicop_.str();
+  ASSERT_TRUE(bicop_.hfunc2(u, P).isApprox(ref_h2, 1e-8)) << bicop_.str();
+  ASSERT_TRUE(bicop_.hinv1(u, P).isApprox(ref_i1, 1e-8)) << bicop_.str();
+  ASSERT_TRUE(bicop_.hinv2(u, P).isApprox(ref_i2, 1e-8)) << bicop_.str();
+
+  // loglik matches the (NaN-ignoring) sum of the looped log-densities
+  double ref_ll = 0.0;
+  for (Eigen::Index i = 0; i < n; ++i) {
+    double lp = std::log(ref_pdf(i));
+    if (!(std::isnan)(lp))
+      ref_ll += lp;
+  }
+  ASSERT_NEAR(bicop_.loglik(u, P, 1), ref_ll, 1e-8) << bicop_.str();
+
+  // threading parity (results must not depend on num_threads)
+  ASSERT_TRUE(bicop_.pdf(u, P, 3).isApprox(bicop_.pdf(u, P, 1), 1e-12))
+    << bicop_.str();
+  ASSERT_TRUE(bicop_.hinv1(u, P, 3).isApprox(bicop_.hinv1(u, P, 1), 1e-12))
+    << bicop_.str();
+
+  // a single parameter set per row (broadcast) matches the single-arg path
+  Eigen::MatrixXd Pb = bicop_.get_parameters().transpose().replicate(n, 1);
+  ASSERT_TRUE(bicop_.pdf(u, Pb).isApprox(bicop_.pdf(u), 1e-8)) << bicop_.str();
+  ASSERT_TRUE(bicop_.hfunc1(u, Pb).isApprox(bicop_.hfunc1(u), 1e-8))
+    << bicop_.str();
+
+  // validation errors
+  EXPECT_ANY_THROW(bicop_.pdf(u, P.topRows(n - 1))); // wrong number of rows
+  {
+    Eigen::MatrixXd Pbad(n, p + 1);
+    Pbad.leftCols(p) = P;
+    Pbad.col(p).setConstant(0.5);
+    EXPECT_ANY_THROW(bicop_.pdf(u, Pbad)); // wrong number of columns
+  }
+
+  // discrete parity (both variables discrete)
+  {
+    Bicop disc = bicop_;
+    disc.set_var_types({ "d", "d" });
+    Eigen::MatrixXd u4(n, 4);
+    u4.leftCols(2) = u;
+    u4.rightCols(2) = (u.array() * 0.9).matrix(); // left limits below the cdf
+    Eigen::VectorXd ref_dpdf(n);
+    for (Eigen::Index i = 0; i < n; ++i) {
+      Bicop bi(family, rotation, P.row(i).transpose().eval(), { "d", "d" });
+      ref_dpdf(i) = bi.pdf(u4.row(i))(0);
+    }
+    ASSERT_TRUE(disc.pdf(u4, P).isApprox(ref_dpdf, 1e-8)) << bicop_.str();
+  }
+}
+
+// Test that nonparametric families reject per-row parameters
+TEST(BicopPerRowParameters, tll_throws)
+{
+  Bicop tll(BicopFamily::tll);
+  Eigen::MatrixXd u(2, 2);
+  u << 0.3, 0.4, 0.5, 0.6;
+  Eigen::MatrixXd parameters(2, 1);
+  parameters << 1.0, 1.0;
+  EXPECT_ANY_THROW(tll.pdf(u, parameters));
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/test/src_test/include/test_bicop_parametric.hpp
+++ b/test/src_test/include/test_bicop_parametric.hpp
@@ -8,12 +8,14 @@
 
 #include "parbicop_test.hpp"
 #include "rscript.hpp"
+#include "test_utils.hpp"
 #include <cmath>
 
 namespace test_bicop_parametric {
 using namespace vinecopulib;
 using namespace tools_stl;
 std::vector<int> rotations = { 0, 90, 180, 270 };
+using test_utils::all_close;
 
 // Test that the serialization works
 TEST_P(ParBicopTest, bicop_serialization_is_correct)
@@ -219,7 +221,9 @@ TEST_P(ParBicopTest, per_row_parameters_match_loop)
   auto rotation = bicop_.get_rotation();
   auto var_types = bicop_.get_var_types();
   Eigen::Index n = 100;
-  Eigen::MatrixXd u = bicop_.simulate(n);
+  // fixed seeds keep the test deterministic across runs and platforms
+  Eigen::MatrixXd u =
+    bicop_.simulate(static_cast<size_t>(n), false, { 1, 2, 3, 4, 5 });
 
   // build n distinct, in-bounds parameter sets (one per row)
   Eigen::VectorXd lb = bicop_.get_parameters_lower_bounds();
@@ -247,12 +251,12 @@ TEST_P(ParBicopTest, per_row_parameters_match_loop)
     ref_i2(i) = bi.hinv2(ui)(0);
   }
 
-  ASSERT_TRUE(bicop_.pdf(u, P).isApprox(ref_pdf, 1e-8)) << bicop_.str();
-  ASSERT_TRUE(bicop_.cdf(u, P).isApprox(ref_cdf, 1e-8)) << bicop_.str();
-  ASSERT_TRUE(bicop_.hfunc1(u, P).isApprox(ref_h1, 1e-8)) << bicop_.str();
-  ASSERT_TRUE(bicop_.hfunc2(u, P).isApprox(ref_h2, 1e-8)) << bicop_.str();
-  ASSERT_TRUE(bicop_.hinv1(u, P).isApprox(ref_i1, 1e-8)) << bicop_.str();
-  ASSERT_TRUE(bicop_.hinv2(u, P).isApprox(ref_i2, 1e-8)) << bicop_.str();
+  ASSERT_TRUE(all_close(bicop_.pdf(u, P), ref_pdf)) << bicop_.str();
+  ASSERT_TRUE(all_close(bicop_.cdf(u, P), ref_cdf)) << bicop_.str();
+  ASSERT_TRUE(all_close(bicop_.hfunc1(u, P), ref_h1)) << bicop_.str();
+  ASSERT_TRUE(all_close(bicop_.hfunc2(u, P), ref_h2)) << bicop_.str();
+  ASSERT_TRUE(all_close(bicop_.hinv1(u, P), ref_i1)) << bicop_.str();
+  ASSERT_TRUE(all_close(bicop_.hinv2(u, P), ref_i2)) << bicop_.str();
 
   // loglik matches the (NaN-ignoring) sum of the looped log-densities
   double ref_ll = 0.0;
@@ -261,18 +265,20 @@ TEST_P(ParBicopTest, per_row_parameters_match_loop)
     if (!(std::isnan)(lp))
       ref_ll += lp;
   }
-  ASSERT_NEAR(bicop_.loglik(u, P, 1), ref_ll, 1e-8) << bicop_.str();
+  ASSERT_NEAR(bicop_.loglik(u, P, 1), ref_ll, 1e-8 * (1.0 + std::abs(ref_ll)))
+    << bicop_.str();
 
   // threading parity (results must not depend on num_threads)
-  ASSERT_TRUE(bicop_.pdf(u, P, 3).isApprox(bicop_.pdf(u, P, 1), 1e-12))
+  ASSERT_TRUE(all_close(bicop_.pdf(u, P, 3), bicop_.pdf(u, P, 1), 1e-12, 1e-12))
     << bicop_.str();
-  ASSERT_TRUE(bicop_.hinv1(u, P, 3).isApprox(bicop_.hinv1(u, P, 1), 1e-12))
+  ASSERT_TRUE(
+    all_close(bicop_.hinv1(u, P, 3), bicop_.hinv1(u, P, 1), 1e-12, 1e-12))
     << bicop_.str();
 
   // a single parameter set per row (broadcast) matches the single-arg path
   Eigen::MatrixXd Pb = bicop_.get_parameters().transpose().replicate(n, 1);
-  ASSERT_TRUE(bicop_.pdf(u, Pb).isApprox(bicop_.pdf(u), 1e-8)) << bicop_.str();
-  ASSERT_TRUE(bicop_.hfunc1(u, Pb).isApprox(bicop_.hfunc1(u), 1e-8))
+  ASSERT_TRUE(all_close(bicop_.pdf(u, Pb), bicop_.pdf(u))) << bicop_.str();
+  ASSERT_TRUE(all_close(bicop_.hfunc1(u, Pb), bicop_.hfunc1(u)))
     << bicop_.str();
 
   // validation errors
@@ -296,7 +302,7 @@ TEST_P(ParBicopTest, per_row_parameters_match_loop)
       Bicop bi(family, rotation, P.row(i).transpose().eval(), { "d", "d" });
       ref_dpdf(i) = bi.pdf(u4.row(i))(0);
     }
-    ASSERT_TRUE(disc.pdf(u4, P).isApprox(ref_dpdf, 1e-8)) << bicop_.str();
+    ASSERT_TRUE(all_close(disc.pdf(u4, P), ref_dpdf)) << bicop_.str();
   }
 }
 

--- a/test/src_test/include/test_bicop_parametric.hpp
+++ b/test/src_test/include/test_bicop_parametric.hpp
@@ -35,7 +35,8 @@ TEST_P(ParBicopTest, bicop_serialization_is_correct)
   EXPECT_EQ(bicop_.get_family_name(), pc.get_family_name());
   EXPECT_EQ(bicop_.get_var_types(), pc.get_var_types());
   EXPECT_EQ(bicop_.get_npars(), pc.get_npars());
-  ASSERT_TRUE(bicop_.get_parameters().isApprox(pc.get_parameters(), 1e-4));
+  ASSERT_TRUE(
+    all_close(bicop_.get_parameters(), pc.get_parameters(), 1e-4, 1e-4));
 }
 
 // Test if the C++ implementation of the basic methods is correct
@@ -72,32 +73,38 @@ TEST_P(ParBicopTest, parametric_bicop_is_correct)
     // evaluate pdf in C++
     Eigen::VectorXd f = bicop_.pdf(u);
     // assert approximate equality
-    ASSERT_TRUE(f.isApprox(results.block(0, 3, n, 1), 1e-4)) << bicop_.str();
+    ASSERT_TRUE(all_close(f, results.block(0, 3, n, 1), 1e-4, 1e-4))
+      << bicop_.str();
 
     // evaluate cdf in C++
     f = bicop_.cdf(u);
     // assert approximate equality
-    ASSERT_TRUE(f.isApprox(results.block(0, 4, n, 1), 1e-4)) << bicop_.str();
+    ASSERT_TRUE(all_close(f, results.block(0, 4, n, 1), 1e-4, 1e-4))
+      << bicop_.str();
 
     // evaluate hfunc1 in C++
     f = bicop_.hfunc1(u);
     // assert approximate equality
-    ASSERT_TRUE(f.isApprox(results.block(0, 5, n, 1), 1e-4)) << bicop_.str();
+    ASSERT_TRUE(all_close(f, results.block(0, 5, n, 1), 1e-4, 1e-4))
+      << bicop_.str();
 
     // evaluate hfunc2 in C++
     f = bicop_.hfunc2(u);
     // assert approximate equality
-    ASSERT_TRUE(f.isApprox(results.block(0, 6, n, 1), 1e-4)) << bicop_.str();
+    ASSERT_TRUE(all_close(f, results.block(0, 6, n, 1), 1e-4, 1e-4))
+      << bicop_.str();
 
     // evaluate hinv1 in C++
     f = bicop_.hinv1(u);
     // assert approximate equality
-    ASSERT_TRUE(f.isApprox(results.block(0, 7, n, 1), 1e-4)) << bicop_.str();
+    ASSERT_TRUE(all_close(f, results.block(0, 7, n, 1), 1e-4, 1e-4))
+      << bicop_.str();
 
     // evaluate hinv2 in C++
     f = bicop_.hinv2(u);
     // assert approximate equality
-    ASSERT_TRUE(f.isApprox(results.block(0, 8, n, 1), 1e-4)) << bicop_.str();
+    ASSERT_TRUE(all_close(f, results.block(0, 8, n, 1), 1e-4, 1e-4))
+      << bicop_.str();
 
     u(0, 0) = std::numeric_limits<double>::quiet_NaN();
     u(1, 1) = std::numeric_limits<double>::quiet_NaN();
@@ -290,19 +297,36 @@ TEST_P(ParBicopTest, per_row_parameters_match_loop)
     EXPECT_ANY_THROW(bicop_.pdf(u, Pbad)); // wrong number of columns
   }
 
-  // discrete parity (both variables discrete)
+  // discrete parity: per-row parameters through the discrete density,
+  // h-function and h-inverse code paths (pdf_c_d / pdf_d_d, the discrete
+  // h-functions, and the numeric h-inverses) for all combinations of
+  // discrete/continuous variables.
   {
-    Bicop disc = bicop_;
-    disc.set_var_types({ "d", "d" });
     Eigen::MatrixXd u4(n, 4);
     u4.leftCols(2) = u;
     u4.rightCols(2) = (u.array() * 0.9).matrix(); // left limits below the cdf
-    Eigen::VectorXd ref_dpdf(n);
-    for (Eigen::Index i = 0; i < n; ++i) {
-      Bicop bi(family, rotation, P.row(i).transpose().eval(), { "d", "d" });
-      ref_dpdf(i) = bi.pdf(u4.row(i))(0);
+    const std::vector<std::vector<std::string>> var_type_sets = {
+      { "d", "d" }, { "c", "d" }, { "d", "c" }
+    };
+    for (const auto& vt : var_type_sets) {
+      Bicop disc = bicop_;
+      disc.set_var_types(vt);
+      Eigen::VectorXd r_pdf(n), r_h1(n), r_h2(n), r_i1(n), r_i2(n);
+      for (Eigen::Index i = 0; i < n; ++i) {
+        Bicop bi(family, rotation, P.row(i).transpose().eval(), vt);
+        Eigen::MatrixXd u4i = u4.row(i);
+        r_pdf(i) = bi.pdf(u4i)(0);
+        r_h1(i) = bi.hfunc1(u4i)(0);
+        r_h2(i) = bi.hfunc2(u4i)(0);
+        r_i1(i) = bi.hinv1(u4i)(0);
+        r_i2(i) = bi.hinv2(u4i)(0);
+      }
+      ASSERT_TRUE(all_close(disc.pdf(u4, P), r_pdf)) << disc.str();
+      ASSERT_TRUE(all_close(disc.hfunc1(u4, P), r_h1)) << disc.str();
+      ASSERT_TRUE(all_close(disc.hfunc2(u4, P), r_h2)) << disc.str();
+      ASSERT_TRUE(all_close(disc.hinv1(u4, P), r_i1)) << disc.str();
+      ASSERT_TRUE(all_close(disc.hinv2(u4, P), r_i2)) << disc.str();
     }
-    ASSERT_TRUE(all_close(disc.pdf(u4, P), ref_dpdf)) << bicop_.str();
   }
 }
 
@@ -315,6 +339,22 @@ TEST(BicopPerRowParameters, tll_throws)
   Eigen::MatrixXd parameters(2, 1);
   parameters << 1.0, 1.0;
   EXPECT_ANY_THROW(tll.pdf(u, parameters));
+}
+
+// The independence copula has no parameters (p = 0); the per-row overloads
+// accept an n x 0 matrix and fall back to the parameter-free leaves.
+TEST(BicopPerRowParameters, independence_zero_parameters)
+{
+  Bicop ind(BicopFamily::indep);
+  const Eigen::Index n = 20;
+  Eigen::MatrixXd u = ind.simulate(static_cast<size_t>(n), false, { 1, 2, 3 });
+  Eigen::MatrixXd P(n, 0); // no parameters
+  EXPECT_TRUE(all_close(ind.pdf(u, P), ind.pdf(u)));
+  EXPECT_TRUE(all_close(ind.cdf(u, P), ind.cdf(u)));
+  EXPECT_TRUE(all_close(ind.hfunc1(u, P), ind.hfunc1(u)));
+  EXPECT_TRUE(all_close(ind.hfunc2(u, P), ind.hfunc2(u)));
+  EXPECT_TRUE(all_close(ind.hinv1(u, P), ind.hinv1(u)));
+  EXPECT_TRUE(all_close(ind.hinv2(u, P), ind.hinv2(u)));
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/test/src_test/include/test_bicop_parametric.hpp
+++ b/test/src_test/include/test_bicop_parametric.hpp
@@ -10,6 +10,7 @@
 #include "rscript.hpp"
 #include "test_utils.hpp"
 #include <cmath>
+#include <limits>
 
 namespace test_bicop_parametric {
 using namespace vinecopulib;
@@ -278,6 +279,11 @@ TEST_P(ParBicopTest, per_row_parameters_match_loop)
   // threading parity (results must not depend on num_threads)
   ASSERT_TRUE(all_close(bicop_.pdf(u, P, 3), bicop_.pdf(u, P, 1), 1e-12, 1e-12))
     << bicop_.str();
+  ASSERT_TRUE(all_close(bicop_.cdf(u, P, 3), bicop_.cdf(u, P, 1), 1e-12, 1e-12))
+    << bicop_.str();
+  ASSERT_TRUE(
+    all_close(bicop_.hfunc2(u, P, 3), bicop_.hfunc2(u, P, 1), 1e-12, 1e-12))
+    << bicop_.str();
   ASSERT_TRUE(
     all_close(bicop_.hinv1(u, P, 3), bicop_.hinv1(u, P, 1), 1e-12, 1e-12))
     << bicop_.str();
@@ -285,8 +291,13 @@ TEST_P(ParBicopTest, per_row_parameters_match_loop)
   // a single parameter set per row (broadcast) matches the single-arg path
   Eigen::MatrixXd Pb = bicop_.get_parameters().transpose().replicate(n, 1);
   ASSERT_TRUE(all_close(bicop_.pdf(u, Pb), bicop_.pdf(u))) << bicop_.str();
+  ASSERT_TRUE(all_close(bicop_.cdf(u, Pb), bicop_.cdf(u))) << bicop_.str();
   ASSERT_TRUE(all_close(bicop_.hfunc1(u, Pb), bicop_.hfunc1(u)))
     << bicop_.str();
+  ASSERT_TRUE(all_close(bicop_.hfunc2(u, Pb), bicop_.hfunc2(u)))
+    << bicop_.str();
+  ASSERT_TRUE(all_close(bicop_.hinv1(u, Pb), bicop_.hinv1(u))) << bicop_.str();
+  ASSERT_TRUE(all_close(bicop_.hinv2(u, Pb), bicop_.hinv2(u))) << bicop_.str();
 
   // validation errors
   EXPECT_ANY_THROW(bicop_.pdf(u, P.topRows(n - 1))); // wrong number of rows
@@ -295,6 +306,16 @@ TEST_P(ParBicopTest, per_row_parameters_match_loop)
     Pbad.leftCols(p) = P;
     Pbad.col(p).setConstant(0.5);
     EXPECT_ANY_THROW(bicop_.pdf(u, Pbad)); // wrong number of columns
+  }
+  {
+    Eigen::MatrixXd Pnan = P;
+    Pnan(0, 0) = std::numeric_limits<double>::quiet_NaN();
+    EXPECT_ANY_THROW(bicop_.pdf(u, Pnan)); // NaN parameter
+  }
+  {
+    Eigen::MatrixXd Poob = P;
+    Poob(0, 0) = lb(0) - 1.0;              // below the lower bound
+    EXPECT_ANY_THROW(bicop_.pdf(u, Poob)); // out-of-bounds parameter
   }
 
   // discrete parity: per-row parameters through the discrete density,
@@ -327,6 +348,36 @@ TEST_P(ParBicopTest, per_row_parameters_match_loop)
       ASSERT_TRUE(all_close(disc.hinv1(u4, P), r_i1)) << disc.str();
       ASSERT_TRUE(all_close(disc.hinv2(u4, P), r_i2)) << disc.str();
     }
+  }
+
+  // when the conditioning variable is continuous, the h-inverse strips the
+  // discrete companion column and must reproduce the purely-continuous result
+  // (the discrete left-limit provably cannot enter the conditional quantile).
+  {
+    Eigen::MatrixXd u4(n, 4);
+    u4.leftCols(2) = u;
+    u4.rightCols(2) = (u.array() * 0.9).matrix();
+    Bicop dc = bicop_;
+    dc.set_var_types({ "d", "c" }); // hinv2 conditions on the continuous var 2
+    Bicop cd = bicop_;
+    cd.set_var_types({ "c", "d" }); // hinv1 conditions on the continuous var 1
+    ASSERT_TRUE(all_close(dc.hinv2(u4, P), bicop_.hinv2(u, P), 0.0, 1e-12))
+      << bicop_.str();
+    ASSERT_TRUE(all_close(cd.hinv1(u4, P), bicop_.hinv1(u, P), 0.0, 1e-12))
+      << bicop_.str();
+  }
+
+  // the h-inverse inverts its own h-function (continuous round-trip):
+  // hfunc1(u1, hinv1(u1, w)) == w and hfunc2(hinv2(w, u2), u2) == w
+  {
+    Eigen::MatrixXd u1inv = u;
+    u1inv.col(1) = bicop_.hinv1(u, P);
+    ASSERT_TRUE(all_close(bicop_.hfunc1(u1inv, P), u.col(1), 1e-5, 1e-5))
+      << bicop_.str();
+    Eigen::MatrixXd u2inv = u;
+    u2inv.col(0) = bicop_.hinv2(u, P);
+    ASSERT_TRUE(all_close(bicop_.hfunc2(u2inv, P), u.col(0), 1e-5, 1e-5))
+      << bicop_.str();
   }
 }
 

--- a/test/src_test/include/test_tools_stats.hpp
+++ b/test/src_test/include/test_tools_stats.hpp
@@ -62,14 +62,19 @@ TEST(test_tools_stats, qrng_are_correct)
   size_t N = 1000;
   double Nd = static_cast<double>(N);
 
+  // seeded so the simulated evaluation points (and hence the test) are
+  // deterministic across runs and platforms
+  std::vector<int> seeds = { 1, 2, 3, 4, 5 };
   auto cop = Bicop(BicopFamily::gaussian);
-  auto u = cop.simulate(n);
+  auto u = cop.simulate(n, false, seeds);
   auto U = tools_stats::ghalton(N, d);
   auto U1 = tools_stats::sobol(N, d);
-  auto U2 = tools_stats::simulate_uniform(N, d);
 
-  Eigen::VectorXd x(N), p(n), p1(N), x2(N), p2(n);
-  p2 = Eigen::VectorXd::Zero(n);
+  // Monte-Carlo CDF estimate at each simulated point using each low-discrepancy
+  // sequence: p(i) = (1/N) sum_j 1{U_j1 <= u_i1, hinv1(U_j) <= u_i2}. ghalton
+  // and sobol converge much faster than plain Monte Carlo, so at N = 1000 they
+  // recover the analytical copula CDF to well within 1e-2.
+  Eigen::VectorXd x(N), p(n), p1(n);
   for (size_t i = 0; i < n; i++) {
     auto f = [i, u](const double& u1, const double& u2) {
       return (u1 <= u(i, 0) && u2 <= u(i, 1)) ? 1.0 : 0.0;
@@ -78,15 +83,11 @@ TEST(test_tools_stats, qrng_are_correct)
     p(i) = x.sum() / Nd;
     x = U1.col(0).binaryExpr(cop.hinv1(U1), f);
     p1(i) = x.sum() / Nd;
-    x2 = U2.col(0).binaryExpr(cop.hinv1(U2), f);
-    p2(i) = x2.sum() / Nd;
   }
 
   x = cop.cdf(u);
-  if (all_close(p2, x, 1e-2, 1e-2)) {
-    ASSERT_TRUE(all_close(p, x, 1e-2, 1e-2));
-    ASSERT_TRUE(all_close(p1, x, 1e-2, 1e-2));
-  }
+  ASSERT_TRUE(all_close(p, x, 1e-2, 1e-2));  // ghalton
+  ASSERT_TRUE(all_close(p1, x, 1e-2, 1e-2)); // sobol
 }
 
 TEST(test_tools_stats, mcor_works)

--- a/test/src_test/include/test_tools_stats.hpp
+++ b/test/src_test/include/test_tools_stats.hpp
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include "test_utils.hpp"
 #include "test_vinecop_sanity_checks.hpp"
 #include "gtest/gtest.h"
 #include <vinecopulib.hpp>
@@ -13,6 +14,7 @@
 namespace test_tools_stats {
 
 using namespace vinecopulib;
+using test_utils::all_close;
 
 TEST(test_tools_stats, to_pseudo_obs_is_correct)
 {
@@ -81,9 +83,9 @@ TEST(test_tools_stats, qrng_are_correct)
   }
 
   x = cop.cdf(u);
-  if (p2.isApprox(x, 1e-2)) {
-    ASSERT_TRUE(p.isApprox(x, 1e-2));
-    ASSERT_TRUE(p1.isApprox(x, 1e-2));
+  if (all_close(p2, x, 1e-2, 1e-2)) {
+    ASSERT_TRUE(all_close(p, x, 1e-2, 1e-2));
+    ASSERT_TRUE(all_close(p1, x, 1e-2, 1e-2));
   }
 }
 
@@ -145,17 +147,17 @@ TEST(test_tools_stats, dpqnorm_work)
   // tools_stats::dnorm is the same as dnorm_boost
   auto d1 = tools_stats::dnorm(X);
   auto d2 = dnorm_boost(X);
-  ASSERT_TRUE(d1.isApprox(d2, 1e-6));
+  ASSERT_TRUE(all_close(d1, d2, 1e-6, 1e-6));
 
   // tools_stats::pnorm is the same as pnorm_boost
   auto p1 = tools_stats::pnorm(X);
   auto p2 = pnorm_boost(X);
-  ASSERT_TRUE(p1.isApprox(p2, 1e-6));
+  ASSERT_TRUE(all_close(p1, p2, 1e-6, 1e-6));
 
   // tools_stats::qnorm is the same as qnorm_boost
   auto q1 = tools_stats::qnorm(p1);
   auto q2 = qnorm_boost(p1);
-  ASSERT_TRUE(q1.isApprox(q2, 1e-6));
+  ASSERT_TRUE(all_close(q1, q2, 1e-6, 1e-6));
 }
 
 TEST(test_tools_stats, dpqnorm_are_nan_safe)

--- a/test/src_test/include/test_utils.hpp
+++ b/test/src_test/include/test_utils.hpp
@@ -13,47 +13,53 @@
 //! Shared helpers for the unit tests.
 namespace test_utils {
 
-//! @brief Element-wise comparison of two vectors that tolerates non-finite
-//! values.
+//! @brief Element-wise comparison of two Eigen expressions that tolerates
+//! non-finite values.
 //!
-//! Finite entries must agree within `atol + rtol * |b(i)|`, while non-finite
+//! Finite entries must agree within `atol + rtol * |b(i, j)|`, while non-finite
 //! entries must agree exactly (both NaN, or equal infinities). This is useful
 //! because some copula quantities are genuinely NaN/Inf at specific parameter
 //! values (e.g., the Frank density at `theta = 0`, which is `0/0` and evaluates
 //! to NaN or a finite value depending on the platform's floating-point
 //! contraction), whereas `Eigen::DenseBase::isApprox` treats any NaN as a
-//! mismatch. On failure the offending index and values are reported.
+//! mismatch and is norm-based rather than element-wise. On failure the
+//! offending index and values are reported.
 //!
-//! @param a,b The vectors to compare.
+//! @param a,b The expressions to compare (must have the same shape).
 //! @param rtol Relative tolerance for finite entries.
 //! @param atol Absolute tolerance for finite entries.
+template<typename DerivedA, typename DerivedB>
 inline ::testing::AssertionResult
-all_close(const Eigen::VectorXd& a,
-          const Eigen::VectorXd& b,
+all_close(const Eigen::DenseBase<DerivedA>& a,
+          const Eigen::DenseBase<DerivedB>& b,
           double rtol = 1e-8,
           double atol = 1e-8)
 {
-  if (a.size() != b.size()) {
+  if (a.rows() != b.rows() || a.cols() != b.cols()) {
     return ::testing::AssertionFailure()
-           << "size mismatch: " << a.size() << " != " << b.size();
+           << "shape mismatch: (" << a.rows() << " x " << a.cols() << ") vs ("
+           << b.rows() << " x " << b.cols() << ")";
   }
-  for (Eigen::Index i = 0; i < a.size(); ++i) {
-    const double x = a(i);
-    const double y = b(i);
-    if ((std::isfinite)(x) && (std::isfinite)(y)) {
-      const double bound = atol + rtol * std::abs(y);
-      if (std::abs(x - y) > bound) {
-        return ::testing::AssertionFailure()
-               << "mismatch at index " << i << ": " << x << " vs " << y
-               << ", abs diff = " << std::abs(x - y)
-               << ", tolerance = " << bound;
-      }
-    } else {
-      // both NaN, or equal infinities (handles +inf/+inf and -inf/-inf)
-      const bool both_nan = (std::isnan)(x) && (std::isnan)(y);
-      if (!both_nan && !(x == y)) {
-        return ::testing::AssertionFailure() << "non-finite mismatch at index "
-                                             << i << ": " << x << " vs " << y;
+  for (Eigen::Index j = 0; j < a.cols(); ++j) {
+    for (Eigen::Index i = 0; i < a.rows(); ++i) {
+      const double x = static_cast<double>(a(i, j));
+      const double y = static_cast<double>(b(i, j));
+      if ((std::isfinite)(x) && (std::isfinite)(y)) {
+        const double bound = atol + rtol * std::abs(y);
+        if (std::abs(x - y) > bound) {
+          return ::testing::AssertionFailure()
+                 << "mismatch at (" << i << ", " << j << "): " << x << " vs "
+                 << y << ", abs diff = " << std::abs(x - y)
+                 << ", tolerance = " << bound;
+        }
+      } else {
+        // both NaN, or equal infinities (handles +inf/+inf and -inf/-inf)
+        const bool both_nan = (std::isnan)(x) && (std::isnan)(y);
+        if (!both_nan && !(x == y)) {
+          return ::testing::AssertionFailure()
+                 << "non-finite mismatch at (" << i << ", " << j << "): " << x
+                 << " vs " << y;
+        }
       }
     }
   }

--- a/test/src_test/include/test_utils.hpp
+++ b/test/src_test/include/test_utils.hpp
@@ -1,0 +1,63 @@
+// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+//
+// This file is part of the vinecopulib library and licensed under the terms of
+// the MIT license. For a copy, see the LICENSE file in the root directory of
+// vinecopulib or https://vinecopulib.github.io/vinecopulib/.
+
+#pragma once
+
+#include "gtest/gtest.h"
+#include <Eigen/Dense>
+#include <cmath>
+
+//! Shared helpers for the unit tests.
+namespace test_utils {
+
+//! @brief Element-wise comparison of two vectors that tolerates non-finite
+//! values.
+//!
+//! Finite entries must agree within `atol + rtol * |b(i)|`, while non-finite
+//! entries must agree exactly (both NaN, or equal infinities). This is useful
+//! because some copula quantities are genuinely NaN/Inf at specific parameter
+//! values (e.g., the Frank density at `theta = 0`, which is `0/0` and evaluates
+//! to NaN or a finite value depending on the platform's floating-point
+//! contraction), whereas `Eigen::DenseBase::isApprox` treats any NaN as a
+//! mismatch. On failure the offending index and values are reported.
+//!
+//! @param a,b The vectors to compare.
+//! @param rtol Relative tolerance for finite entries.
+//! @param atol Absolute tolerance for finite entries.
+inline ::testing::AssertionResult
+all_close(const Eigen::VectorXd& a,
+          const Eigen::VectorXd& b,
+          double rtol = 1e-8,
+          double atol = 1e-8)
+{
+  if (a.size() != b.size()) {
+    return ::testing::AssertionFailure()
+           << "size mismatch: " << a.size() << " != " << b.size();
+  }
+  for (Eigen::Index i = 0; i < a.size(); ++i) {
+    const double x = a(i);
+    const double y = b(i);
+    if ((std::isfinite)(x) && (std::isfinite)(y)) {
+      const double bound = atol + rtol * std::abs(y);
+      if (std::abs(x - y) > bound) {
+        return ::testing::AssertionFailure()
+               << "mismatch at index " << i << ": " << x << " vs " << y
+               << ", abs diff = " << std::abs(x - y)
+               << ", tolerance = " << bound;
+      }
+    } else {
+      // both NaN, or equal infinities (handles +inf/+inf and -inf/-inf)
+      const bool both_nan = (std::isnan)(x) && (std::isnan)(y);
+      if (!both_nan && !(x == y)) {
+        return ::testing::AssertionFailure() << "non-finite mismatch at index "
+                                             << i << ": " << x << " vs " << y;
+      }
+    }
+  }
+  return ::testing::AssertionSuccess();
+}
+
+} // namespace test_utils

--- a/test/src_test/include/test_vinecop_class.hpp
+++ b/test/src_test/include/test_vinecop_class.hpp
@@ -6,6 +6,7 @@
 
 #pragma once
 
+#include "test_utils.hpp"
 #include "vinecop_test.hpp"
 #include <string>
 #include <vinecopulib.hpp>
@@ -13,6 +14,7 @@
 
 namespace test_vinecop_class {
 using namespace vinecopulib;
+using test_utils::all_close;
 
 TEST_F(VinecopTest, constructors_without_error)
 {
@@ -281,7 +283,7 @@ TEST_F(VinecopTest, pdf_is_correct)
   }
   Vinecop vinecop(model_matrix, pair_copulas);
 
-  ASSERT_TRUE(vinecop.pdf(u).isApprox(f, 1e-4));
+  ASSERT_TRUE(all_close(vinecop.pdf(u), f, 1e-4, 1e-4));
 }
 
 TEST_F(VinecopTest, hfuncs_is_correct)
@@ -345,7 +347,7 @@ TEST_F(VinecopTest, cdf_is_correct)
 
   // Test whether the analytic and simulated versions are "close" enough
   auto u2 = vinecop.simulate(10);
-  ASSERT_TRUE(vinecop.cdf(u2, 10000).isApprox(bicop.cdf(u2), 1e-2));
+  ASSERT_TRUE(all_close(vinecop.cdf(u2, 10000), bicop.cdf(u2), 1e-2, 1e-2));
 
   // verify that qrng stuff works
   Vinecop vinecop2(301);
@@ -366,7 +368,7 @@ TEST_F(VinecopTest, simulate_is_correct)
   // only check if it works
   vinecop.simulate(10);
   // check the underlying transformation from independent samples
-  ASSERT_TRUE(vinecop.inverse_rosenblatt(u).isApprox(sim, 1e-4));
+  ASSERT_TRUE(all_close(vinecop.inverse_rosenblatt(u), sim, 1e-4, 1e-4));
 
   // verify that qrng stuff works
   vinecop.simulate(10, true);
@@ -385,8 +387,8 @@ TEST_F(VinecopTest, rosenblatt_is_correct)
   }
   Vinecop vinecop(model_matrix, pair_copulas);
   auto u2 = vinecop.simulate(5);
-  ASSERT_TRUE(
-    vinecop.rosenblatt(vinecop.inverse_rosenblatt(u2)).isApprox(u2, 1e-6));
+  ASSERT_TRUE(all_close(
+    vinecop.rosenblatt(vinecop.inverse_rosenblatt(u2)), u2, 1e-6, 1e-6));
 
   // truncated multivariate
   pair_copulas = Vinecop::make_pair_copula_store(7, 2);
@@ -396,8 +398,8 @@ TEST_F(VinecopTest, rosenblatt_is_correct)
     }
   }
   vinecop = Vinecop(model_matrix, pair_copulas);
-  ASSERT_TRUE(
-    vinecop.rosenblatt(vinecop.inverse_rosenblatt(u)).isApprox(u, 1e-6));
+  ASSERT_TRUE(all_close(
+    vinecop.rosenblatt(vinecop.inverse_rosenblatt(u)), u, 1e-6, 1e-6));
 
   // bivariate case
   pair_copulas = Vinecop::make_pair_copula_store(2);
@@ -410,8 +412,8 @@ TEST_F(VinecopTest, rosenblatt_is_correct)
   mat << 1, 1, 2, 0;
   vinecop = Vinecop(mat, pair_copulas);
   u = vinecop.simulate(5);
-  ASSERT_TRUE(
-    vinecop.rosenblatt(vinecop.inverse_rosenblatt(u)).isApprox(u, 1e-6));
+  ASSERT_TRUE(all_close(
+    vinecop.rosenblatt(vinecop.inverse_rosenblatt(u)), u, 1e-6, 1e-6));
 }
 
 TEST_F(VinecopTest, scores_stepwise)
@@ -601,10 +603,11 @@ TEST_F(VinecopTest, works_multi_threaded)
   EXPECT_NEAR(fit1.loglik(u), fit3.loglik(u), 1e-2);
 
   // check if parallel evaluators have same output as single threaded ones
-  EXPECT_TRUE(fit2.pdf(u, 2).isApprox(fit2.pdf(u), 1e-10));
+  EXPECT_TRUE(all_close(fit2.pdf(u, 2), fit2.pdf(u), 1e-10, 1e-10));
+  EXPECT_TRUE(all_close(
+    fit2.inverse_rosenblatt(u, 2), fit2.inverse_rosenblatt(u), 1e-10, 1e-10));
   EXPECT_TRUE(
-    fit2.inverse_rosenblatt(u, 2).isApprox(fit2.inverse_rosenblatt(u), 1e-10));
-  EXPECT_TRUE(fit2.rosenblatt(u, 2).isApprox(fit2.rosenblatt(u), 1e-10));
+    all_close(fit2.rosenblatt(u, 2), fit2.rosenblatt(u), 1e-10, 1e-10));
 
   // just check that it works
   fit2.simulate(2, false, 3);
@@ -853,7 +856,8 @@ TEST_F(VinecopTest, tawn_flipping)
       auto pc2 = fit2.get_pair_copula(tree, edge);
       ASSERT_EQ(pc1.get_family(), pc2.get_family());
       ASSERT_EQ(pc1.get_rotation(), pc2.get_rotation());
-      ASSERT_TRUE(pc1.get_parameters().isApprox(pc2.get_parameters(), 0.01));
+      ASSERT_TRUE(
+        all_close(pc1.get_parameters(), pc2.get_parameters(), 0.01, 0.01));
     }
   }
 }


### PR DESCRIPTION
## Per-row parameters for `Bicop` (+ eval-core refactor)

Adds overloads of `Bicop::pdf`, `cdf`, `hfunc1`, `hfunc2`, `hinv1`, `hinv2`, and `loglik` that evaluate a parametric bivariate copula at a **different parameter set per row of `u`** in one (optionally multi-threaded) call. Following review, it also refactors the evaluation core to a single parameter-aware interface and fixes a latent out-of-bounds bug in the mixed discrete/continuous h-inverse.

```cpp
Eigen::VectorXd pdf(const Eigen::MatrixXd& u,
                    const Eigen::MatrixXd& parameters,  // n x p, one set per row
                    size_t num_threads = 1) const;
```

### What's in it
- **Feature — per-row parameters.** Additive overloads for all six evaluators + `loglik`, parametric families only (TLL throws; independence accepts an `n×0` matrix). The facade validates shape/bounds/finiteness and parallelizes over row batches.
- **Refactor — one leaf per primitive.** Each of `pdf_raw/cdf/hfunc1_raw/hfunc2_raw/hinv1_raw/hinv2_raw` is now a single **parameter-aware pure-virtual** leaf; the duplicated no-argument state forms are removed. State dispatchers call the leaves with the stored parameters as a broadcast row; nonparametric families ignore the argument and use their grid. Net **−235 lines**.
- **Bug fix — mixed-discrete h-inverse.** For a `{d,c}` copula with a numeric inverse (Frank, BB*, Tawn), `hinv2` stripped to two columns and the bisection re-entered the discrete difference-quotient branch of `hfunc1` on a 2-column matrix → out-of-bounds read (heap corruption in release, assertion in debug). The numeric inverse is split so the continuous `_raw` primitives invert the continuous `*_raw` leaves; the discrete branch is now reachable only with 4-column data by construction, and the `u.cols()==4` guard is removed.
- **Internal convention.** The internal parameter layout now matches the public API (`n×p`, one row per observation), so `format_parameters` no longer transposes.

### Correctness
The h-inverse is correct for all four var-type configs: stripping the discrete companion column when the *conditioning* variable is continuous is **exact** (`{d,c}` hinv2 ≡ `{c,c}` hinv2 bit-for-bit), and the difference-quotient inversion for discrete-conditioning configs is the right primitive. Confirmed from first principles, against VineCopula's `BiCopHinv` (~3e-11), and by bit-identity + round-trip tests.

### Tests & verification
Per-row parity (all methods × families × rotations), discrete configs, threading, broadcast, NaN/bounds, `{d,c}`≡`{c,c}` bit-identity, continuous round-trip. Release **350/350**; Debug **+ASan 350/350** (no sanitizer errors); `STRICT_COMPILER` GNU build clean; `VINECOPULIB_PRECOMPILED=ON` build + tests pass; R-parity; clang-format-14 clean.

### Downstream
No public-API break (leaves are `protected`); `rvinecopulib`/`pyvinecopulib` keep compiling. Exposing the overloads is a pin bump + bindings.
