### PR TITLE
Fix thread include

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -450,7 +450,8 @@ Infrastructure shared across both modules:
 - **`tools_thread` + `tools_interface` + `tools_batch`** — a `std::thread`
   `ThreadPool`, batched work partitioning, and the `INTERFACED_FROM_R`
   switch that swaps in RcppThread + R printing/interrupt handling when the
-  library is compiled inside R.
+  library is compiled inside R. **Never include `tools_thread.hpp`
+  directly; always pull it implicitly through `tools_interface.hpp`.**
 - **`triangular_array.hpp`** — `TriangularArray<T>`, the ragged container
   that mirrors a (possibly truncated) vine.
 - **`tools_eigen`, `tools_stl`, `tools_integration`, `tools_constants`,

--- a/include/vinecopulib/bicop/implementation/class.ipp
+++ b/include/vinecopulib/bicop/implementation/class.ipp
@@ -13,7 +13,6 @@
 #include <vinecopulib/misc/tools_serialization.hpp>
 #include <vinecopulib/misc/tools_stats.hpp>
 #include <vinecopulib/misc/tools_stl.hpp>
-#include <vinecopulib/misc/tools_thread.hpp>
 
 //! Tools for bivariate and vine copula modeling
 namespace vinecopulib {


### PR DESCRIPTION
`tools_thread.hpp` should never be included directly; always pull it implicitly through `tools_interface.hpp` or the R-frontend breaks.