### PR TITLE
Discrete start pars

### DIFF
--- a/include/vinecopulib/bicop/implementation/parametric.ipp
+++ b/include/vinecopulib/bicop/implementation/parametric.ipp
@@ -217,16 +217,16 @@ ParBicop::check_parameters_size(const Eigen::MatrixXd& parameters)
   if (parameters.size() != parameters_.size()) {
     if (parameters.rows() != parameters_.rows()) {
       std::stringstream message;
-      message << "parameters have has wrong number of rows " << "for "
-              << get_family_name() << " copula; "
+      message << "parameters have has wrong number of rows "
+              << "for " << get_family_name() << " copula; "
               << "expected: " << parameters_.rows() << ", "
               << "actual: " << parameters.rows() << std::endl;
       throw std::runtime_error(message.str().c_str());
     }
     if (parameters.cols() != parameters_.cols()) {
       std::stringstream message;
-      message << "parameters have wrong number of columns " << "for "
-              << get_family_name() << " copula; "
+      message << "parameters have wrong number of columns "
+              << "for " << get_family_name() << " copula; "
               << "expected: " << parameters_.cols() << ", "
               << "actual: " << parameters.cols() << std::endl;
       throw std::runtime_error(message.str().c_str());
@@ -240,8 +240,8 @@ ParBicop::check_parameters_lower(const Eigen::MatrixXd& parameters)
   if (parameters_lower_bounds_.size() > 0) {
     std::stringstream message;
     if ((parameters.array() < parameters_lower_bounds_.array()).any()) {
-      message << "parameters exceed lower bound " << "for " << get_family_name()
-              << " copula; " << std::endl
+      message << "parameters exceed lower bound "
+              << "for " << get_family_name() << " copula; " << std::endl
               << "bound:" << std::endl
               << parameters_lower_bounds_ << std::endl
               << "actual:" << std::endl
@@ -257,8 +257,8 @@ ParBicop::check_parameters_upper(const Eigen::MatrixXd& parameters)
   if (parameters_upper_bounds_.size() > 0) {
     std::stringstream message;
     if ((parameters.array() > parameters_upper_bounds_.array()).any()) {
-      message << "parameters exceed upper bound " << "for " << get_family_name()
-              << " copula; " << std::endl
+      message << "parameters exceed upper bound "
+              << "for " << get_family_name() << " copula; " << std::endl
               << "bound:" << std::endl
               << parameters_upper_bounds_ << std::endl
               << "actual:" << std::endl

--- a/include/vinecopulib/bicop/implementation/parametric.ipp
+++ b/include/vinecopulib/bicop/implementation/parametric.ipp
@@ -176,15 +176,16 @@ ParBicop::adjust_parameters_bounds(Eigen::MatrixXd& lb,
   }
 
   // refine search interval for Brent algorithm
+  double eps = (var_types_ == std::vector<std::string>{"c", "c"}) ? 0.1 : 0.6;
   if (tools_stl::is_member(family_, bicop_families::one_par)) {
     auto lb2 = lb;
     auto ub2 = ub;
     if (tools_stl::is_member(family_, bicop_families::rotationless)) {
-      lb = tau_to_parameters(std::max(tau - 0.1, -0.99));
-      ub = tau_to_parameters(std::min(tau + 0.1, 0.99));
+      lb = tau_to_parameters(std::max(tau - eps, -0.99));
+      ub = tau_to_parameters(std::min(tau + eps, 0.99));
     } else {
-      lb = tau_to_parameters(std::max(std::fabs(tau) - 0.1, 1e-10));
-      ub = tau_to_parameters(std::min(std::fabs(tau) + 0.1, 0.95));
+      lb = tau_to_parameters(std::max(std::fabs(tau) - eps, 1e-10));
+      ub = tau_to_parameters(std::min(std::fabs(tau) + eps, 0.95));
     }
     // make sure that parameter bounds are respected
     lb = lb2.cwiseMax(lb);

--- a/include/vinecopulib/bicop/implementation/parametric.ipp
+++ b/include/vinecopulib/bicop/implementation/parametric.ipp
@@ -176,7 +176,7 @@ ParBicop::adjust_parameters_bounds(Eigen::MatrixXd& lb,
   }
 
   // refine search interval for Brent algorithm
-  double eps = (var_types_ == std::vector<std::string>{"c", "c"}) ? 0.1 : 0.6;
+  double eps = (var_types_ == std::vector<std::string>{ "c", "c" }) ? 0.1 : 0.6;
   if (tools_stl::is_member(family_, bicop_families::one_par)) {
     auto lb2 = lb;
     auto ub2 = ub;
@@ -217,16 +217,16 @@ ParBicop::check_parameters_size(const Eigen::MatrixXd& parameters)
   if (parameters.size() != parameters_.size()) {
     if (parameters.rows() != parameters_.rows()) {
       std::stringstream message;
-      message << "parameters have has wrong number of rows "
-              << "for " << get_family_name() << " copula; "
+      message << "parameters have has wrong number of rows " << "for "
+              << get_family_name() << " copula; "
               << "expected: " << parameters_.rows() << ", "
               << "actual: " << parameters.rows() << std::endl;
       throw std::runtime_error(message.str().c_str());
     }
     if (parameters.cols() != parameters_.cols()) {
       std::stringstream message;
-      message << "parameters have wrong number of columns "
-              << "for " << get_family_name() << " copula; "
+      message << "parameters have wrong number of columns " << "for "
+              << get_family_name() << " copula; "
               << "expected: " << parameters_.cols() << ", "
               << "actual: " << parameters.cols() << std::endl;
       throw std::runtime_error(message.str().c_str());
@@ -240,8 +240,8 @@ ParBicop::check_parameters_lower(const Eigen::MatrixXd& parameters)
   if (parameters_lower_bounds_.size() > 0) {
     std::stringstream message;
     if ((parameters.array() < parameters_lower_bounds_.array()).any()) {
-      message << "parameters exceed lower bound "
-              << "for " << get_family_name() << " copula; " << std::endl
+      message << "parameters exceed lower bound " << "for " << get_family_name()
+              << " copula; " << std::endl
               << "bound:" << std::endl
               << parameters_lower_bounds_ << std::endl
               << "actual:" << std::endl
@@ -257,8 +257,8 @@ ParBicop::check_parameters_upper(const Eigen::MatrixXd& parameters)
   if (parameters_upper_bounds_.size() > 0) {
     std::stringstream message;
     if ((parameters.array() > parameters_upper_bounds_.array()).any()) {
-      message << "parameters exceed upper bound "
-              << "for " << get_family_name() << " copula; " << std::endl
+      message << "parameters exceed upper bound " << "for " << get_family_name()
+              << " copula; " << std::endl
               << "bound:" << std::endl
               << parameters_upper_bounds_ << std::endl
               << "actual:" << std::endl


### PR DESCRIPTION
For discrete variables, the inversion of Kendall's tau can be off by a lot (because, e.g., sample tau is 0.3 even under perfect dependence). This extends the search range for the MLE of one-parameter families under discrete data.