### PR TITLE
safeguard nlohmann_json for new xcode version

### DIFF
--- a/include/vinecopulib/misc/nlohmann_json.hpp
+++ b/include/vinecopulib/misc/nlohmann_json.hpp
@@ -17015,7 +17015,17 @@ private:
   StringType& str;
 };
 
-template<typename CharType, typename StringType = std::basic_string<CharType>>
+template<typename CharType>
+struct is_standard_char_type : std::integral_constant<
+  bool,
+  std::is_same<CharType, char>::value ||
+    std::is_same<CharType, wchar_t>::value ||
+    std::is_same<CharType, char16_t>::value ||
+    std::is_same<CharType, char32_t>::value>
+{
+};
+
+template<typename CharType, typename StringType = void>
 class output_adapter
 {
 public:
@@ -17024,13 +17034,28 @@ public:
   {
   }
 
-  output_adapter(std::basic_ostream<CharType>& s)
-    : oa(std::make_shared<output_stream_adapter<CharType>>(s))
+  template<
+    typename CompatibleCharType,
+    enable_if_t<
+      is_standard_char_type<CompatibleCharType>::value &&
+        std::is_same<CompatibleCharType, CharType>::value,
+      int> = 0>
+  output_adapter(std::basic_ostream<CompatibleCharType>& s)
+    : oa(std::make_shared<output_stream_adapter<CompatibleCharType>>(s))
   {
   }
 
-  output_adapter(StringType& s)
-    : oa(std::make_shared<output_string_adapter<CharType, StringType>>(s))
+  template<
+    typename CompatibleStringType = StringType,
+    enable_if_t<
+      !std::is_same<CompatibleStringType, void>::value &&
+        is_standard_char_type<CharType>::value &&
+        std::is_same<typename CompatibleStringType::value_type,
+                     CharType>::value,
+      int> = 0>
+  output_adapter(CompatibleStringType& s)
+    : oa(std::make_shared<
+          output_string_adapter<CharType, CompatibleStringType>>(s))
   {
   }
 


### PR DESCRIPTION
New macOS builds for R package complained:
```
/Applications/Xcode_26.5.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk/usr/include/c++/v1/__fwd/ostream.h:21:41: 
warning: 'char_traits<unsigned char>' is deprecated: char_traits<T> for T not equal to 
char, wchar_t, char8_t, char16_t or char32_t is non-standard and is provided for a temporary period. 
It will be removed in a future release, so please migrate off of it. [-Wdeprecated-declarations]
```

See: https://github.com/vinecopulib/rvinecopulib/actions/runs/29027935457/job/86152604776