### PR TITLE
Rename Vinecop Hessian API (hessian_avg → hessian, hessian → hessian_full)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -407,7 +407,7 @@ For any behaviour change:
   accessors (`get_pair_copula`, `get_all_families`, …), structure
   accessors (`get_matrix`, `get_struct_array`, `get_order`), fit
   statistics (`loglik`/`aic`/`bic`/`mbicv`), `truncate`, the asymptotic
-  helpers (`scores`, `hessian`, `scores_cov`), and JSON I/O.
+  helpers (`scores`, `scores_cov`, `hessian`, `hessian_full`), and JSON I/O.
 - **`RVineStructure` / `CVineStructure` / `DVineStructure`**
   ([rvine_structure.hpp](include/vinecopulib/vinecop/rvine_structure.hpp))
   — the tree structure as an R-vine matrix / triangular array, with

--- a/include/vinecopulib/vinecop/class.hpp
+++ b/include/vinecopulib/vinecop/class.hpp
@@ -236,13 +236,13 @@ public:
   Eigen::MatrixXd scores(Eigen::MatrixXd u,
                          bool step_wise = true,
                          const size_t num_threads = 1);
-  TriangularArray<std::vector<Eigen::MatrixXd>> hessian(
+  Eigen::MatrixXd hessian(Eigen::MatrixXd u,
+                          bool step_wise = true,
+                          const size_t num_threads = 1);
+  TriangularArray<std::vector<Eigen::MatrixXd>> hessian_full(
     Eigen::MatrixXd u,
     bool step_wise = true,
     const size_t num_threads = 1);
-  Eigen::MatrixXd hessian_avg(Eigen::MatrixXd u,
-                              bool step_wise = true,
-                              const size_t num_threads = 1);
   Eigen::MatrixXd scores_cov(Eigen::MatrixXd u,
                              bool step_wise = true,
                              const size_t num_threads = 1);

--- a/include/vinecopulib/vinecop/implementation/class.ipp
+++ b/include/vinecopulib/vinecop/implementation/class.ipp
@@ -1256,7 +1256,7 @@ Vinecop::scores(Eigen::MatrixXd u, bool step_wise, const size_t num_threads)
 
 //! @brief Evaluates the hessian per observation.
 //!
-//! Hessian is meant losely as "gradients of each component of the score
+//! Hessian is meant loosely as "gradients of each component of the score
 //! function".
 //!
 //! @param u An \f$ n \times (d + k) \f$ or \f$ n \times 2d \f$ matrix of
@@ -1268,7 +1268,9 @@ Vinecop::scores(Eigen::MatrixXd u, bool step_wise, const size_t num_threads)
 //!   than 1, the function will be applied concurrently to `num_threads` batches
 //!   of `u`.
 inline TriangularArray<std::vector<Eigen::MatrixXd>>
-Vinecop::hessian(Eigen::MatrixXd u, bool step_wise, const size_t num_threads)
+Vinecop::hessian_full(Eigen::MatrixXd u,
+                      bool step_wise,
+                      const size_t num_threads)
 {
   check_data(u);
   u = collapse_data(u);
@@ -1304,10 +1306,12 @@ Vinecop::hessian(Eigen::MatrixXd u, bool step_wise, const size_t num_threads)
   return hess;
 }
 
-//! @brief Evaluates the average hessian.
+//! @brief Evaluates the averaged Hessian of the log-likelihood.
 //!
-//! Hessian is meant losely as "gradients of each component of the score
-//! function". The Hessian is averaged over all samples in `u`.
+//! Hessian is meant loosely as "gradients of each component of the score
+//! function". The Hessian is averaged over all samples in `u`, yielding an
+//! \f$ \mathrm{npars} \times \mathrm{npars} \f$ matrix (use `hessian_full()`
+//! for the per-observation decomposition).
 //!
 //! @param u An \f$ n \times (d + k) \f$ or \f$ n \times 2d \f$ matrix of
 //!   evaluation points, where \f$ k \f$ is the number of discrete variables
@@ -1318,11 +1322,9 @@ Vinecop::hessian(Eigen::MatrixXd u, bool step_wise, const size_t num_threads)
 //!   than 1, the function will be applied concurrently to `num_threads` batches
 //!   of `u`.
 inline Eigen::MatrixXd
-Vinecop::hessian_avg(Eigen::MatrixXd u,
-                     bool step_wise,
-                     const size_t num_threads)
+Vinecop::hessian(Eigen::MatrixXd u, bool step_wise, const size_t num_threads)
 {
-  auto hess = this->hessian(u, step_wise, num_threads);
+  auto hess = this->hessian_full(u, step_wise, num_threads);
   size_t npars = static_cast<size_t>(this->get_npars());
   Eigen::MatrixXd H(npars, npars);
 
@@ -1343,6 +1345,10 @@ Vinecop::hessian_avg(Eigen::MatrixXd u,
 
 //! @brief Computes the covariance matrix of scores.
 //!
+//! Returns the (mean-centered, divided by `n`) covariance of the
+//! per-observation scores as an \f$ \mathrm{npars} \times \mathrm{npars} \f$
+//! matrix. Together with `hessian()` this forms the sandwich estimator of the
+//! asymptotic covariance.
 //!
 //! @param u An \f$ n \times (d + k) \f$ or \f$ n \times 2d \f$ matrix of
 //!   evaluation points, where \f$ k \f$ is the number of discrete variables

--- a/test/src_test/include/test_vinecop_class.hpp
+++ b/test/src_test/include/test_vinecop_class.hpp
@@ -429,19 +429,32 @@ TEST_F(VinecopTest, scores_stepwise)
 
   auto uu = vinecop.simulate(100, false, 1, { 1 });
 
-  auto J = vinecop.hessian_avg(uu, true);
+  auto J = vinecop.hessian(uu, true);
   EXPECT_TRUE(J.isUpperTriangular());
-  // Eigen::MatrixXd Jinv = J.triangularView<Eigen::Upper>()
-  //                          .solve(Eigen::MatrixXd::Identity(J.cols(),
-  //                          J.cols())) .triangularView<Eigen::Upper>();
-  // // std::cout << J << std::endl << std::endl;
-  // // std::cout << Jinv << std::endl;
-  // auto I = vinecop.scores_cov(uu, true);
-  // std::cout << (Jinv * I * Jinv.transpose() /
-  // u.rows()).diagonal().cwiseSqrt()
-  //           << std::endl
-  //           << std::endl;
-  // std::cout << vinecop.str() << std::endl;
+
+  // hessian() is the observation-average of hessian_full()
+  auto H = vinecop.hessian_full(uu, true);
+  Eigen::MatrixXd J_manual(J.rows(), J.cols());
+  size_t d = vinecop.get_dim();
+  size_t trunc_lvl = vinecop.get_trunc_lvl();
+  size_t ipar = 0;
+  for (size_t t = 0; t < trunc_lvl; t++) {
+    for (size_t e = 0; e < d - 1 - t; e++) {
+      size_t np = static_cast<size_t>(
+        vinecop.get_pair_copula(t, e).get_parameters().size());
+      for (size_t p = 0; p < np; p++) {
+        J_manual.row(ipar++) = H(t, e)[p].colwise().mean();
+      }
+    }
+  }
+  EXPECT_TRUE(all_close(J, J_manual, 1e-10, 1e-10));
+
+  // scores_cov() is the mean-centered covariance of scores()
+  auto s = vinecop.scores(uu, true);
+  Eigen::MatrixXd sc = s.rowwise() - s.colwise().mean();
+  Eigen::MatrixXd I_manual =
+    (sc.adjoint() * sc) / static_cast<double>(s.rows());
+  EXPECT_TRUE(all_close(vinecop.scores_cov(uu, true), I_manual, 1e-10, 1e-10));
 }
 
 TEST_F(VinecopTest, scores_joint)
@@ -456,7 +469,7 @@ TEST_F(VinecopTest, scores_joint)
   Vinecop vinecop(model_matrix, pair_copulas);
 
   auto uu = vinecop.simulate(100, false, 1, { 1 });
-  auto J = vinecop.hessian_avg(uu, false);
+  auto J = vinecop.hessian(uu, false);
   auto I = vinecop.scores_cov(uu, false);
 
   EXPECT_FALSE(J.isUpperTriangular());


### PR DESCRIPTION
## What

Renames the `Vinecop` asymptotic-helper Hessian methods (added in #645, still unreleased) to follow the established `pdf`/`pdf_full` convention, where the **bare name returns the headline result** and the **`_full` variant returns the detailed decomposition**:

- `hessian_avg` → **`hessian`** — headline `npars × npars` averaged matrix (the sandwich "bread", `B = E[H]`)
- `hessian` → **`hessian_full`** — detailed per-observation, per-edge, per-parameter ragged `TriangularArray<std::vector<Eigen::MatrixXd>>`

The base `hessian` remains a thin wrapper that averages `hessian_full`, mirroring how `pdf` wraps `pdf_full`.

## Why `scores` / `scores_cov` are left unchanged

The base/detailed asymmetry is inherent to the math and can't be made symmetric: the useful Hessian aggregate is a **mean**, but the useful scores aggregate is a **covariance** (the sandwich "meat", `M = Var[s]`) — the mean of scores is ≈0 at the MLE, so there's no meaningful `scores_avg`. After the rename the sandwich pairs cleanly:

- headline aggregates: **`hessian`** (bread) ↔ **`scores_cov`** (meat), both `npars × npars`
- per-observation building blocks: **`hessian_full`** ↔ **`scores`**

## Also

- Added identity tests: `hessian` == observation-average of `hessian_full`, and `scores_cov` == mean-centered `sᵀs / n` from `scores` — giving the previously-uncalled `hessian_full` and `scores` direct coverage.
- Fixed a doc typo ("losely" → "loosely") and updated the AGENTS.md helper list.
