### PR TITLE
TriangularArray owns its JSON/list conversions

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,6 +6,11 @@
   and `loglik` that evaluate a bivariate copula at a different parameter set per row of `u` in a
   single (optionally multi-threaded) call. The new overloads take an `n x p` matrix of parameters
   (one row per observation) and are available for parametric families (#675).
+* Make `TriangularArray<T>` own its conversions like the other user-facing classes: add
+  `to_json()`, a JSON constructor, and `to_list()` (the rows as a nested vector, complementing
+  the existing nested-vector constructor). The free helpers
+  `tools_serialization::triangular_array_to_json` / `json_to_triangular_array` now delegate to
+  them.
 * Allow a user-supplied edge-weight function for vine structure selection via
   `tree_criterion = "custom"` together with
   `FitControlsVinecop::set_tree_criterion_function` (or

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,9 +8,9 @@
   (one row per observation) and are available for parametric families (#675).
 * Make `TriangularArray<T>` own its conversions like the other user-facing classes: add
   `to_json()`, a JSON constructor, and `to_list()` (the rows as a nested vector, complementing
-  the existing nested-vector constructor). The free helpers
-  `tools_serialization::triangular_array_to_json` / `json_to_triangular_array` now delegate to
-  them.
+  the existing nested-vector constructor). The internal free helpers
+  `tools_serialization::triangular_array_to_json` / `json_to_triangular_array` are removed in
+  favor of the class methods.
 * Allow a user-supplied edge-weight function for vine structure selection via
   `tree_criterion = "custom"` together with
   `FitControlsVinecop::set_tree_criterion_function` (or

--- a/include/vinecopulib/misc/tools_serialization.hpp
+++ b/include/vinecopulib/misc/tools_serialization.hpp
@@ -46,23 +46,7 @@ template<class T>
 inline nlohmann::json
 triangular_array_to_json(const TriangularArray<T>& array)
 {
-  nlohmann::json output;
-  size_t d = array.get_dim();
-  size_t trunc_lvl = array.get_trunc_lvl();
-  output["d"] = d;
-  output["t"] = trunc_lvl;
-
-  nlohmann::json json_data;
-  for (size_t i = 0; i < std::min(d - -1, trunc_lvl); i++) {
-    nlohmann::json row;
-    for (size_t j = 0; j < d - 1 - i; j++) {
-      row.push_back(array(i, j));
-    }
-    json_data.push_back(row);
-  }
-  output["data"] = json_data;
-
-  return output;
+  return array.to_json();
 }
 
 //! conversion from std::vector to nlohmann::json
@@ -107,9 +91,7 @@ template<typename T>
 inline TriangularArray<T>
 json_to_triangular_array(const nlohmann::json& input)
 {
-
-  std::vector<std::vector<T>> vec = input["data"];
-  return TriangularArray<T>(vec);
+  return TriangularArray<T>(input);
 }
 
 //! conversion from nlohmann::json to std::vector

--- a/include/vinecopulib/misc/tools_serialization.hpp
+++ b/include/vinecopulib/misc/tools_serialization.hpp
@@ -38,17 +38,6 @@ matrix_to_json(const Eigen::Matrix<T, Eigen::Dynamic, Eigen::Dynamic>& matrix)
   return output;
 }
 
-//! conversion from vinecopulib::TriangularArray to nlohmann::json
-//!
-//! @param array The vinecopulib::TriangularArray to convert.
-//! @return the corresponding nlohmann::json.
-template<class T>
-inline nlohmann::json
-triangular_array_to_json(const TriangularArray<T>& array)
-{
-  return array.to_json();
-}
-
 //! conversion from std::vector to nlohmann::json
 //!
 //! @param vec The std::vector to convert.
@@ -81,17 +70,6 @@ json_to_matrix(const nlohmann::json& input)
     matrix = Eigen::MatrixXd();
   }
   return matrix.cast<T>();
-}
-
-//! conversion from nlohmann::json to vinecopulib::TriangularArray
-//!
-//! @param input The nlohmann::json to convert.
-//! @return the corresponding vinecopulib::TriangularArray
-template<typename T>
-inline TriangularArray<T>
-json_to_triangular_array(const nlohmann::json& input)
-{
-  return TriangularArray<T>(input);
 }
 
 //! conversion from nlohmann::json to std::vector

--- a/include/vinecopulib/misc/triangular_array.hpp
+++ b/include/vinecopulib/misc/triangular_array.hpp
@@ -8,7 +8,9 @@
 
 #include <iostream>
 #include <stdexcept>
+#include <type_traits>
 #include <vector>
+#include <vinecopulib/misc/nlohmann_json.hpp>
 
 namespace vinecopulib {
 
@@ -47,6 +49,23 @@ public:
   TriangularArray(size_t d, size_t trunc_lvl);
   explicit TriangularArray(const std::vector<std::vector<T>>& rows);
 
+  //! @brief Constructs a triangular array from a `nlohmann::json` object.
+  //!
+  //! The `"data"` field must contain the rows of the array (as written by
+  //! `to_json()`); the dimension and truncation level are derived from the
+  //! rows. Templated so that brace-enclosed initializer lists keep selecting
+  //! the nested-vector constructor.
+  //!
+  //! @param input The `nlohmann::json` object to convert from.
+  template<typename Json,
+           typename std::enable_if<std::is_same<typename std::decay<Json>::type,
+                                                nlohmann::json>::value,
+                                   int>::type = 0>
+  explicit TriangularArray(const Json& input)
+    : TriangularArray(input["data"].template get<std::vector<std::vector<T>>>())
+  {
+  }
+
   T& operator()(size_t row, size_t column);
   T operator()(size_t row, size_t column) const;
   bool operator==(const TriangularArray<T>& rhs) const;
@@ -55,6 +74,9 @@ public:
 
   size_t get_trunc_lvl() const;
   size_t get_dim() const;
+
+  nlohmann::json to_json() const;
+  std::vector<std::vector<T>> to_list() const;
 
   std::string str() const;
 
@@ -216,6 +238,41 @@ size_t
 TriangularArray<T>::get_dim() const
 {
   return d_;
+}
+
+//! @brief Converts the triangular array to a `nlohmann::json` object.
+//!
+//! The result contains the fields `"d"` (dimension), `"t"` (truncation
+//! level), and `"data"` (the rows of the array); it can be converted back
+//! with the JSON constructor.
+//!
+//! @return The `nlohmann::json` object containing the array.
+template<typename T>
+nlohmann::json
+TriangularArray<T>::to_json() const
+{
+  nlohmann::json output;
+  output["d"] = d_;
+  output["t"] = trunc_lvl_;
+  output["data"] = this->to_list();
+  return output;
+}
+
+//! @brief Converts the triangular array to a nested vector of rows.
+//!
+//! Row `i` holds the `d - 1 - i` entries of tree `i`; the result can be
+//! converted back with the nested-vector constructor.
+//!
+//! @return The rows of the array.
+template<typename T>
+std::vector<std::vector<T>>
+TriangularArray<T>::to_list() const
+{
+  std::vector<std::vector<T>> rows(std::min(d_ - 1, trunc_lvl_));
+  for (size_t i = 0; i < rows.size(); i++) {
+    rows[i].assign(arr_[i].begin(), arr_[i].begin() + (d_ - 1 - i));
+  }
+  return rows;
 }
 
 //! represent triangular array as a string.

--- a/include/vinecopulib/vinecop/implementation/rvine_structure.ipp
+++ b/include/vinecopulib/vinecop/implementation/rvine_structure.ipp
@@ -145,10 +145,9 @@ inline RVineStructure::RVineStructure(
 //!      a valid R-vine structure.
 inline RVineStructure::RVineStructure(const nlohmann::json& input,
                                       const bool check)
-  : RVineStructure(
-      tools_serialization::json_to_vector<size_t>(input["order"]),
-      tools_serialization::json_to_triangular_array<size_t>(input["array"]),
-      check)
+  : RVineStructure(tools_serialization::json_to_vector<size_t>(input["order"]),
+                   TriangularArray<size_t>(input["array"]),
+                   check)
 {
 }
 
@@ -176,11 +175,8 @@ inline nlohmann::json
 RVineStructure::to_json() const
 {
   nlohmann::json output;
-  auto array_json =
-    tools_serialization::triangular_array_to_json(struct_array_);
-  output["array"] = array_json;
-  auto order_json = tools_serialization::vector_to_json(order_);
-  output["order"] = order_json;
+  output["array"] = struct_array_.to_json();
+  output["order"] = tools_serialization::vector_to_json(order_);
 
   return output;
 }

--- a/test/src_test/include/test_rvine_structure.hpp
+++ b/test/src_test/include/test_rvine_structure.hpp
@@ -7,7 +7,6 @@
 #pragma once
 
 #include "gtest/gtest.h"
-#include <vinecopulib/misc/tools_serialization.hpp>
 #include <vinecopulib/misc/tools_stl.hpp>
 #include <vinecopulib/vinecop/rvine_structure.hpp>
 
@@ -111,11 +110,6 @@ TEST(rvine_structure, triangular_array_conversions_work)
   EXPECT_EQ(filled_rows[0].size(), static_cast<size_t>(4));
   EXPECT_EQ(filled_rows[1].size(), static_cast<size_t>(3));
   EXPECT_TRUE(TriangularArray<size_t>(filled_rows) == filled);
-
-  // The tools_serialization free functions delegate to the class methods.
-  EXPECT_EQ(tools_serialization::triangular_array_to_json(ta), ta.to_json());
-  EXPECT_TRUE(
-    tools_serialization::json_to_triangular_array<size_t>(ta.to_json()) == ta);
 }
 
 TEST(rvine_structure, rvine_structure_print)

--- a/test/src_test/include/test_rvine_structure.hpp
+++ b/test/src_test/include/test_rvine_structure.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "gtest/gtest.h"
+#include <vinecopulib/misc/tools_serialization.hpp>
 #include <vinecopulib/misc/tools_stl.hpp>
 #include <vinecopulib/vinecop/rvine_structure.hpp>
 
@@ -70,6 +71,51 @@ TEST(rvine_structure, triangular_array_works)
   ta4.truncate(3);
   EXPECT_FALSE(ta3 < ta4);
   EXPECT_FALSE(ta4 < ta3);
+}
+
+TEST(rvine_structure, triangular_array_conversions_work)
+{
+  std::vector<std::vector<size_t>> rows = {
+    { 1, 2, 3, 4 }, { 4, 5, 6 }, { 6, 7 }, { 8 }
+  };
+  TriangularArray<size_t> ta(rows);
+
+  // to_list() returns the rows; round-trips through the nested-vector
+  // constructor.
+  EXPECT_EQ(ta.to_list(), rows);
+  EXPECT_TRUE(TriangularArray<size_t>(ta.to_list()) == ta);
+
+  // to_json() carries dimension, truncation level, and rows; round-trips
+  // through the JSON constructor.
+  auto json = ta.to_json();
+  EXPECT_EQ(json["d"].get<size_t>(), ta.get_dim());
+  EXPECT_EQ(json["t"].get<size_t>(), ta.get_trunc_lvl());
+  EXPECT_TRUE(TriangularArray<size_t>(json) == ta);
+
+  // Truncated arrays keep the reduced number of rows.
+  ta.truncate(2);
+  EXPECT_EQ(ta.to_list().size(), static_cast<size_t>(2));
+  EXPECT_EQ(ta.to_json()["t"].get<size_t>(), static_cast<size_t>(2));
+  EXPECT_TRUE(TriangularArray<size_t>(ta.to_json()) == ta);
+
+  // Arrays allocated by dimension (internal rows are over-allocated by one
+  // element) still convert to rows of the logical length d - 1 - i.
+  TriangularArray<size_t> filled(5, 2);
+  for (size_t i = 0; i < 2; i++) {
+    for (size_t j = 0; j < 5 - 1 - i; j++) {
+      filled(i, j) = i + j;
+    }
+  }
+  auto filled_rows = filled.to_list();
+  ASSERT_EQ(filled_rows.size(), static_cast<size_t>(2));
+  EXPECT_EQ(filled_rows[0].size(), static_cast<size_t>(4));
+  EXPECT_EQ(filled_rows[1].size(), static_cast<size_t>(3));
+  EXPECT_TRUE(TriangularArray<size_t>(filled_rows) == filled);
+
+  // The tools_serialization free functions delegate to the class methods.
+  EXPECT_EQ(tools_serialization::triangular_array_to_json(ta), ta.to_json());
+  EXPECT_TRUE(
+    tools_serialization::json_to_triangular_array<size_t>(ta.to_json()) == ta);
 }
 
 TEST(rvine_structure, rvine_structure_print)


### PR DESCRIPTION
## TriangularArray owns its JSON/list conversions

`TriangularArray<T>` is a user-facing container (it backs `RVineStructure` and the new per-edge `Vinecop` outputs), but unlike the other public classes it didn't own its conversions — JSON (de)serialization lived in `tools_serialization` free functions, and both downstream wrappers hand-roll the nested-rows conversion (`struct_array_wrap` in rvinecopulib; the Python bindings in pyvinecopulib).

This PR makes the class self-contained:

- **`to_json()`** — emits the same `{"d", "t", "data"}` encoding as before (byte-compatible; `RVineStructure::to_json` round-trips are unchanged).
- **JSON constructor** — mirrors the other classes' constructor-based deserialization. It is a constrained template so that brace-enclosed initializer lists (`TriangularArray<size_t>({{...}, ...})`) keep selecting the nested-vector constructor unambiguously (`nlohmann::json` also accepts nested init-lists, so a plain `const nlohmann::json&` overload would be ambiguous at every braced call site).
- **`to_list()`** — the rows as a nested `std::vector`, complementing the existing nested-vector constructor. It copies the logical `d - 1 - i` prefix of each row, so arrays allocated by dimension — whose internal rows are over-allocated by one element — convert correctly.
- The internal `tools_serialization` free helpers (`triangular_array_to_json` / `json_to_triangular_array`) are **removed** in favor of the class methods (their only call sites, in `rvine_structure.ipp`, now use the methods directly; neither rvinecopulib nor pyvinecopulib referenced them); a latent `d - -1` typo in the old loop bound is gone along the way.

Downstream, this lets the wrappers replace their hand-rolled conversions with `to_list()` and expose e.g. `RVineStructure.from_struct_array` / `get_struct_array` naturally (pyvinecopulib#228).

### Tests & validation

- New `rvine_structure.triangular_array_conversions_work`: `to_json` → JSON-ctor and `to_list` → rows-ctor round-trips, truncated arrays, dimension-allocated arrays, and delegation of the free functions. Full `rvine_structure` suite passes in Debug.
- clang-format-14 clean.