### PR TITLE
Seed RNG-dependent unit tests to remove flakiness

### DIFF
--- a/test/src_test/include/test_bicop_parametric.hpp
+++ b/test/src_test/include/test_bicop_parametric.hpp
@@ -142,7 +142,7 @@ TEST_P(ParBicopTest, parametric_bicop_is_correct)
     EXPECT_ANY_THROW(bicop_.aic());
     EXPECT_ANY_THROW(bicop_.bic());
     EXPECT_ANY_THROW(bicop_.mbic());
-    EXPECT_NO_THROW(bicop_.simulate(10, true));
+    EXPECT_NO_THROW(bicop_.simulate(10, true, { 1 }));
     EXPECT_NO_THROW(bicop_.str());
     if ((bicop_.get_parameters().size() > 1) &&
         (bicop_.get_family() != BicopFamily::student)) {
@@ -168,7 +168,7 @@ TEST_P(ParBicopTest, bicop_select_mle_bic_is_correct)
     "bic");
 
   if (needs_check_) {
-    auto data = bicop_.simulate(get_n());
+    auto data = bicop_.simulate(get_n(), false, { 1 });
     auto bicop = Bicop(data, controls);
     EXPECT_EQ(bicop.loglik(data), bicop.get_loglik()) << bicop_.str();
 
@@ -212,7 +212,7 @@ TEST_P(ParBicopTest, bicop_select_itau_bic_is_correct)
       "bic");
 
     if (needs_check_) {
-      auto data = bicop_.simulate(get_n());
+      auto data = bicop_.simulate(get_n(), false, { 1 });
       auto bicop = Bicop(data, controls);
       auto selected_family = bicop.get_family_name();
       EXPECT_EQ(selected_family, true_family)

--- a/test/src_test/include/test_bicop_sanity_checks.hpp
+++ b/test/src_test/include/test_bicop_sanity_checks.hpp
@@ -49,7 +49,7 @@ TEST(bicop_sanity_checks, catches_var_types)
 TEST(bicop_sanity_checks, catches_data_dim)
 {
   Bicop bicop;
-  auto u = tools_stats::simulate_uniform(10, 3);
+  auto u = tools_stats::simulate_uniform(10, 3, false, { 1 });
   EXPECT_ANY_THROW(bicop.select(u));
   bicop.set_var_types({ "d", "d" });
   EXPECT_ANY_THROW(bicop.select(u));
@@ -68,7 +68,7 @@ TEST(bicop_sanity_checks, catches_not_fitted_to_data)
 TEST(bicop_sanity_checks, select_can_handle_zeros_and_ones)
 {
   Bicop bicop;
-  auto u = bicop.simulate(10);
+  auto u = bicop.simulate(10, false, { 1 });
   u(0, 0) = 0.0;
   u(1, 0) = 1.0;
   EXPECT_NO_THROW(bicop.select(u));
@@ -152,7 +152,7 @@ TEST(bicop_sanity_checks, copy)
   EXPECT_EQ(bc1.get_parameters(), rho);
   EXPECT_ANY_THROW(bc1.get_loglik());
 
-  auto u = bc1.simulate(10);
+  auto u = bc1.simulate(10, false, { 1 });
   bc2.select(u);
   auto bc3 = bc2;
   EXPECT_EQ(bc2.get_loglik(), bc3.get_loglik());

--- a/test/src_test/include/test_bicop_select.hpp
+++ b/test/src_test/include/test_bicop_select.hpp
@@ -15,7 +15,7 @@ using namespace vinecopulib;
 TEST(bicop_select, works_in_parallel)
 {
   Bicop cop(BicopFamily::gaussian, 0, Eigen::VectorXd::Constant(1, -0.5));
-  auto u = cop.simulate(15);
+  auto u = cop.simulate(15, false, { 1 });
   Bicop fit1, fit2;
   fit1.select(u);
   FitControlsBicop controls;
@@ -28,7 +28,7 @@ TEST(bicop_select, works_in_parallel)
 TEST(bicop_select, allows_all_selcrits)
 {
   Bicop cop(BicopFamily::gaussian, 0, Eigen::VectorXd::Constant(1, -0.5));
-  auto u = cop.simulate(15);
+  auto u = cop.simulate(15, false, { 1 });
   FitControlsBicop controls;
   controls.set_selection_criterion("loglik");
   cop.select(u, controls);
@@ -45,7 +45,7 @@ TEST(bicop_select, allows_all_selcrits)
 TEST(bicop_select, allow_rotations_works)
 {
   Bicop cop(BicopFamily::clayton, 180, Eigen::VectorXd::Constant(1, 5));
-  auto u = cop.simulate(static_cast<size_t>(5e3));
+  auto u = cop.simulate(static_cast<size_t>(5e3), false, { 1 });
   FitControlsBicop controls;
   controls.set_family_set({ BicopFamily::clayton });
   cop.select(u, controls);
@@ -58,7 +58,7 @@ TEST(bicop_select, allow_rotations_works)
 TEST(bicop_select, fit_stats_are_correct)
 {
   Bicop cop(BicopFamily::gaussian, 0, Eigen::VectorXd::Constant(1, -0.5));
-  auto u = cop.simulate(15);
+  auto u = cop.simulate(15, false, { 1 });
   cop.select(u);
   EXPECT_EQ(cop.get_nobs(), 15);
   EXPECT_NEAR(cop.get_loglik(), cop.loglik(u), 1e-10);

--- a/test/src_test/include/test_bicop_taildep.hpp
+++ b/test/src_test/include/test_bicop_taildep.hpp
@@ -136,7 +136,8 @@ TEST(bicop_taildep, getters_match_parameter_methods)
 // Blomqvist's beta (computable from the cdf).
 TEST(bicop_taildep, tll_taildep_is_nan_beta_is_finite)
 {
-  auto u = Bicop(BicopFamily::clayton, 0, par1(2.0)).simulate(1000);
+  auto u =
+    Bicop(BicopFamily::clayton, 0, par1(2.0)).simulate(1000, false, { 1 });
   Bicop tll(BicopFamily::tll);
   tll.fit(u);
   auto td = tll.get_taildep();

--- a/test/src_test/include/test_rvine_structure.hpp
+++ b/test/src_test/include/test_rvine_structure.hpp
@@ -269,7 +269,8 @@ TEST(rvine_structure, rvine_struct_sanity_checks_work)
 TEST(rvine_structure, random_sampling)
 {
   for (size_t i = 0; i < 20; i++) {
-    RVineStructure test = RVineStructure::simulate(10);
+    RVineStructure test =
+      RVineStructure::simulate(10, false, { static_cast<int>(i + 1) });
   }
 }
 

--- a/test/src_test/include/test_tools_stats.hpp
+++ b/test/src_test/include/test_tools_stats.hpp
@@ -34,7 +34,7 @@ TEST(test_tools_stats, to_pseudo_obs_is_correct)
     EXPECT_NEAR(U(i, 1), 1.0 - (i + 1.0) * 0.1, 1e-2);
   }
 
-  Eigen::MatrixXd X2 = tools_stats::simulate_uniform(100, 2);
+  Eigen::MatrixXd X2 = tools_stats::simulate_uniform(100, 2, false, { 1 });
   EXPECT_NO_THROW(tools_stats::to_pseudo_obs(X2, "random"));
   EXPECT_NO_THROW(tools_stats::to_pseudo_obs(X2, "first"));
   EXPECT_ANY_THROW(tools_stats::to_pseudo_obs(X2, "something"));

--- a/test/src_test/include/test_vinecop_class.hpp
+++ b/test/src_test/include/test_vinecop_class.hpp
@@ -111,7 +111,7 @@ TEST_F(VinecopTest, print)
   }
   EXPECT_EQ(last_line, expected_last_line);
 
-  auto data = tools_stats::simulate_uniform(100, 5);
+  auto data = tools_stats::simulate_uniform(100, 5, false, { 1 });
   auto controls = FitControlsVinecop({ BicopFamily::tll });
   vc1.select(data, controls);
 
@@ -227,7 +227,7 @@ TEST_F(VinecopTest, getters_are_correct)
 
 TEST_F(VinecopTest, 1dim)
 {
-  auto data = tools_stats::simulate_uniform(3, 1);
+  auto data = tools_stats::simulate_uniform(3, 1, false, { 1 });
   auto vc = Vinecop(1);
   vc.select(data);
   EXPECT_TRUE((vc.pdf(data).array() == 1).all());
@@ -235,7 +235,7 @@ TEST_F(VinecopTest, 1dim)
   EXPECT_TRUE((vc.inverse_rosenblatt(data).array() == data.array()).all());
   vc.loglik();
   vc.aic();
-  vc.simulate(3);
+  vc.simulate(3, false, 1, { 1 });
   Vinecop::make_pair_copula_store(1, 2);
   Eigen::Matrix<size_t, Eigen::Dynamic, Eigen::Dynamic> mat(1, 1);
   mat(0, 0) = 1;
@@ -244,7 +244,7 @@ TEST_F(VinecopTest, 1dim)
 
 TEST_F(VinecopTest, fit_statistics_getters_are_correct)
 {
-  auto data = tools_stats::simulate_uniform(100, 3);
+  auto data = tools_stats::simulate_uniform(100, 3, false, { 1 });
   auto vc = Vinecop(
     data, RVineStructure(), {}, FitControlsVinecop({ BicopFamily::clayton }));
   EXPECT_NEAR(vc.get_loglik(), vc.loglik(data), 1e-10);
@@ -346,12 +346,13 @@ TEST_F(VinecopTest, cdf_is_correct)
   Vinecop vinecop(matrix, pair_copulas);
 
   // Test whether the analytic and simulated versions are "close" enough
-  auto u2 = vinecop.simulate(10);
-  ASSERT_TRUE(all_close(vinecop.cdf(u2, 10000), bicop.cdf(u2), 1e-2, 1e-2));
+  auto u2 = vinecop.simulate(10, false, 1, { 1 });
+  ASSERT_TRUE(
+    all_close(vinecop.cdf(u2, 10000, 1, { 1 }), bicop.cdf(u2), 1e-2, 1e-2));
 
   // verify that qrng stuff works
   Vinecop vinecop2(301);
-  vinecop.simulate(10, true);
+  vinecop.simulate(10, true, 1, { 1 });
 }
 
 TEST_F(VinecopTest, simulate_is_correct)
@@ -366,14 +367,14 @@ TEST_F(VinecopTest, simulate_is_correct)
   Vinecop vinecop(model_matrix, pair_copulas);
 
   // only check if it works
-  vinecop.simulate(10);
+  vinecop.simulate(10, false, 1, { 1 });
   // check the underlying transformation from independent samples
   ASSERT_TRUE(all_close(vinecop.inverse_rosenblatt(u), sim, 1e-4, 1e-4));
 
   // verify that qrng stuff works
-  vinecop.simulate(10, true);
+  vinecop.simulate(10, true, 1, { 1 });
   Vinecop vinecop2(301);
-  vinecop.simulate(10, true);
+  vinecop.simulate(10, true, 1, { 1 });
 }
 
 TEST_F(VinecopTest, rosenblatt_is_correct)
@@ -386,7 +387,7 @@ TEST_F(VinecopTest, rosenblatt_is_correct)
     }
   }
   Vinecop vinecop(model_matrix, pair_copulas);
-  auto u2 = vinecop.simulate(5);
+  auto u2 = vinecop.simulate(5, false, 1, { 1 });
   ASSERT_TRUE(all_close(
     vinecop.rosenblatt(vinecop.inverse_rosenblatt(u2)), u2, 1e-6, 1e-6));
 
@@ -411,7 +412,7 @@ TEST_F(VinecopTest, rosenblatt_is_correct)
   Eigen::Matrix<size_t, 2, 2> mat;
   mat << 1, 1, 2, 0;
   vinecop = Vinecop(mat, pair_copulas);
-  u = vinecop.simulate(5);
+  u = vinecop.simulate(5, false, 1, { 1 });
   ASSERT_TRUE(all_close(
     vinecop.rosenblatt(vinecop.inverse_rosenblatt(u)), u, 1e-6, 1e-6));
 }
@@ -490,7 +491,7 @@ TEST_F(VinecopTest, scores_joint)
 TEST_F(VinecopTest, aic_bic_are_correct)
 {
   int d = 7;
-  auto data = tools_stats::simulate_uniform(100, 7);
+  auto data = tools_stats::simulate_uniform(100, 7, false, { 1 });
   Vinecop true_model(d);
 
   auto pair_copulas = Vinecop::make_pair_copula_store(d);
@@ -546,7 +547,7 @@ TEST_F(VinecopTest, family_select_finds_true_rotations)
     }
   }
   Vinecop vinecop(model_matrix, pair_copulas);
-  auto data = vinecop.simulate(2000);
+  auto data = vinecop.simulate(2000, false, 1, { 1 });
 
   auto controls = FitControlsVinecop({ BicopFamily::clayton }, "itau");
   // controls.set_show_trace(true);
@@ -623,8 +624,8 @@ TEST_F(VinecopTest, works_multi_threaded)
     all_close(fit2.rosenblatt(u, 2), fit2.rosenblatt(u), 1e-10, 1e-10));
 
   // just check that it works
-  fit2.simulate(2, false, 3);
-  fit2.cdf(u, 100, 2);
+  fit2.simulate(2, false, 3, { 1 });
+  fit2.cdf(u, 100, 2, { 1 });
 }
 
 // check if the same conditioned sets appear for each tree
@@ -739,8 +740,8 @@ TEST_F(VinecopTest, select_finds_different_structures_random)
   FitControlsVinecop controls_unweighted({ BicopFamily::tll });
   controls_unweighted.set_tree_algorithm("random_unweighted");
 
-  // For reseeding the random number generator
-  std::random_device rd;
+  // For reseeding the random number generator (deterministic, so the test
+  // is reproducible in CI)
   std::vector<int> seeds(20);
 
   // To store the unique structures
@@ -753,9 +754,11 @@ TEST_F(VinecopTest, select_finds_different_structures_random)
   const size_t num_trials = 10;
 
   for (size_t i = 0; i < num_trials; ++i) {
-    // Seed controls randomly for each test run
-    std::generate(
-      seeds.begin(), seeds.end(), [&]() { return static_cast<int>(rd()); });
+    // Deterministic but distinct seeds for each trial, so every run uses a
+    // different RNG stream (and hence a different random structure) without
+    // depending on std::random_device.
+    for (size_t k = 0; k < seeds.size(); ++k)
+      seeds[k] = static_cast<int>(i * seeds.size() + k + 1);
     controls_weighted.set_seeds(seeds);
     controls_unweighted.set_seeds(seeds);
 
@@ -779,7 +782,8 @@ TEST_F(VinecopTest, select_finds_different_structures_random)
     unique_structures_unweighted.insert(struct_array_unweighted);
   }
 
-  // The probability that any 2 samples are the same by chance is very low
+  // With distinct seeds the RNG streams and selected structures should all
+  // differ; being deterministic, this is stable across runs.
   EXPECT_EQ(first_rng_outputs.size(), num_trials);
   EXPECT_EQ(unique_structures_weighted.size(), num_trials);
   EXPECT_EQ(unique_structures_unweighted.size(), num_trials);
@@ -826,7 +830,7 @@ TEST_F(VinecopTest, sparse_threshold_selection)
   fit.select(u, controls);
   EXPECT_NEAR(fit.get_loglik(), fit.loglik(u), 0.001);
 
-  u = tools_stats::simulate_uniform(100, 7);
+  u = tools_stats::simulate_uniform(100, 7, false, { 1 });
   fit.select(u, controls);
 }
 
@@ -836,7 +840,7 @@ TEST_F(VinecopTest, sparse_truncation_selection)
   FitControlsVinecop controls(bicop_families::itau, "itau");
   controls.set_select_trunc_lvl(true);
   // controls.set_show_trace(true);
-  u = tools_stats::simulate_uniform(100, 7);
+  u = tools_stats::simulate_uniform(100, 7, false, { 1 });
   Vinecop fit(7);
   fit.select(u, controls);
   EXPECT_LE(fit.get_rvine_structure().get_trunc_lvl(), 6);

--- a/test/src_test/include/test_vinecop_sanity_checks.hpp
+++ b/test/src_test/include/test_vinecop_sanity_checks.hpp
@@ -39,10 +39,10 @@ TEST(vinecop_sanity_checks, catches_wrong_size)
   EXPECT_ANY_THROW(vinecop.select(U));
 
   vinecop = Vinecop(301);
-  U = tools_stats::simulate_uniform(1, 301);
-  EXPECT_NO_THROW(vinecop.cdf(U));
+  U = tools_stats::simulate_uniform(1, 301, false, { 1 });
+  EXPECT_NO_THROW(vinecop.cdf(U, 1e4, 1, { 1 }));
   vinecop = Vinecop(21202);
-  U = tools_stats::simulate_uniform(1, 21202);
+  U = tools_stats::simulate_uniform(1, 21202, false, { 1 });
   EXPECT_ANY_THROW(vinecop.cdf(U));
 
   pair_copulas.resize(4); // too many

--- a/test/src_test/include/test_weights.hpp
+++ b/test/src_test/include/test_weights.hpp
@@ -14,20 +14,20 @@ using namespace vinecopulib;
 
 TEST(test_weights, catches_incompatible_sizes)
 {
-  auto u = tools_stats::simulate_uniform(20, 2);
-  auto w = tools_stats::simulate_uniform(9, 1);
+  auto u = tools_stats::simulate_uniform(20, 2, false, { 1 });
+  auto w = tools_stats::simulate_uniform(9, 1, false, { 2 });
   FitControlsBicop controls;
   controls.set_weights(w);
   EXPECT_ANY_THROW(Bicop(u, controls));
-  u = tools_stats::simulate_uniform(20, 4);
+  u = tools_stats::simulate_uniform(20, 4, false, { 3 });
   EXPECT_ANY_THROW(
     Vinecop(u, RVineStructure(), {}, FitControlsVinecop(controls)));
 }
 
 TEST(test_weights, allows_nans)
 {
-  auto u = tools_stats::simulate_uniform(20, 2);
-  auto w = tools_stats::simulate_uniform(20, 1);
+  auto u = tools_stats::simulate_uniform(20, 2, false, { 1 });
+  auto w = tools_stats::simulate_uniform(20, 1, false, { 2 });
   w(1) = std::numeric_limits<double>::quiet_NaN();
   FitControlsBicop controls;
   controls.set_weights(w);
@@ -37,7 +37,7 @@ TEST(test_weights, allows_nans)
 TEST(test_weights, works_in_bicop_select)
 {
   // if half of the weights are zero
-  auto u = tools_stats::simulate_uniform(200, 2);
+  auto u = tools_stats::simulate_uniform(200, 2, false, { 1 });
   Eigen::VectorXd w = Eigen::VectorXd::Zero(200);
   w.head(100) = Eigen::VectorXd::Ones(100);
 
@@ -52,7 +52,7 @@ TEST(test_weights, works_in_bicop_select)
 TEST(test_weights, works_in_vinecop_select)
 {
   // if half of the weights are zero
-  auto u = tools_stats::simulate_uniform(200, 7);
+  auto u = tools_stats::simulate_uniform(200, 7, false, { 1 });
   Eigen::VectorXd w = Eigen::VectorXd::Zero(200);
   w.head(100) = Eigen::VectorXd::Ones(100);
 


### PR DESCRIPTION
## Summary

Several unit tests generated random data through generators that fall back to `std::random_device` when no `seeds` vector is passed, making them nondeterministic run-to-run:

- `tools_stats::simulate_uniform`
- `Bicop::simulate` / `Vinecop::simulate`
- Monte-Carlo `Vinecop::cdf`
- `RVineStructure::simulate`

Every such call site now passes a fixed seed, so the suite is reproducible.

`select_finds_different_structures_random` — the reported CI flake — previously reseeded from `std::random_device` on each of its 10 trials and asserted all outputs were distinct, so two trials could collide by chance. It now derives distinct-but-deterministic seeds from the trial index, preserving the test's intent (distinct seeds → distinct random structures) while making it reproducible.

The intentionally-unseeded `seed_works` test (which asserts seeded ≠ unseeded) is left unchanged. The R parity scripts are already deterministic (`set.seed` before every stochastic call) and the C++ side consumes the R-generated data, so no change was needed there.

## Testing

- `clang-format-14 --dry-run --Werror` clean on all touched files.
- Debug build; recovery-sensitive subset passes **161/161** (both `bicop_select` mle/itau across all family parameterizations, `aic_bic_are_correct`, `family_select_finds_true_rotations`, sparse threshold/truncation selection, `cdf`/`rosenblatt` round-trips).

🤖 Generated with [Claude Code](https://claude.com/claude-code)