### PR TITLE
Speed up Vinecop evaluation and structure selection

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,13 +8,30 @@
   selection fast paths (NaN-free criterion, moved h-function storage, final
   tree h-functions skipped, in-place candidate fits). `pdf_full` no longer
   fills `hfunc*_sub` with duplicated continuous h-functions (#692).
-* Speed up `Vinecop` evaluation and structure selection: no per-edge
-  `Bicop` deep copies in `inverse_rosenblatt`, in-place data collapsing with
-  lazy discrete sub-buffers, parallel allocation-free Monte-Carlo `cdf`,
-  selection fast paths (NaN-free criterion, moved h-function storage, final
-  tree h-functions skipped, in-place candidate fits), and an allocation-free
-  rolling-bitmask proximity check in `RVineStructure`. `pdf_full` no longer
-  fills `hfunc*_sub` with duplicated continuous h-functions (#692).
+* Speed up TLL fitting and evaluation: fused conditional-cdf interpolation
+  (single pass, no per-query allocation), direct closed-form inversion of the
+  conditional cdf replacing 35-sweep bisection, bucket-accelerated cell
+  lookup, O(m) cached `integrate_2d`, and fixed-size influence matrices in
+  the local-likelihood fit (#691).
+* Speed up `tools_stats`: SIMD `qnorm` via Eigen's packetized `pndtri`
+  (~2–3× faster, roughly halving the Gaussian-copula pdf cost), leaner
+  `pbvnorm`/`pbvt` kernels, single weight conversion in `to_pseudo_obs`,
+  reusable FFT workspace for `"mcor"`, flattened `BoxCovering`, and faster
+  `simulate_uniform`/`sobol` fills (#690).
+* Speed up shared primitives: `tools_eigen` helpers take `Eigen::Ref`
+  (`ConstMatRef`) with raw-pointer inner loops and gain a safeguarded-Newton
+  inverter; `ThreadPool::push` binds arguments instead of capturing a
+  by-value lambda; `integrate_zero_to_one` is templated on the callable with
+  integration tolerance 1e-12 → 1e-9 (Kendall's τ of integrated families may
+  shift by up to ~1e-7) (#689).
+* Add binary CBOR persistence for `Bicop`, `Vinecop`, and `RVineStructure`,
+  selected automatically by a `.cbor` filename extension (#684).
+* Add an opt-in google/benchmark suite (`VINECOPULIB_BUILD_BENCHMARKS`, off by
+  default), a numerical parity harness (`parity_dump` +
+  `scripts/compare_parity.py` with per-key tolerance gates in
+  `scripts/parity_gates.json`), and golden-value tests freezing QRNG streams,
+  Genz `pbvnorm`/`pbvt` kernels, pseudo-observations, seeded TLL fits, and
+  h∘hinv round trips (#688).
 * Add `Bicop::parameters_to_taildep()`/`Bicop::get_taildep()` to compute the tail
   dependence coefficients (returned as a 2x2 matrix collecting all four corners of
   the unit square) and `Bicop::parameters_to_beta()`/`Bicop::get_beta()` to compute

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,30 +2,19 @@
 
 ### NEW FEATURES
 
-* Speed up TLL fitting and evaluation: fused conditional-cdf interpolation
-  (single pass, no per-query allocation), direct closed-form inversion of the
-  conditional cdf replacing 35-sweep bisection, bucket-accelerated cell
-  lookup, O(m) cached `integrate_2d`, and fixed-size influence matrices in
-  the local-likelihood fit (#691).
-* Speed up `tools_stats`: SIMD `qnorm` via Eigen's packetized `pndtri`
-  (~2–3× faster, roughly halving the Gaussian-copula pdf cost), leaner
-  `pbvnorm`/`pbvt` kernels, single weight conversion in `to_pseudo_obs`,
-  reusable FFT workspace for `"mcor"`, flattened `BoxCovering`, and faster
-  `simulate_uniform`/`sobol` fills (#690).
-* Speed up shared primitives: `tools_eigen` helpers take `Eigen::Ref`
-  (`ConstMatRef`) with raw-pointer inner loops and gain a safeguarded-Newton
-  inverter; `ThreadPool::push` binds arguments instead of capturing a
-  by-value lambda; `integrate_zero_to_one` is templated on the callable with
-  integration tolerance 1e-12 → 1e-9 (Kendall's τ of integrated families may
-  shift by up to ~1e-7) (#689).
-* Add binary CBOR persistence for `Bicop`, `Vinecop`, and `RVineStructure`,
-  selected automatically by a `.cbor` filename extension (#684).
-* Add an opt-in google/benchmark suite (`VINECOPULIB_BUILD_BENCHMARKS`, off by
-  default), a numerical parity harness (`parity_dump` +
-  `scripts/compare_parity.py` with per-key tolerance gates in
-  `scripts/parity_gates.json`), and golden-value tests freezing QRNG streams,
-  Genz `pbvnorm`/`pbvt` kernels, pseudo-observations, seeded TLL fits, and
-  h∘hinv round trips (#688).
+* Speed up `Vinecop` evaluation and structure selection: no per-edge
+  `Bicop` deep copies in `inverse_rosenblatt`, in-place data collapsing with
+  lazy discrete sub-buffers, parallel allocation-free Monte-Carlo `cdf`, and
+  selection fast paths (NaN-free criterion, moved h-function storage, final
+  tree h-functions skipped, in-place candidate fits). `pdf_full` no longer
+  fills `hfunc*_sub` with duplicated continuous h-functions (#692).
+* Speed up `Vinecop` evaluation and structure selection: no per-edge
+  `Bicop` deep copies in `inverse_rosenblatt`, in-place data collapsing with
+  lazy discrete sub-buffers, parallel allocation-free Monte-Carlo `cdf`,
+  selection fast paths (NaN-free criterion, moved h-function storage, final
+  tree h-functions skipped, in-place candidate fits), and an allocation-free
+  rolling-bitmask proximity check in `RVineStructure`. `pdf_full` no longer
+  fills `hfunc*_sub` with duplicated continuous h-functions (#692).
 * Add `Bicop::parameters_to_taildep()`/`Bicop::get_taildep()` to compute the tail
   dependence coefficients (returned as a 2x2 matrix collecting all four corners of
   the unit square) and `Bicop::parameters_to_beta()`/`Bicop::get_beta()` to compute

--- a/include/vinecopulib/vinecop/class.hpp
+++ b/include/vinecopulib/vinecop/class.hpp
@@ -255,6 +255,7 @@ protected:
   double loglik_{ NAN };
   size_t nobs_{ 0 };
   mutable std::vector<std::string> var_types_;
+  mutable int n_discrete_{ 0 };
 
   void check_data_dim(const Eigen::MatrixXd& data) const;
   void check_data(const Eigen::MatrixXd& data) const;
@@ -273,6 +274,7 @@ protected:
   int get_n_discrete() const;
   bool is_discrete() const;
   Eigen::MatrixXd collapse_data(const Eigen::MatrixXd& u) const;
+  void collapse_data_inplace(Eigen::MatrixXd& u) const;
 };
 }
 

--- a/include/vinecopulib/vinecop/implementation/class.ipp
+++ b/include/vinecopulib/vinecop/implementation/class.ipp
@@ -157,6 +157,10 @@ inline Vinecop::Vinecop(const nlohmann::json& input, const bool check)
   try {
     var_types_ =
       tools_serialization::json_to_vector<std::string>(input["var_types"]);
+    n_discrete_ = 0;
+    for (const auto& t : var_types_) {
+      n_discrete_ += (t == "d");
+    }
     nobs_ = static_cast<size_t>(input["nobs_"]);
     threshold_ = static_cast<double>(input["threshold"]);
     loglik_ = static_cast<double>(input["loglik"]);
@@ -400,6 +404,13 @@ Vinecop::fit(const Eigen::MatrixXd& data,
 
   for (size_t tree = 0; tree < trunc_lvl; ++tree) {
     tools_interface::check_user_interrupt();
+    // scale down the per-fit thread budget: the edges of this tree already
+    // run concurrently on the pool, so nested threading would oversubscribe
+    FitControlsBicop tree_controls = controls;
+    if (num_threads > 1) {
+      tree_controls.set_num_threads(
+        std::max<size_t>(1, num_threads / std::max<size_t>(1, d_ - tree - 1)));
+    }
     auto fit_edge = [&](size_t edge) {
       tools_interface::check_user_interrupt(edge % 5 == 0);
       // extract evaluation point from hfunction matrices (have been
@@ -408,7 +419,7 @@ Vinecop::fit(const Eigen::MatrixXd& data,
       auto var_types = edge_copula->get_var_types();
       size_t m = rvine_structure_.min_array(tree, edge);
 
-      auto u_e = Eigen::MatrixXd(n, 2), u_e_sub = Eigen::MatrixXd(n, 2);
+      Eigen::MatrixXd u_e(n, 2), u_e_sub;
       u_e.col(0) = hfunc2.col(edge);
       if (m == rvine_structure_.struct_array(tree, edge, true)) {
         u_e.col(1) = hfunc2.col(m - 1);
@@ -426,7 +437,7 @@ Vinecop::fit(const Eigen::MatrixXd& data,
         }
       }
 
-      edge_copula->fit(u_e, controls);
+      edge_copula->fit(u_e, tree_controls);
 
       // h-functions are only evaluated if needed in next tree
       if (rvine_structure_.needed_hfunc1(tree, edge)) {
@@ -855,14 +866,19 @@ inline void
 Vinecop::set_var_types_internal(const std::vector<std::string>& var_types) const
 {
   var_types_ = var_types;
+  n_discrete_ = 0;
+  for (const auto& t : var_types_) {
+    n_discrete_ += (t == "d");
+  }
   if (pair_copulas_.size() == 0) {
     return;
   }
 
   // set new var_types for all pair-copulas
+  const auto order = rvine_structure_.get_order();
   std::vector<std::string> natural_types(d_), pair_types(2);
   for (size_t j = 0; j < d_; ++j) {
-    natural_types[j] = var_types[rvine_structure_.get_order()[j] - 1];
+    natural_types[j] = var_types[order[j] - 1];
   }
   // we set the first tree explicitly and deduce later trees
   for (size_t e = 0; e < d_ - 1; ++e) {
@@ -938,12 +954,13 @@ Vinecop::pdf_full(Eigen::MatrixXd u,
                   const bool keep_all) const
 {
   check_data(u);
-  u = collapse_data(u);
+  collapse_data_inplace(u);
 
   // info about the vine structure (reverse rows (!) for more natural indexing)
   size_t trunc_lvl = rvine_structure_.get_trunc_lvl();
   auto order = rvine_structure_.get_order();
   auto disc_cols = tools_select::get_disc_cols(var_types_);
+  const bool discrete = is_discrete();
 
   PdfWithHfuncsResult result;
 
@@ -951,18 +968,24 @@ Vinecop::pdf_full(Eigen::MatrixXd u,
     result.pdf_edges = TriangularArray<Eigen::VectorXd>(d_, trunc_lvl);
     result.hfunc1 = TriangularArray<Eigen::VectorXd>(d_, trunc_lvl);
     result.hfunc2 = TriangularArray<Eigen::VectorXd>(d_, trunc_lvl);
-    result.hfunc1_sub = TriangularArray<Eigen::VectorXd>(d_, trunc_lvl);
-    result.hfunc2_sub = TriangularArray<Eigen::VectorXd>(d_, trunc_lvl);
+    if (discrete) {
+      result.hfunc1_sub = TriangularArray<Eigen::VectorXd>(d_, trunc_lvl);
+      result.hfunc2_sub = TriangularArray<Eigen::VectorXd>(d_, trunc_lvl);
+    }
     for (size_t tree = 0; tree < trunc_lvl; ++tree) {
       for (size_t edge = 0; edge < d_ - tree - 1; ++edge) {
         result.pdf_edges(tree, edge) = Eigen::VectorXd::Zero(u.rows());
         if (rvine_structure_.needed_hfunc1(tree, edge)) {
           result.hfunc1(tree, edge) = Eigen::VectorXd::Zero(u.rows());
-          result.hfunc1_sub(tree, edge) = Eigen::VectorXd::Zero(u.rows());
+          if (discrete) {
+            result.hfunc1_sub(tree, edge) = Eigen::VectorXd::Zero(u.rows());
+          }
         }
         if (rvine_structure_.needed_hfunc2(tree, edge)) {
           result.hfunc2(tree, edge) = Eigen::VectorXd::Zero(u.rows());
-          result.hfunc2_sub(tree, edge) = Eigen::VectorXd::Zero(u.rows());
+          if (discrete) {
+            result.hfunc2_sub(tree, edge) = Eigen::VectorXd::Zero(u.rows());
+          }
         }
       }
     }
@@ -976,7 +999,7 @@ Vinecop::pdf_full(Eigen::MatrixXd u,
     Eigen::MatrixXd hfunc1, hfunc2, u_e, hfunc1_sub, hfunc2_sub, u_e_sub;
     hfunc1 = Eigen::MatrixXd::Zero(b.size, d_);
     hfunc2 = Eigen::MatrixXd::Zero(b.size, d_);
-    if (is_discrete()) {
+    if (discrete) {
       hfunc1_sub = hfunc1;
       hfunc2_sub = hfunc2;
     }
@@ -1002,7 +1025,7 @@ Vinecop::pdf_full(Eigen::MatrixXd u,
         auto var_types = edge_copula->get_var_types();
         size_t m = rvine_structure_.min_array(tree, edge);
 
-        u_e = Eigen::MatrixXd(b.size, 2);
+        u_e.resize(b.size, 2);
         u_e.col(0) = hfunc2.col(edge);
         if (m == rvine_structure_.struct_array(tree, edge, true)) {
           u_e.col(1) = hfunc2.col(m - 1);
@@ -1047,14 +1070,18 @@ Vinecop::pdf_full(Eigen::MatrixXd u,
           if (rvine_structure_.needed_hfunc1(tree, edge)) {
             result.hfunc1(tree, edge).segment(b.begin, b.size) =
               hfunc1.col(edge);
-            result.hfunc1_sub(tree, edge).segment(b.begin, b.size) =
-              is_discrete() ? hfunc1_sub.col(edge) : hfunc1.col(edge);
+            if (discrete) {
+              result.hfunc1_sub(tree, edge).segment(b.begin, b.size) =
+                hfunc1_sub.col(edge);
+            }
           }
           if (rvine_structure_.needed_hfunc2(tree, edge)) {
             result.hfunc2(tree, edge).segment(b.begin, b.size) =
               hfunc2.col(edge);
-            result.hfunc2_sub(tree, edge).segment(b.begin, b.size) =
-              is_discrete() ? hfunc2_sub.col(edge) : hfunc2.col(edge);
+            if (discrete) {
+              result.hfunc2_sub(tree, edge).segment(b.begin, b.size) =
+                hfunc2_sub.col(edge);
+            }
           }
         }
       }
@@ -1366,7 +1393,9 @@ inline Eigen::MatrixXd
 Vinecop::scores_cov(Eigen::MatrixXd u, bool step_wise, const size_t num_threads)
 {
   auto s = this->scores(u, step_wise, num_threads);
-  auto sc = s.rowwise() - s.colwise().mean();
+  // materialize the centered scores; a lazy expression would be evaluated
+  // twice by the product below
+  Eigen::MatrixXd sc = s.rowwise() - s.colwise().mean();
   return (sc.adjoint() * sc) / static_cast<double>(s.rows());
 }
 
@@ -1417,14 +1446,19 @@ Vinecop::cdf(const Eigen::MatrixXd& u,
 
   size_t n = u.rows();
   Eigen::VectorXd vine_distribution(n);
-  Eigen::ArrayXXd x(N, 1);
-  Eigen::RowVectorXd temp(d_);
-  for (size_t i = 0; i < n; i++) {
-    tools_interface::check_user_interrupt(i % 1000 == 0);
-    temp = u.block(i, 0, 1, d_);
-    x = (u_sim.rowwise() - temp).rowwise().maxCoeff().array();
-    vine_distribution(i) = static_cast<double>((x <= 0.0).count());
-  }
+  auto do_batch = [&](const tools_batch::Batch& b) {
+    // lazy dominance count per query point (no N-sized temporary)
+    Eigen::RowVectorXd temp(d_);
+    for (size_t i = b.begin; i < b.begin + b.size; i++) {
+      tools_interface::check_user_interrupt(i % 1000 == 0);
+      temp = u.block(i, 0, 1, d_);
+      vine_distribution(i) = static_cast<double>(
+        ((u_sim.rowwise() - temp).rowwise().maxCoeff().array() <= 0.0).count());
+    }
+  };
+  tools_thread::ThreadPool pool((num_threads == 1) ? 0 : num_threads);
+  pool.map(do_batch, tools_batch::create_batches(n, num_threads));
+  pool.join();
   return vine_distribution / static_cast<double>(N);
 }
 
@@ -1625,7 +1659,7 @@ Vinecop::rosenblatt(Eigen::MatrixXd u,
                     std::vector<int> seeds) const
 {
   check_data(u);
-  u = collapse_data(u);
+  collapse_data_inplace(u);
 
   size_t d = d_;
   size_t n = u.rows();
@@ -1638,8 +1672,7 @@ Vinecop::rosenblatt(Eigen::MatrixXd u,
 
   // fill first row of hfunc2 matrix with evaluation points;
   // points have to be reordered to correspond to natural order
-  Eigen::MatrixXd hfunc1(n, d), hfunc2(n, d), hfunc1_sub(n, d),
-    hfunc2_sub(n, d);
+  Eigen::MatrixXd hfunc1(n, d), hfunc2(n, d), hfunc1_sub, hfunc2_sub;
   for (size_t j = 0; j < d; ++j) {
     hfunc2.col(j) = u.col(order[j] - 1);
   }
@@ -1647,14 +1680,10 @@ Vinecop::rosenblatt(Eigen::MatrixXd u,
   if (is_discrete()) {
     hfunc1_sub = hfunc1;
     hfunc2_sub = hfunc2;
-  }
-
-  // fill first row of hfunc2 matrix with evaluation points;
-  // points have to be reordered to correspond to natural order
-  for (size_t j = 0; j < d_; ++j) {
-    hfunc2.col(j) = u.col(order[j] - 1);
-    if (var_types_[order[j] - 1] == "d") {
-      hfunc2_sub.col(j) = u.col(d_ + disc_cols[order[j] - 1]);
+    for (size_t j = 0; j < d_; ++j) {
+      if (var_types_[order[j] - 1] == "d") {
+        hfunc2_sub.col(j) = u.col(d_ + disc_cols[order[j] - 1]);
+      }
     }
   }
 
@@ -1671,7 +1700,7 @@ Vinecop::rosenblatt(Eigen::MatrixXd u,
         auto var_types = edge_copula->get_var_types();
         size_t m = rvine_structure_.min_array(tree, edge);
 
-        u_e = Eigen::MatrixXd(b.size, 2);
+        u_e.resize(b.size, 2);
         u_e.col(0) = hfunc2.block(b.begin, edge, b.size, 1);
         if (m == rvine_structure_.struct_array(tree, edge, true)) {
           u_e.col(1) = hfunc2.block(b.begin, m - 1, b.size, 1);
@@ -1809,6 +1838,7 @@ Vinecop::inverse_rosenblatt(const Eigen::MatrixXd& u,
     // temporary storage objects for (inverse) h-functions
     TriangularArray<Eigen::VectorXd> hinv2(d + 1, trunc_lvl + 1);
     TriangularArray<Eigen::VectorXd> hfunc1(d + 1, trunc_lvl + 1);
+    Eigen::MatrixXd U_e(b.size, 2);
 
     // initialize with independent uniforms (corresponding to natural
     // order)
@@ -1824,10 +1854,11 @@ Vinecop::inverse_rosenblatt(const Eigen::MatrixXd& u,
         static_cast<double>(n) * static_cast<double>(d) > 1e5);
       size_t tree_start = std::min(trunc_lvl - 1, d - var - 2);
       for (ptrdiff_t tree = tree_start; tree >= 0; --tree) {
-        Bicop edge_copula = pair_copulas_[tree][var].as_continuous();
+        // var types have already been set to continuous above, so no copy
+        // via as_continuous() is needed
+        const Bicop& edge_copula = pair_copulas_[tree][var];
 
         // extract data for conditional pair
-        Eigen::MatrixXd U_e(b.size, 2);
         size_t m = rvine_structure_.min_array(tree, var);
         U_e.col(0) = hinv2(tree + 1, var);
         if (m == rvine_structure_.struct_array(tree, var, true)) {
@@ -2015,17 +2046,13 @@ Vinecop::set_continuous_var_types() const
 inline int
 Vinecop::get_n_discrete() const
 {
-  int n_discrete = 0;
-  for (auto t : var_types_) {
-    n_discrete += (t == "d");
-  }
-  return n_discrete;
+  return n_discrete_;
 }
 
 inline bool
 Vinecop::is_discrete() const
 {
-  return get_n_discrete() > 0;
+  return n_discrete_ > 0;
 }
 
 //! @brief Removes superfluous columns for continuous data.
@@ -2044,6 +2071,16 @@ Vinecop::collapse_data(const Eigen::MatrixXd& u) const
     }
   }
   return u_new;
+}
+
+//! @brief Removes superfluous columns for continuous data, avoiding the
+//! copy when the data is already in collapsed format.
+inline void
+Vinecop::collapse_data_inplace(Eigen::MatrixXd& u) const
+{
+  if (static_cast<size_t>(u.cols()) != d_ + get_n_discrete()) {
+    u = collapse_data(u);
+  }
 }
 
 //! @brief Summarizes the model into a string (can be used for printing).

--- a/include/vinecopulib/vinecop/implementation/rvine_structure.ipp
+++ b/include/vinecopulib/vinecop/implementation/rvine_structure.ipp
@@ -4,7 +4,6 @@
 // the MIT license. For a copy, see the LICENSE file in the root directory of
 // vinecopulib or https://vinecopulib.github.io/vinecopulib/.
 
-#include <cstdint>
 #include <vinecopulib/misc/tools_serialization.hpp>
 #include <vinecopulib/misc/tools_stats.hpp>
 #include <vinecopulib/misc/tools_stl.hpp>
@@ -688,50 +687,21 @@ RVineStructure::check_antidiagonal() const
 inline void
 RVineStructure::check_proximity_condition() const
 {
-  if (trunc_lvl_ < 2) {
-    return;
-  }
-  // The sets to compare consist of distinct values in 1, ..., d (enforced by
-  // check_columns), so they can be represented as bitmasks. The conditioning
-  // sets are prefixes of the structure array columns; the masks are grown
-  // one row at a time, giving O(d^3 / 64) work without any allocation in
-  // the loop (compared to a copy + sort per pair for the set version).
-  const size_t w = d_ / 64 + 1; // 64-bit words per column mask
-  std::vector<uint64_t> masks(d_ * w, 0);
   for (size_t t = 1; t < trunc_lvl_; ++t) {
-    // fold row t - 1 into the column masks
-    for (size_t e = 0; e < d_ - t; ++e) {
-      const size_t v = struct_array_(t - 1, e);
-      masks[e * w + (v >> 6)] |= (uint64_t(1) << (v & 63));
-    }
     for (size_t e = 0; e < d_ - t - 1; ++e) {
-      const size_t m = min_array_(t, e);
-      const size_t b1 = struct_array_(t, e);
-      const size_t b2 = m;
-      bool equal = true;
-      for (size_t k = 0; k < w; ++k) {
-        uint64_t m1 = masks[e * w + k];
-        uint64_t m2 = masks[(m - 1) * w + k];
-        if ((b1 >> 6) == k) {
-          m1 |= (uint64_t(1) << (b1 & 63));
-        }
-        if ((b2 >> 6) == k) {
-          m2 |= (uint64_t(1) << (b2 & 63));
-        }
-        if (m1 != m2) {
-          equal = false;
-          break;
-        }
+      std::vector<size_t> target_set(t + 1), test_set(t + 1);
+      // conditioning set
+      for (size_t i = 0; i < t; i++) {
+        target_set[i] = struct_array_(i, e);
+        test_set[i] = struct_array_(i, min_array_(t, e) - 1);
       }
 
-      if (!equal) {
-        // cold path: rebuild the sets for the error message
-        std::vector<size_t> target_set(t + 1);
-        for (size_t i = 0; i < t; i++) {
-          target_set[i] = struct_array_(i, e);
-        }
-        target_set[t] = struct_array_(t, e);
+      // non-diagonal conditioned variable
+      target_set[t] = struct_array_(t, e);
+      // diagonal conditioned variable in other column
+      test_set[t] = min_array_(t, e);
 
+      if (!tools_stl::is_same_set(target_set, test_set)) {
         std::stringstream problem;
         problem << "not a valid R-vine array: "
                 << "proximity condition violated; "

--- a/include/vinecopulib/vinecop/implementation/rvine_structure.ipp
+++ b/include/vinecopulib/vinecop/implementation/rvine_structure.ipp
@@ -4,6 +4,7 @@
 // the MIT license. For a copy, see the LICENSE file in the root directory of
 // vinecopulib or https://vinecopulib.github.io/vinecopulib/.
 
+#include <cstdint>
 #include <vinecopulib/misc/tools_serialization.hpp>
 #include <vinecopulib/misc/tools_stats.hpp>
 #include <vinecopulib/misc/tools_stl.hpp>
@@ -687,21 +688,50 @@ RVineStructure::check_antidiagonal() const
 inline void
 RVineStructure::check_proximity_condition() const
 {
+  if (trunc_lvl_ < 2) {
+    return;
+  }
+  // The sets to compare consist of distinct values in 1, ..., d (enforced by
+  // check_columns), so they can be represented as bitmasks. The conditioning
+  // sets are prefixes of the structure array columns; the masks are grown
+  // one row at a time, giving O(d^3 / 64) work without any allocation in
+  // the loop (compared to a copy + sort per pair for the set version).
+  const size_t w = d_ / 64 + 1; // 64-bit words per column mask
+  std::vector<uint64_t> masks(d_ * w, 0);
   for (size_t t = 1; t < trunc_lvl_; ++t) {
+    // fold row t - 1 into the column masks
+    for (size_t e = 0; e < d_ - t; ++e) {
+      const size_t v = struct_array_(t - 1, e);
+      masks[e * w + (v >> 6)] |= (uint64_t(1) << (v & 63));
+    }
     for (size_t e = 0; e < d_ - t - 1; ++e) {
-      std::vector<size_t> target_set(t + 1), test_set(t + 1);
-      // conditioning set
-      for (size_t i = 0; i < t; i++) {
-        target_set[i] = struct_array_(i, e);
-        test_set[i] = struct_array_(i, min_array_(t, e) - 1);
+      const size_t m = min_array_(t, e);
+      const size_t b1 = struct_array_(t, e);
+      const size_t b2 = m;
+      bool equal = true;
+      for (size_t k = 0; k < w; ++k) {
+        uint64_t m1 = masks[e * w + k];
+        uint64_t m2 = masks[(m - 1) * w + k];
+        if ((b1 >> 6) == k) {
+          m1 |= (uint64_t(1) << (b1 & 63));
+        }
+        if ((b2 >> 6) == k) {
+          m2 |= (uint64_t(1) << (b2 & 63));
+        }
+        if (m1 != m2) {
+          equal = false;
+          break;
+        }
       }
 
-      // non-diagonal conditioned variable
-      target_set[t] = struct_array_(t, e);
-      // diagonal conditioned variable in other column
-      test_set[t] = min_array_(t, e);
+      if (!equal) {
+        // cold path: rebuild the sets for the error message
+        std::vector<size_t> target_set(t + 1);
+        for (size_t i = 0; i < t; i++) {
+          target_set[i] = struct_array_(i, e);
+        }
+        target_set[t] = struct_array_(t, e);
 
-      if (!tools_stl::is_same_set(target_set, test_set)) {
         std::stringstream problem;
         problem << "not a valid R-vine array: "
                 << "proximity condition violated; "

--- a/include/vinecopulib/vinecop/implementation/tools_select.ipp
+++ b/include/vinecopulib/vinecop/implementation/tools_select.ipp
@@ -27,40 +27,64 @@ using namespace tools_stl;
 //! @param weights Vector of weights for each observation (can be empty).
 //! @param tree_criterion_function Custom criterion function, used when
 //!   `tree_criterion == "custom"`.
+//! (internal) criterion dispatch on clean (NaN-free) data.
 inline double
-calculate_criterion(const Eigen::MatrixXd& data,
-                    std::string tree_criterion,
-                    Eigen::VectorXd weights,
-                    const TreeCriterionFunction& tree_criterion_function)
+calculate_criterion_clean(const Eigen::MatrixXd& data,
+                          const std::string& tree_criterion,
+                          const Eigen::VectorXd& weights,
+                          const TreeCriterionFunction& tree_criterion_function)
 {
   double w = 0.0;
-  Eigen::MatrixXd data_no_nan = data;
-  tools_eigen::remove_nans(data_no_nan, weights);
-  double freq =
-    static_cast<double>(data_no_nan.rows()) / static_cast<double>(data.rows());
-  if (data_no_nan.rows() > 10) {
+  if (data.rows() > 10) {
     if (tree_criterion == "custom") {
       if (!tree_criterion_function) {
         throw std::runtime_error(
           "tree_criterion = \"custom\" requires a tree_criterion_function "
           "callable");
       }
-      w = tree_criterion_function(data_no_nan, weights);
+      w = tree_criterion_function(data, weights);
     } else if (tree_criterion == "mcor") {
-      w = tools_stats::pairwise_mcor(data_no_nan, weights);
+      w = tools_stats::pairwise_mcor(data, weights);
     } else if (tree_criterion == "joe") {
       // mutual information for Gaussian copula
-      w = wdm::wdm(tools_stats::qnorm(data_no_nan), "pearson", weights)(0, 1);
+      w = wdm::wdm(tools_stats::qnorm(data), "pearson", weights)(0, 1);
       w = -0.5 * std::log(1 - w * w);
     } else {
-      w = wdm::wdm(data_no_nan, tree_criterion, weights)(0, 1);
+      w = wdm::wdm(data, tree_criterion, weights)(0, 1);
     }
 
     if (std::isnan(w)) {
       w = 0.0;
     }
   }
-  return std::fabs(w) * std::sqrt(freq);
+  return std::fabs(w);
+}
+
+inline double
+calculate_criterion(const Eigen::MatrixXd& data,
+                    const std::string& tree_criterion,
+                    const Eigen::VectorXd& weights,
+                    const TreeCriterionFunction& tree_criterion_function)
+{
+  // fast path (the common case): no NaNs and no zero weights, so the
+  // copy + compaction can be skipped altogether
+  bool clean = !data.array().isNaN().any();
+  if (clean && (weights.size() > 0)) {
+    clean = !(weights.array().isNaN().any() || (weights.array() == 0.0).any());
+  }
+  if (clean) {
+    return calculate_criterion_clean(
+      data, tree_criterion, weights, tree_criterion_function);
+  }
+
+  Eigen::MatrixXd data_no_nan = data;
+  Eigen::VectorXd weights_no_nan = weights;
+  tools_eigen::remove_nans(data_no_nan, weights_no_nan);
+  double freq =
+    static_cast<double>(data_no_nan.rows()) / static_cast<double>(data.rows());
+  double w = calculate_criterion_clean(
+    data_no_nan, tree_criterion, weights_no_nan, tree_criterion_function);
+  return w * std::sqrt(freq);
 }
 
 //! computes
@@ -363,7 +387,12 @@ VinecopSelector::get_next_threshold(std::vector<double>& thresholded_crits)
 inline void
 VinecopSelector::add_allowed_edges(VineTree& vine_tree)
 {
-  std::string tree_criterion = controls_.get_tree_criterion();
+  // hoist loop invariants: the getters return by value, so calling them
+  // per candidate edge would copy the weights vector every time
+  const std::string tree_criterion = controls_.get_tree_criterion();
+  const Eigen::VectorXd weights = controls_.get_weights();
+  const TreeCriterionFunction criterion_fun =
+    controls_.get_tree_criterion_function();
   if (structure_unknown_) {
     std::vector<std::pair<size_t, size_t>> edge_list;
     for (size_t v0 = 0; v0 < num_vertices(vine_tree); ++v0) {
@@ -384,10 +413,7 @@ VinecopSelector::add_allowed_edges(VineTree& vine_tree)
 
       auto pc_data = get_pc_data(v0, v1, vine_tree);
       double crit =
-        calculate_criterion(pc_data,
-                            tree_criterion,
-                            controls_.get_weights(),
-                            controls_.get_tree_criterion_function());
+        calculate_criterion(pc_data, tree_criterion, weights, criterion_fun);
       double w = 1.0 - static_cast<double>(crit >= threshold) * crit;
 
       {
@@ -411,11 +437,8 @@ VinecopSelector::add_allowed_edges(VineTree& vine_tree)
         size_t v1 = vine_struct_.min_array(tree, v0) - 1;
         Eigen::MatrixXd pc_data = get_pc_data(v0, v1, vine_tree);
         EdgeIterator e = boost::add_edge(v0, v1, 1.0, vine_tree).first;
-        double crit =
-          calculate_criterion(pc_data.leftCols(2),
-                              tree_criterion,
-                              controls_.get_weights(),
-                              controls_.get_tree_criterion_function());
+        double crit = calculate_criterion(
+          pc_data.leftCols(2), tree_criterion, weights, criterion_fun);
         vine_tree[e].weight = 1.0;
         vine_tree[e].crit = crit;
       }
@@ -677,7 +700,7 @@ VinecopSelector::add_pc_info(const EdgeIterator& e, VineTree& tree)
   tree[e].all_indices = cat(tree[e].conditioned, tree[e].conditioning);
 }
 
-inline Eigen::VectorXd
+inline const Eigen::VectorXd&
 VinecopSelector::get_hfunc(const VertexProperties& vertex_data, bool is_first)
 {
   if (is_first) {
@@ -687,7 +710,7 @@ VinecopSelector::get_hfunc(const VertexProperties& vertex_data, bool is_first)
   }
 }
 
-inline Eigen::VectorXd
+inline const Eigen::VectorXd&
 VinecopSelector::get_hfunc_sub(const VertexProperties& vertex_data,
                                bool is_first)
 {
@@ -757,10 +780,20 @@ VinecopSelector::select_tree(size_t t)
       // adjust prior probability to tree level
       controls_.set_psi0(std::pow(psi0_, t + 1));
     }
-    if (trees_opt_.size() > t + 1) {
-      select_pair_copulas(new_tree, trees_opt_[t + 1]);
+    // h-functions of this tree's edges are only consumed when another tree
+    // is selected afterwards; skip them for the final tree. In sparse mode
+    // the loop selects one extra tree (index == trunc_lvl) for the mbicv
+    // comparison, in regular mode it stops after tree trunc_lvl - 1.
+    bool last_tree = (t + 1 >= d_ - 1);
+    if (controls_.needs_sparse_select()) {
+      last_tree = last_tree || (t >= controls_.get_trunc_lvl());
     } else {
-      select_pair_copulas(new_tree);
+      last_tree = last_tree || (t + 1 >= controls_.get_trunc_lvl());
+    }
+    if (trees_opt_.size() > t + 1) {
+      select_pair_copulas(new_tree, trees_opt_[t + 1], last_tree);
+    } else {
+      select_pair_copulas(new_tree, VineTree(), last_tree);
     }
   }
   // make sure there is space for new tree
@@ -861,6 +894,12 @@ inline void
 VinecopSelector::set_current_fit_as_opt(const double& loglik)
 {
   threshold_ = controls_.get_threshold();
+  // the bulky per-edge data is not needed in the snapshot (nor in trees_
+  // afterwards): later iterations only read fit_id, crit, and pair_copula,
+  // and h-functions are always recomputed in select_pair_copulas
+  for (auto& tree : trees_) {
+    remove_edge_data(tree);
+  }
   trees_opt_ = trees_;
   loglik_ = loglik;
 }
@@ -917,19 +956,21 @@ VinecopSelector::make_base_tree(const Eigen::MatrixXd& data)
 //! @return A edge-less graph of vertices, each representing one edge of the
 //!     previous tree.
 inline VineTree
-VinecopSelector::edges_as_vertices(const VineTree& prev_tree)
+VinecopSelector::edges_as_vertices(VineTree& prev_tree)
 {
   // start with full graph
   size_t d = num_edges(prev_tree);
   VineTree new_tree(d);
 
-  // copy & paste information from previous tree
+  // copy & paste information from previous tree; the h-function vectors are
+  // moved because the previous tree's edge data is discarded right after
+  // this call (see select_tree)
   int i = 0;
   for (auto e : boost::edges(prev_tree)) {
-    new_tree[i].hfunc1 = prev_tree[e].hfunc1;
-    new_tree[i].hfunc2 = prev_tree[e].hfunc2;
-    new_tree[i].hfunc1_sub = prev_tree[e].hfunc1_sub;
-    new_tree[i].hfunc2_sub = prev_tree[e].hfunc2_sub;
+    new_tree[i].hfunc1 = std::move(prev_tree[e].hfunc1);
+    new_tree[i].hfunc2 = std::move(prev_tree[e].hfunc2);
+    new_tree[i].hfunc1_sub = std::move(prev_tree[e].hfunc1_sub);
+    new_tree[i].hfunc2_sub = std::move(prev_tree[e].hfunc2_sub);
     new_tree[i].conditioned = prev_tree[e].conditioned;
     new_tree[i].conditioning = prev_tree[e].conditioning;
     new_tree[i].all_indices = prev_tree[e].all_indices;
@@ -1026,7 +1067,9 @@ VinecopSelector::remove_vertex_data(VineTree& tree)
 //! @param tree_opt The current optimal tree (used only for sparse
 //!     selection).
 inline void
-VinecopSelector::select_pair_copulas(VineTree& tree, const VineTree& tree_opt)
+VinecopSelector::select_pair_copulas(VineTree& tree,
+                                     const VineTree& tree_opt,
+                                     bool last_tree)
 {
   auto select_pc = [&](EdgeIterator e) -> void {
     tools_interface::check_user_interrupt();
@@ -1052,23 +1095,27 @@ VinecopSelector::select_pair_copulas(VineTree& tree, const VineTree& tree_opt)
       }
     }
 
-    tree[e].hfunc1 = tree[e].pair_copula.hfunc1(tree[e].pc_data);
-    tree[e].hfunc2 = tree[e].pair_copula.hfunc2(tree[e].pc_data);
-    if (tree[e].var_types[1] == "d") {
-      auto sub_data = tree[e].pc_data;
-      sub_data.col(1) = sub_data.col(3);
-      tree[e].hfunc1_sub = tree[e].pair_copula.hfunc1(sub_data);
-    }
-    if (tree[e].var_types[0] == "d") {
-      auto sub_data = tree[e].pc_data;
-      sub_data.col(0) = sub_data.col(2);
-      tree[e].hfunc2_sub = tree[e].pair_copula.hfunc2(sub_data);
+    // h-functions are only consumed by the selection of the next tree
+    if (!last_tree) {
+      tree[e].hfunc1 = tree[e].pair_copula.hfunc1(tree[e].pc_data);
+      tree[e].hfunc2 = tree[e].pair_copula.hfunc2(tree[e].pc_data);
+      if (tree[e].var_types[1] == "d") {
+        auto sub_data = tree[e].pc_data;
+        sub_data.col(1) = sub_data.col(3);
+        tree[e].hfunc1_sub = tree[e].pair_copula.hfunc1(sub_data);
+      }
+      if (tree[e].var_types[0] == "d") {
+        auto sub_data = tree[e].pc_data;
+        sub_data.col(0) = sub_data.col(2);
+        tree[e].hfunc2_sub = tree[e].pair_copula.hfunc2(sub_data);
+      }
     }
   };
 
   // make sure that Bicop.select() doesn't spawn too many new threads
   size_t num_threads = controls_.get_num_threads();
-  controls_.set_num_threads(num_threads / boost::num_edges(tree));
+  controls_.set_num_threads(std::max<size_t>(
+    1, num_threads / std::max<size_t>(1, boost::num_edges(tree))));
   pool_.map(select_pc, boost::edges(tree));
   pool_.wait();
   controls_.set_num_threads(num_threads);

--- a/include/vinecopulib/vinecop/tools_select.hpp
+++ b/include/vinecopulib/vinecop/tools_select.hpp
@@ -34,8 +34,8 @@ namespace tools_select {
 
 double
 calculate_criterion(const Eigen::MatrixXd& data,
-                    std::string tree_criterion,
-                    Eigen::VectorXd weights,
+                    const std::string& tree_criterion,
+                    const Eigen::VectorXd& weights,
                     const TreeCriterionFunction& tree_criterion_function = {});
 
 std::vector<size_t>
@@ -144,10 +144,12 @@ protected:
 
   Eigen::MatrixXd get_pc_data(size_t v0, size_t v1, const VineTree& tree);
 
-  Eigen::VectorXd get_hfunc(const VertexProperties& vertex_data, bool is_first);
+  static const Eigen::VectorXd& get_hfunc(const VertexProperties& vertex_data,
+                                          bool is_first);
 
-  Eigen::VectorXd get_hfunc_sub(const VertexProperties& vertex_data,
-                                bool is_first);
+  static const Eigen::VectorXd& get_hfunc_sub(
+    const VertexProperties& vertex_data,
+    bool is_first);
 
   ptrdiff_t find_common_neighbor(size_t v0, size_t v1, const VineTree& tree);
 
@@ -173,7 +175,7 @@ protected:
   // functions for manipulation of trees ----------------
   VineTree make_base_tree(const Eigen::MatrixXd& data);
 
-  VineTree edges_as_vertices(const VineTree& prev_tree);
+  VineTree edges_as_vertices(VineTree& prev_tree);
 
   void add_edge_info(VineTree& tree);
 
@@ -184,7 +186,8 @@ protected:
   void remove_vertex_data(VineTree& tree);
 
   void select_pair_copulas(VineTree& tree,
-                           const VineTree& tree_opt = VineTree());
+                           const VineTree& tree_opt = VineTree(),
+                           bool last_tree = false);
 
   FoundEdge find_old_fit(double fit_id, const VineTree& old_graph);
 

--- a/test/src_test/include/test_rvine_structure.hpp
+++ b/test/src_test/include/test_rvine_structure.hpp
@@ -266,6 +266,26 @@ TEST(rvine_structure, rvine_struct_sanity_checks_work)
   EXPECT_ANY_THROW(rvm = RVineStructure(wrong_mat));
 }
 
+TEST(rvine_structure, proximity_condition_multiword)
+{
+  // Exercise the >64-dimensional proximity check, where the rolling column
+  // bitmasks span more than one 64-bit word (d = 70 -> 2 words). The 7x7
+  // case above only covers a single word.
+  const size_t d = 70;
+  auto mat = CVineStructure(tools_stl::seq_int(1, d)).get_matrix();
+
+  // a valid structure must pass the multi-word proximity check
+  EXPECT_NO_THROW(RVineStructure{ mat }); // check = true by default
+
+  // a proximity violation must still be caught with multi-word masks:
+  // swapping two non-antidiagonal entries within a column keeps the column's
+  // value set and the diagonal intact, so only the proximity check rejects it
+  // (verified to raise the "proximity condition violated" error)
+  auto wrong_mat = mat;
+  std::swap(wrong_mat(0, 0), wrong_mat(2, 0));
+  EXPECT_ANY_THROW(RVineStructure{ wrong_mat });
+}
+
 TEST(rvine_structure, random_sampling)
 {
   for (size_t i = 0; i < 20; i++) {

--- a/test/src_test/include/test_rvine_structure.hpp
+++ b/test/src_test/include/test_rvine_structure.hpp
@@ -266,21 +266,19 @@ TEST(rvine_structure, rvine_struct_sanity_checks_work)
   EXPECT_ANY_THROW(rvm = RVineStructure(wrong_mat));
 }
 
-TEST(rvine_structure, proximity_condition_multiword)
+TEST(rvine_structure, proximity_condition_large_d)
 {
-  // Exercise the >64-dimensional proximity check, where the rolling column
-  // bitmasks span more than one 64-bit word (d = 70 -> 2 words). The 7x7
-  // case above only covers a single word.
+  // exercise the proximity check in a higher dimension than the 7x7 case
+  // above, including the error path
   const size_t d = 70;
   auto mat = CVineStructure(tools_stl::seq_int(1, d)).get_matrix();
 
-  // a valid structure must pass the multi-word proximity check
+  // a valid structure must pass the check
   EXPECT_NO_THROW(RVineStructure{ mat }); // check = true by default
 
-  // a proximity violation must still be caught with multi-word masks:
   // swapping two non-antidiagonal entries within a column keeps the column's
   // value set and the diagonal intact, so only the proximity check rejects it
-  // (verified to raise the "proximity condition violated" error)
+  // (raises the "proximity condition violated" error)
   auto wrong_mat = mat;
   std::swap(wrong_mat(0, 0), wrong_mat(2, 0));
   EXPECT_ANY_THROW(RVineStructure{ wrong_mat });

--- a/test/src_test/include/test_vinecop_class.hpp
+++ b/test/src_test/include/test_vinecop_class.hpp
@@ -305,26 +305,49 @@ TEST_F(VinecopTest, hfuncs_is_correct)
 
   ASSERT_EQ(r.hfunc1.get_trunc_lvl(), trunc_lvl);
   ASSERT_EQ(r.hfunc2.get_trunc_lvl(), trunc_lvl);
-  ASSERT_EQ(r.hfunc1_sub.get_trunc_lvl(), trunc_lvl);
-  ASSERT_EQ(r.hfunc2_sub.get_trunc_lvl(), trunc_lvl);
   ASSERT_EQ(r.pdf_edges.get_trunc_lvl(), trunc_lvl);
+  // the _sub arrays are only filled when at least one variable is discrete
+  ASSERT_EQ(r.hfunc1_sub.get_trunc_lvl(), 0);
+  ASSERT_EQ(r.hfunc2_sub.get_trunc_lvl(), 0);
 
   for (size_t tree = 0; tree < trunc_lvl; ++tree) {
     for (size_t edge = 0; edge < d - tree - 1; ++edge) {
       EXPECT_EQ(r.pdf_edges(tree, edge).size(), u.rows());
       if (rvine_structure.needed_hfunc1(tree, edge)) {
         EXPECT_EQ(r.hfunc1(tree, edge).size(), u.rows());
-        EXPECT_EQ(r.hfunc1_sub(tree, edge).size(), u.rows());
       } else {
         EXPECT_EQ(r.hfunc1(tree, edge).size(), 0);
-        EXPECT_EQ(r.hfunc1_sub(tree, edge).size(), 0);
       }
       if (rvine_structure.needed_hfunc2(tree, edge)) {
         EXPECT_EQ(r.hfunc2(tree, edge).size(), u.rows());
-        EXPECT_EQ(r.hfunc2_sub(tree, edge).size(), u.rows());
       } else {
         EXPECT_EQ(r.hfunc2(tree, edge).size(), 0);
-        EXPECT_EQ(r.hfunc2_sub(tree, edge).size(), 0);
+      }
+    }
+  }
+
+  // discrete model: _sub arrays must be allocated and filled
+  std::vector<std::string> var_types(7, "c");
+  var_types[0] = "d";
+  Vinecop vinecop_disc(model_matrix, pair_copulas, var_types);
+  Eigen::MatrixXd u_disc(u.rows(), 8);
+  u_disc.leftCols(7) = u;
+  u_disc.col(0) = (u.col(0).array() * 10).ceil() / 10;
+  u_disc.col(7) = (u.col(0).array() * 10).floor() / 10;
+  auto r_disc = vinecop_disc.pdf_full(u_disc, 1, true);
+  ASSERT_EQ(r_disc.hfunc1_sub.get_trunc_lvl(), trunc_lvl);
+  ASSERT_EQ(r_disc.hfunc2_sub.get_trunc_lvl(), trunc_lvl);
+  for (size_t tree = 0; tree < trunc_lvl; ++tree) {
+    for (size_t edge = 0; edge < d - tree - 1; ++edge) {
+      if (rvine_structure.needed_hfunc1(tree, edge)) {
+        EXPECT_EQ(r_disc.hfunc1_sub(tree, edge).size(), u.rows());
+      } else {
+        EXPECT_EQ(r_disc.hfunc1_sub(tree, edge).size(), 0);
+      }
+      if (rvine_structure.needed_hfunc2(tree, edge)) {
+        EXPECT_EQ(r_disc.hfunc2_sub(tree, edge).size(), u.rows());
+      } else {
+        EXPECT_EQ(r_disc.hfunc2_sub(tree, edge).size(), 0);
       }
     }
   }


### PR DESCRIPTION
Speeds up Vinecop evaluation and structure selection (split out of #681). Independent of the derivatives PR #683: this touches only the evaluation/selection code paths (the `scores`/`hessian` block is untouched, so both merge cleanly in either order).

## Changes

**Evaluation**
- `inverse_rosenblatt` no longer deep-copies a `Bicop` per edge × tree × batch via `as_continuous()` (previously cloned TLL interpolation grids on every access — the dominant cost of simulating from TLL vines).
- `collapse_data_inplace` + cached discrete count + lazy discrete sub-buffers; no-copy fast path for already-collapsed (all-continuous) data.
- Parallelized, allocation-free Monte-Carlo `cdf`.
- `pdf_full(keep_all=true)` no longer fills `hfunc*_sub` with duplicated continuous h-functions (matches the documented discrete-only contract); the test pins both the continuous (empty) and discrete (filled) behavior.

**Selection**
- NaN-free fast path for the tree criterion (no per-candidate data copy); weights/criterion invariants hoisted; h-function storage *moved* between trees; h-functions skipped on the final tree; sparse-selection snapshots stripped of dead data; candidates fitted in place.

## Numerical impact

Bit-identical except `vinecop` log-likelihoods ≤ 1e-12 (documented gates). Full Debug suite (incl. R-parity) passes on current `dev`.

> Review update: the rolling-bitmask rewrite of the proximity check was dropped (see the review thread) — measured, it is 17–77× faster in relative terms but the check runs once per structure construction and costs milliseconds at most, so readability wins. A behavioral large-d proximity test (d=70, pass + violation) was kept.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Benchmarks

Idle 64-core host, single-threaded (except threads=4 cases), 4 interleaved rounds × 8 repetitions, median-of-medians vs `dev` (Gaussian vines; ratio < 1 = faster):

| case | dev (ns) | PR (ns) | ratio |
|---|---|---|---|
| vinecop/simulate/d=5/n=1000 | 1,398,809 | 1,098,961 | **0.79** |
| vinecop/inverse_rosenblatt/d=5/n=1000 | 1,414,114 | 1,116,423 | **0.79** |
| vinecop/simulate/d=25/n=1000 | 42,978,810 | 34,199,281 | **0.80** |
| vinecop/inverse_rosenblatt/d=25/n=1000 | 44,257,446 | 35,426,469 | **0.80** |
| vinecop/pdf/d=5/n=1000/threads=4 | 1,155,367 | 1,095,092 | 0.95 |
| vinecop/cdf/d=5/n=100/N=10000 | 23,734,859 | 22,723,223 | 0.96 |
| vinecop/select/tll/d=5/n=1000/threads=4 | 135,117,935 | 130,607,542 | 0.97 |
| vinecop/select/itau/d=10/threads={1,4} | — | — | ~1.00 |

The 1.25× on `simulate`/`inverse_rosenblatt` is the per-edge `Bicop`-copy removal on *Gaussian* vines; for TLL vines (where each copy cloned interpolation grids) the effect is much larger — that was the dominant cost of simulating from TLL vines.
