### PR TITLE
feat(vinecop): conditioning-aware structure selection (VineCopulas port)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -32,6 +32,20 @@
   reproduces the conditioning values exactly. Discrete conditioning variables
   are supported via the randomized Rosenblatt transform (each requires its
   left-limit CDF as an extra column of the conditioning matrix) (#696)
+
+* Add conditioning-aware vine structure selection via
+  `FitControlsVinecop::set_conditioning_set()` (also settable through
+  `FitControlsConfig::conditioning_set`): `Vinecop::select()` fits the
+  conditioning set's own optimal sub-vine and grows the remaining variables on
+  top of it, then places the conditioning set at the tail of the order (drawn
+  first) so it can be conditioned on with `simulate_conditional()`. The
+  conditioned variables' sub-structure is chosen by the usual Dissmann
+  selection (no degenerate fallback). Requires an MST `tree_algorithm` (#697)
+
+* Add `Vinecop::reorient()`, which relabels a fitted vine to an equivalent one
+  whose order tail equals a given set of variables (a value-preserving change:
+  `pdf`/`loglik` are invariant), so the model can be re-targeted for
+  conditioning without re-fitting (#697)
 * Speed up the bivariate copula evaluation engine: all internal evaluation
   leaves take `Eigen::Ref` (`tools_eigen::ConstMatRef`), removing an n x 2
   copy on every `pdf`/`hfunc`/`hinv`/`cdf` call; a new `log_pdf_raw` pathway

--- a/include/vinecopulib/misc/fit_controls.hpp
+++ b/include/vinecopulib/misc/fit_controls.hpp
@@ -94,6 +94,12 @@ struct FitControlsConfig
 
   //! A vector of random seeds for the random number generator
   optional::optional<std::vector<int>> seeds;
+
+  //! Conditioning set for conditioning-aware structure selection: 1-based
+  //! variable indices to place at the tail of the vine order (so they can be
+  //! conditioned on with `Vinecop::simulate_conditional()`). Default: empty
+  //! (unconditional selection).
+  optional::optional<std::vector<size_t>> conditioning_set;
 };
 
 }

--- a/include/vinecopulib/vinecop/class.hpp
+++ b/include/vinecopulib/vinecop/class.hpp
@@ -205,6 +205,8 @@ public:
     const size_t num_threads = 1,
     const std::vector<int>& seeds = std::vector<int>()) const;
 
+  void reorient(const std::vector<size_t>& conditioning_set);
+
   Eigen::MatrixXd rosenblatt(Eigen::MatrixXd u,
                              const size_t num_threads = 1,
                              bool randomize_discrete = true,
@@ -411,6 +413,8 @@ protected:
     const std::vector<std::vector<Bicop>>& pair_copulas) const;
   double calculate_mbicv_penalty(const size_t nobs, const double psi0) const;
   void finalize_fit(const tools_select::VinecopSelector& selector);
+  void check_conditioning_set(const std::vector<size_t>& conditioning_set,
+                              const FitControlsVinecop& controls) const;
   void check_weights_size(const Eigen::VectorXd& weights,
                           const Eigen::MatrixXd& data) const;
   void check_enough_data(const Eigen::MatrixXd& data) const;

--- a/include/vinecopulib/vinecop/fit_controls.hpp
+++ b/include/vinecopulib/vinecop/fit_controls.hpp
@@ -114,6 +114,11 @@ public:
   //! to use a non-reproducible seed).
   std::vector<int> get_seeds() const;
 
+  //! @return the conditioning set (1-based variable indices) placed at the
+  //! tail of the vine order during structure selection; empty for
+  //! unconditional selection.
+  std::vector<size_t> get_conditioning_set() const;
+
   boost::random::mt19937 get_rng() const;
 
   // Setters
@@ -146,6 +151,12 @@ public:
 
   void set_seeds(std::vector<int> seeds);
 
+  //! Sets the conditioning set for conditioning-aware structure selection.
+  //! @param conditioning_set 1-based variable indices to place at the tail of
+  //! the vine order (so they can be conditioned on with
+  //! `Vinecop::simulate_conditional()`); empty for unconditional selection.
+  void set_conditioning_set(std::vector<size_t> conditioning_set);
+
   // Misc
   std::string str() const;
 
@@ -163,11 +174,14 @@ private:
   bool select_families_ = true;
   std::string tree_algorithm_ = "mst_prim";
   std::vector<int> seeds_;
+  std::vector<size_t> conditioning_set_ = {};
   boost::random::mt19937 rng_;
 
   void check_tree_criterion(std::string tree_criterion);
 
   void check_threshold(double threshold);
+
+  void check_conditioning_set(const std::vector<size_t>& conditioning_set);
 };
 }
 

--- a/include/vinecopulib/vinecop/implementation/class.ipp
+++ b/include/vinecopulib/vinecop/implementation/class.ipp
@@ -335,6 +335,12 @@ Vinecop::select(const Eigen::MatrixXd& data, const FitControlsVinecop& controls)
       nobs_ = data.rows();
       return;
     }
+
+    auto conditioning_set = controls.get_conditioning_set();
+    if (!conditioning_set.empty()) {
+      check_conditioning_set(conditioning_set, controls);
+    }
+
     Eigen::MatrixXd u = collapse_data(data);
 
     tools_select::VinecopSelector selector(
@@ -345,9 +351,214 @@ Vinecop::select(const Eigen::MatrixXd& data, const FitControlsVinecop& controls)
       selector.select_all_trees(u);
     }
     finalize_fit(selector);
+
+    // Relabel the fitted vine (a value-preserving re-orientation, no re-fit) so
+    // the conditioning set becomes the tail of the order and can be conditioned
+    // on with simulate_conditional(). The constrained first tree makes this
+    // achievable.
+    if (!conditioning_set.empty()) {
+      reorient(conditioning_set);
+    }
   } else {
     fit(data, controls.get_fit_controls_bicop(), controls.get_num_threads());
   }
+}
+
+//! @brief Validates the conditioning set against the vine dimension and
+//! selection controls (called from `select()` where `d_` is known).
+inline void
+Vinecop::check_conditioning_set(const std::vector<size_t>& conditioning_set,
+                                const FitControlsVinecop& controls) const
+{
+  if (conditioning_set.size() >= d_) {
+    throw std::runtime_error(
+      "conditioning_set must contain at most d - 1 variables.");
+  }
+  for (auto v : conditioning_set) {
+    if ((v < 1) || (v > d_)) {
+      throw std::runtime_error(
+        "conditioning_set entries must be in 1, ..., d.");
+    }
+  }
+  auto algo = controls.get_tree_algorithm();
+  if ((algo != "mst_prim") && (algo != "mst_kruskal")) {
+    throw std::runtime_error(
+      "conditioning-aware selection requires an MST tree_algorithm "
+      "('mst_prim' or 'mst_kruskal').");
+  }
+  // v1: re-orientation operates on the full R-vine matrix, so structural
+  // truncation is not supported (thresholding, which keeps the structure full,
+  // is fine).
+  if (controls.get_select_trunc_lvl() || (controls.get_trunc_lvl() < d_ - 1)) {
+    throw std::runtime_error(
+      "conditioning-aware selection does not support truncation "
+      "(trunc_lvl / select_trunc_lvl) in this version.");
+  }
+}
+
+//! @brief Relabels the vine to an equivalent one whose order tail equals
+//! `conditioning_set`.
+//!
+//! @details This is a value-preserving re-orientation (a port of VineCopulas'
+//! `samplingmatrix`): the fitted model is unchanged (`pdf`/`loglik` invariant),
+//! only its sampling-order representation changes so that the variables in
+//! `conditioning_set` are drawn first and can be conditioned on with
+//! `simulate_conditional()`. It chooses, per tree, which conditioned variable
+//! sits on the matrix diagonal, and flips each pair copula whose stored
+//! orientation no longer matches its new position. Throws if the current
+//! structure admits no sampling order ending in `conditioning_set` (fit with
+//! `FitControlsVinecop::set_conditioning_set()` to guarantee one exists).
+//!
+//! @param conditioning_set 1-based variable indices to place at the tail of
+//! `get_order()`.
+inline void
+Vinecop::reorient(const std::vector<size_t>& conditioning_set)
+{
+  size_t k = conditioning_set.size();
+
+  // ---- validation ----
+  if ((k == 0) || (k >= d_)) {
+    throw std::runtime_error(
+      "conditioning_set must contain between 1 and d - 1 variables.");
+  }
+  auto sorted = conditioning_set;
+  std::sort(sorted.begin(), sorted.end());
+  if (std::adjacent_find(sorted.begin(), sorted.end()) != sorted.end()) {
+    throw std::runtime_error("conditioning_set must not contain duplicates.");
+  }
+  if ((sorted.front() < 1) || (sorted.back() > d_)) {
+    throw std::runtime_error("conditioning_set entries must be in 1, ..., d.");
+  }
+  if (rvine_structure_.get_trunc_lvl() != d_ - 1) {
+    throw std::runtime_error(
+      "reorient() requires a non-truncated vine (trunc_lvl == d - 1).");
+  }
+
+  std::vector<char> in_b(d_ + 1, 0);
+  for (auto v : conditioning_set)
+    in_b[v] = 1;
+
+  auto tail_is_b = [&](const std::vector<size_t>& order) {
+    for (size_t i = d_ - k; i < d_; ++i)
+      if (!in_b[order[i]])
+        return false;
+    return true;
+  };
+
+  // early no-op: the conditioning set is already the tail of the order
+  if (tail_is_b(rvine_structure_.get_order())) {
+    return;
+  }
+
+  // ---- decompose the current matrix into an edge list ----
+  auto mat = get_matrix();
+  struct Edge
+  {
+    std::vector<size_t> cond;    // the two conditioned variables
+    std::vector<size_t> all_idx; // sorted (conditioned + conditioning)
+    Bicop bicop;
+    size_t diag_orig; // variable currently on this edge's diagonal (= arg1)
+    size_t tree;
+    bool used;
+  };
+  std::vector<Edge> edges;
+  for (size_t t = 0; t < d_ - 1; ++t) {
+    for (size_t e = 0; e < d_ - 1 - t; ++e) {
+      Edge ed;
+      size_t diag = mat(d_ - 1 - e, e);
+      ed.cond = { diag, mat(t, e) };
+      ed.all_idx = ed.cond;
+      for (size_t r = 0; r < t; ++r)
+        ed.all_idx.push_back(mat(r, e));
+      std::sort(ed.all_idx.begin(), ed.all_idx.end());
+      ed.bicop = pair_copulas_[t][e];
+      ed.diag_orig = diag;
+      ed.tree = t;
+      ed.used = false;
+      edges.push_back(ed);
+    }
+  }
+  auto conditioning_of = [](const Edge& ed) {
+    std::vector<size_t> ning;
+    for (auto v : ed.all_idx)
+      if ((v != ed.cond[0]) && (v != ed.cond[1]))
+        ning.push_back(v);
+    return ning;
+  };
+
+  // ---- rebuild the matrix column by column (direct O(d^2), no enumeration).
+  //      At each column choose which endpoint of the tree's top edge goes on
+  //      the diagonal: a non-conditioning variable for the leading columns
+  //      (head of the order), a conditioning variable for the trailing columns
+  //      + root (tail). Because the conditioning set forms a self-contained
+  //      sub-vine (its edges are the low trees; every other edge involves a
+  //      non-conditioning variable), the required endpoint is always available;
+  //      the final tail check guards against any structure that is not a block.
+  Eigen::Matrix<size_t, Eigen::Dynamic, Eigen::Dynamic> mnew(d_, d_);
+  mnew.fill(0);
+  auto pcs = make_pair_copula_store(d_, d_ - 1);
+  bool ok = true;
+  for (size_t e = 0; (e < d_ - 1) && ok; ++e) {
+    size_t t_top = d_ - 2 - e;
+    Edge* top = nullptr;
+    for (auto& ed : edges)
+      if (!ed.used && (ed.tree == t_top)) {
+        top = &ed;
+        break;
+      }
+    if (top == nullptr) {
+      ok = false;
+      break;
+    }
+    size_t c0 = top->cond[0], c1 = top->cond[1];
+    bool want_cond = (e >= d_ - k); // tail columns take the conditioning set
+    size_t s = want_cond ? (in_b[c0] ? c0 : c1) : (in_b[c0] ? c1 : c0);
+    size_t partner = (s == c0) ? c1 : c0;
+
+    mnew(d_ - 1 - e, e) = s;
+    mnew(t_top, e) = partner;
+    pcs[t_top][e] = top->bicop;
+    if (top->diag_orig != s)
+      pcs[t_top][e].flip();
+    top->used = true;
+
+    auto ning = conditioning_of(*top);
+    for (size_t row = t_top; row-- > 0;) {
+      std::vector<size_t> want = ning;
+      want.push_back(s);
+      std::sort(want.begin(), want.end());
+      Edge* nxt = nullptr;
+      for (auto& ed : edges)
+        if (!ed.used && (ed.tree == row) && (ed.all_idx == want)) {
+          nxt = &ed;
+          break;
+        }
+      if (nxt == nullptr) {
+        ok = false;
+        break;
+      }
+      mnew(row, e) = (nxt->cond[0] == s) ? nxt->cond[1] : nxt->cond[0];
+      pcs[row][e] = nxt->bicop;
+      if (nxt->diag_orig != s)
+        pcs[row][e].flip();
+      nxt->used = true;
+      ning = conditioning_of(*nxt);
+    }
+  }
+  mnew(0, d_ - 1) = mnew(0, d_ - 2); // root (last remaining variable)
+
+  // ---- validate: the tail must equal B, then the full R-vine check ----
+  std::vector<size_t> new_order(d_);
+  for (size_t i = 0; i < d_; ++i)
+    new_order[i] = mnew(d_ - 1 - i, i);
+  if (!ok || !tail_is_b(new_order)) {
+    throw std::runtime_error(
+      "conditioning set is not admissible as a sampling-order tail of this "
+      "vine; fit with FitControlsVinecop::set_conditioning_set() or condition "
+      "on an admissible set.");
+  }
+  rvine_structure_ = RVineStructure(mnew); // check = true (proximity etc.)
+  pair_copulas_ = pcs;
 }
 
 //! @brief Fits the parameters of a pre-specified vine copula model.

--- a/include/vinecopulib/vinecop/implementation/fit_controls.ipp
+++ b/include/vinecopulib/vinecop/implementation/fit_controls.ipp
@@ -209,6 +209,9 @@ inline FitControlsVinecop::FitControlsVinecop(const FitControlsConfig& config)
   if (optional::has_value(config.seeds)) {
     set_seeds(optional::value(config.seeds));
   }
+  if (optional::has_value(config.conditioning_set)) {
+    set_conditioning_set(optional::value(config.conditioning_set));
+  }
 }
 
 //! @name Sanity checks
@@ -229,6 +232,26 @@ FitControlsVinecop::check_threshold(double threshold)
 {
   if (threshold < 0 || threshold > 1) {
     throw std::runtime_error("threshold should be in [0,1]");
+  }
+}
+
+inline void
+FitControlsVinecop::check_conditioning_set(
+  const std::vector<size_t>& conditioning_set)
+{
+  // Dimension-free checks only (the vine dimension d is not known here; the
+  // upper bounds max(set) <= d and |set| <= d - 1 are checked in
+  // Vinecop::select()).
+  for (auto v : conditioning_set) {
+    if (v < 1) {
+      throw std::runtime_error(
+        "conditioning_set entries must be >= 1 (1-based variable indices)");
+    }
+  }
+  auto sorted = conditioning_set;
+  std::sort(sorted.begin(), sorted.end());
+  if (std::adjacent_find(sorted.begin(), sorted.end()) != sorted.end()) {
+    throw std::runtime_error("conditioning_set must not contain duplicates");
   }
 }
 //! @}
@@ -358,6 +381,21 @@ FitControlsVinecop::get_seeds() const
   return seeds_;
 }
 
+//! @brief Gets the conditioning set for conditioning-aware selection.
+inline std::vector<size_t>
+FitControlsVinecop::get_conditioning_set() const
+{
+  return conditioning_set_;
+}
+
+//! @brief Sets the conditioning set for conditioning-aware selection.
+inline void
+FitControlsVinecop::set_conditioning_set(std::vector<size_t> conditioning_set)
+{
+  check_conditioning_set(conditioning_set);
+  conditioning_set_ = conditioning_set;
+}
+
 //! @brief Gets the random number generator.
 inline boost::random::mt19937
 FitControlsVinecop::get_rng() const
@@ -472,6 +510,14 @@ FitControlsVinecop::str() const
   controls_str << "Number of threads: "
                << (get_num_threads() == 0 ? 1 : get_num_threads()) << std::endl;
   controls_str << "MST algorithm: " << get_tree_algorithm() << std::endl;
+  controls_str << "Conditioning set: ";
+  if (get_conditioning_set().empty()) {
+    controls_str << "none (default)";
+  } else {
+    for (auto v : get_conditioning_set())
+      controls_str << v << " ";
+  }
+  controls_str << std::endl;
   return controls_str.str().c_str();
 }
 

--- a/include/vinecopulib/vinecop/implementation/tools_select.ipp
+++ b/include/vinecopulib/vinecop/implementation/tools_select.ipp
@@ -117,6 +117,16 @@ inline VinecopSelector::VinecopSelector(const Eigen::MatrixXd& data,
   , psi0_(controls.get_psi0())
 {
   vine_struct_ = RVineStructure(tools_stl::seq_int(1, d_), 1, false);
+
+  // conditioning-aware selection bookkeeping (empty set -> ordinary selection)
+  auto cond = controls.get_conditioning_set();
+  n_cond_ = cond.size();
+  in_cond_ = std::vector<char>(d_, 0);
+  for (auto v : cond) {
+    if ((v >= 1) && (v <= d_)) {
+      in_cond_[v - 1] = 1;
+    }
+  }
 }
 
 inline VinecopSelector::VinecopSelector(const Eigen::MatrixXd& data,
@@ -465,6 +475,33 @@ VinecopSelector::add_allowed_edges_proximity(
     double crit =
       calculate_criterion(pc_data, tree_criterion, weights, criterion_fun);
     double w = 1.0 - static_cast<double>(crit >= threshold) * crit;
+
+    // Conditioning-aware selection: penalize edges that involve any
+    // non-conditioning variable. Since base weights lie in [0, 1], adding `d_`
+    // keeps all weights non-negative (required by Boost's Prim) while making
+    // every all-conditioning edge strictly cheaper. The (minimum) spanning tree
+    // then selects the conditioning set's own optimal sub-vine at every tree
+    // before attaching any other variable, so every remaining edge involves at
+    // least one non-conditioning variable. This makes the conditioning set a
+    // self-contained block that `Vinecop::reorient()` can place at the tail of
+    // the sampling order. Only `w` (the tree weight) is shifted; `crit` (used
+    // for thresholding/fit reuse) is left unchanged.
+    if (n_cond_ > 0) {
+      bool all_cond = true;
+      for (auto var : vine_tree[v0].all_indices)
+        if (!in_cond_[var]) {
+          all_cond = false;
+          break;
+        }
+      if (all_cond)
+        for (auto var : vine_tree[v1].all_indices)
+          if (!in_cond_[var]) {
+            all_cond = false;
+            break;
+          }
+      if (!all_cond)
+        w += static_cast<double>(d_);
+    }
 
     {
       std::lock_guard<std::mutex> lk(m);

--- a/include/vinecopulib/vinecop/tools_select.hpp
+++ b/include/vinecopulib/vinecop/tools_select.hpp
@@ -190,6 +190,12 @@ protected:
   size_t n_;
   size_t d_;
   bool structure_unknown_{ true };
+  // conditioning-aware selection: in_cond_[v] == 1 iff variable v (0-based) is
+  // in the conditioning set; n_cond_ = |conditioning set|. n_cond_ == 0 means
+  // ordinary (unconditional) selection and every conditioning-specific branch
+  // below is skipped, leaving the default path byte-for-byte unchanged.
+  std::vector<char> in_cond_;
+  size_t n_cond_{ 0 };
   std::vector<std::string> var_types_;
   FitControlsVinecop controls_;
   tools_thread::ThreadPool pool_;

--- a/test/src_test/include/test_vinecop_class.hpp
+++ b/test/src_test/include/test_vinecop_class.hpp
@@ -641,6 +641,166 @@ TEST_F(VinecopTest, simulate_conditional_multi_discrete)
   EXPECT_NEAR(cond_mean, sum / cnt, 0.03);
 }
 
+TEST_F(VinecopTest, conditional_select_places_conditioning_set_at_tail)
+{
+  size_t d = 6;
+  auto data = make_clayton_dvine(d, 3.0).simulate(2000, false, 1, { 1 });
+  auto fam = std::vector<BicopFamily>{ BicopFamily::gaussian,
+                                       BicopFamily::clayton,
+                                       BicopFamily::gumbel,
+                                       BicopFamily::frank };
+  std::vector<std::vector<size_t>> sets{ { 3 }, { 2, 5 }, { 1, 4, 6 } };
+  for (auto B : sets) {
+    FitControlsVinecop c;
+    c.set_family_set(fam);
+    c.set_conditioning_set(B);
+    Vinecop vc(d);
+    vc.select(data, c);
+
+    // the conditioning set must be the tail of the order (drawn first)
+    auto order = vc.get_order();
+    std::vector<size_t> tail(order.end() - static_cast<ptrdiff_t>(B.size()),
+                             order.end());
+    std::sort(tail.begin(), tail.end());
+    auto b_sorted = B;
+    std::sort(b_sorted.begin(), b_sorted.end());
+    EXPECT_EQ(tail, b_sorted);
+    // and the produced structure is a valid R-vine (checked on construction)
+    EXPECT_NO_THROW(RVineStructure(vc.get_matrix()));
+  }
+}
+
+TEST_F(VinecopTest, conditional_select_empty_equals_plain)
+{
+  size_t d = 6;
+  auto data = make_clayton_dvine(d, 3.0).simulate(2000, false, 1, { 1 });
+  auto fam =
+    std::vector<BicopFamily>{ BicopFamily::gaussian, BicopFamily::clayton };
+  FitControlsVinecop c;
+  c.set_family_set(fam);
+  Vinecop a(d);
+  a.select(data, c);
+
+  FitControlsVinecop c2;
+  c2.set_family_set(fam);
+  c2.set_conditioning_set({}); // empty -> ordinary selection
+  Vinecop b(d);
+  b.select(data, c2);
+
+  EXPECT_TRUE(a.get_matrix() == b.get_matrix());
+  EXPECT_NEAR(a.get_loglik(), b.get_loglik(), 1e-10);
+}
+
+TEST_F(VinecopTest, conditional_select_then_simulate_conditional)
+{
+  size_t d = 5;
+  auto data = make_clayton_dvine(d, 3.0).simulate(2000, false, 1, { 3 });
+  FitControlsVinecop c;
+  c.set_family_set(
+    { BicopFamily::gaussian, BicopFamily::clayton, BicopFamily::frank });
+  std::vector<size_t> B{ 2, 4 };
+  c.set_conditioning_set(B);
+  Vinecop vc(d);
+  vc.select(data, c);
+
+  // condition on the tail (== B); the tail columns must be reproduced exactly
+  auto order = vc.get_order();
+  Eigen::MatrixXd uc = Eigen::MatrixXd::Constant(400, B.size(), 0.4);
+  auto U = vc.simulate_conditional(uc, false, 1, { 9 });
+  for (size_t i = 0; i < B.size(); ++i) {
+    size_t col = order[d - B.size() + i] - 1;
+    EXPECT_TRUE(
+      all_close(U.col(col), Eigen::VectorXd::Constant(400, 0.4), 1e-9, 1e-9));
+  }
+}
+
+TEST_F(VinecopTest, reorient_preserves_model)
+{
+  size_t d = 6;
+  // rotated Clayton D-vine (asymmetric + rotations) so the flip logic in
+  // reorient() is genuinely exercised
+  auto pcs = Vinecop::make_pair_copula_store(d);
+  auto par = Eigen::VectorXd::Constant(1, 3.0);
+  for (size_t t = 0; t < d - 1; ++t)
+    for (auto& pc : pcs[t])
+      pc = Bicop(BicopFamily::clayton, (t % 2 == 0) ? 90 : 270, par);
+  Vinecop model(DVineStructure(std::vector<size_t>{ 1, 2, 3, 4, 5, 6 }), pcs);
+  auto data = model.simulate(500, false, 1, { 7 });
+
+  auto fam = std::vector<BicopFamily>{ BicopFamily::gaussian,
+                                       BicopFamily::clayton,
+                                       BicopFamily::gumbel };
+  Vinecop vc(d);
+  {
+    FitControlsVinecop c;
+    c.set_family_set(fam);
+    vc.select(data, c);
+  }
+  auto pdf0 = vc.pdf(data);
+
+  size_t feasible = 0;
+  std::vector<std::vector<size_t>> candidates{
+    { 1 },    { 2 },    { 3 },    { 4 },       { 5 },      { 6 },
+    { 1, 2 }, { 2, 5 }, { 3, 6 }, { 1, 4, 6 }, { 2, 3, 5 }
+  };
+  for (auto B : candidates) {
+    Vinecop vr = vc;
+    try {
+      vr.reorient(B);
+    } catch (const std::exception&) {
+      continue; // infeasible for this structure -> allowed
+    }
+    ++feasible;
+    // reorient is a pure relabeling: the density is unchanged (up to fp)
+    EXPECT_TRUE(all_close(vr.pdf(data), pdf0, 1e-6, 1e-6));
+    // the conditioning set is now the tail of the order
+    auto o = vr.get_order();
+    std::vector<size_t> tail(o.end() - static_cast<ptrdiff_t>(B.size()),
+                             o.end());
+    std::sort(tail.begin(), tail.end());
+    auto bs = B;
+    std::sort(bs.begin(), bs.end());
+    EXPECT_EQ(tail, bs);
+    EXPECT_NO_THROW(RVineStructure(vr.get_matrix()));
+  }
+  EXPECT_GT(feasible, 0u); // at least some sets are admissible tails
+
+  // validation throws
+  EXPECT_ANY_THROW(vc.reorient({}));                   // empty
+  EXPECT_ANY_THROW(vc.reorient({ 1, 2, 3, 4, 5, 6 })); // |B| == d
+  EXPECT_ANY_THROW(vc.reorient({ 7 }));                // out of range
+  EXPECT_ANY_THROW(vc.reorient({ 2, 2 }));             // duplicate
+}
+
+TEST_F(VinecopTest, conditional_select_throws)
+{
+  size_t d = 5;
+  auto data = make_clayton_dvine(d, 2.0).simulate(500, false, 1, { 1 });
+  {
+    // index out of range
+    FitControlsVinecop c;
+    c.set_conditioning_set({ 6 });
+    Vinecop vc(d);
+    EXPECT_ANY_THROW(vc.select(data, c));
+  }
+  {
+    // |B| == d (no free variable)
+    FitControlsVinecop c;
+    c.set_conditioning_set({ 1, 2, 3, 4, 5 });
+    Vinecop vc(d);
+    EXPECT_ANY_THROW(vc.select(data, c));
+  }
+  {
+    // random tree_algorithm is incompatible with conditioning-aware selection
+    FitControlsVinecop c;
+    c.set_conditioning_set({ 2 });
+    c.set_tree_algorithm("random_weighted");
+    c.set_seeds({ 1 });
+    Vinecop vc(d);
+    EXPECT_ANY_THROW(vc.select(data, c));
+  }
+}
+
 TEST_F(VinecopTest, scores_stepwise)
 {
   auto pair_copulas = Vinecop::make_pair_copula_store(7, 3);

--- a/test/src_test/include/test_vinecop_sanity_checks.hpp
+++ b/test/src_test/include/test_vinecop_sanity_checks.hpp
@@ -73,6 +73,7 @@ TEST(vinecop_sanity_checks, fit_controls_config_works)
   controls.set_tree_algorithm("mst_kruskal");
   std::vector<int> seeds = { 1, 2, 3, 4, 5 };
   controls.set_seeds(seeds);
+  controls.set_conditioning_set({ 2, 4 });
 
   // Create a config object from the controls
   FitControlsConfig config;
@@ -86,6 +87,7 @@ TEST(vinecop_sanity_checks, fit_controls_config_works)
   config.num_threads = controls.get_num_threads();
   config.tree_algorithm = controls.get_tree_algorithm();
   config.seeds = controls.get_seeds();
+  config.conditioning_set = controls.get_conditioning_set();
 
   // Create and test new controls from the config object
   FitControlsVinecop controls2(config);
@@ -99,6 +101,7 @@ TEST(vinecop_sanity_checks, fit_controls_config_works)
   EXPECT_EQ(controls.get_num_threads(), controls2.get_num_threads());
   EXPECT_EQ(controls.get_tree_algorithm(), controls2.get_tree_algorithm());
   EXPECT_EQ(controls.get_seeds(), controls2.get_seeds());
+  EXPECT_EQ(controls.get_conditioning_set(), controls2.get_conditioning_set());
 }
 
 TEST(vinecop_sanity_checks, controls_check)
@@ -107,5 +110,7 @@ TEST(vinecop_sanity_checks, controls_check)
   EXPECT_ANY_THROW(controls.set_tree_criterion("foo"));
   EXPECT_ANY_THROW(controls.set_threshold(-1.0));
   EXPECT_ANY_THROW(controls.set_threshold(2.0));
+  EXPECT_ANY_THROW(controls.set_conditioning_set({ 0 }));
+  EXPECT_ANY_THROW(controls.set_conditioning_set({ 2, 2 }));
 }
 }


### PR DESCRIPTION
## What

Conditioning-aware vine structure selection — the companion to #696 (conditional sampling), ported from the Python *VineCopulas* library and adapted to vinecopulib's matrix convention.

- `FitControlsVinecop::set_conditioning_set(B)` (also via `FitControlsConfig::conditioning_set`): `Vinecop::select()` produces a vine whose **`get_order()` tail equals B**, so B can be conditioned on with `simulate_conditional()`.
- New public **`Vinecop::reorient(B)`**: relabels a fitted vine to put B at the order tail **without re-fitting** — a value-preserving change (`pdf`/`loglik` invariant).

> **Stacked PR.** Base is `refactor/vinecop-tools-select` (#695); this branch also merges #696 so the end-to-end test can exercise `select → simulate_conditional`. PR2's own changes are the top commit. Merge after #695 and #696.

## Algorithm

"Grow B's sub-vine, then grow the rest on top", in two clean pieces:

1. **Selection (a one-line weight bonus).** In `add_allowed_edges_proximity`, an edge whose entire variable set lies in B is penalized-relative so the maximum spanning tree selects **B's own optimal Dissmann sub-vine (all |B|−1 trees)** before attaching any other variable. Every remaining edge then involves a non-conditioning variable ⇒ B is a self-contained block. All four tree criteria/`mst_*` algorithms drive the rest of the structure. (Weights stay ≥0 for Boost's Prim; only the tree weight is shifted — `crit` is untouched.)

2. **`reorient` (direct O(d²)).** A column-by-column rebuild of the R-vine matrix that places non-conditioning variables in the head columns and B in the tail, flipping each pair copula when its stored orientation no longer matches its new diagonal. Because B is a block, the required endpoint is always available (no enumeration, no fallback). Validated with `RVineStructure(check=true)`; a final tail check guards correctness.

This replaces the earlier (flawed) constrained-tree + biased-peeling + **D-vine fallback** approach — that fell back to a D-vine ~81% of the time. There is now no degenerate fallback: B is placed at the tail by construction.

## Verification

- **Relabeling invariance** (`reorient_preserves_model`): `pdf` unchanged (to fp) on rotated/asymmetric copulas, tail == B, valid R-vine.
- **Parallel stress**, 2820 configs (d=4..8, all |B|∈1..3, `mst_prim`/`mst_kruskal`): **0 throws, 0 tail≠B, 0 pdf/tail failures** (10.7 s on 64 cores).
- **Scales**: conditioning-aware select verified to **d=30** (select 1.5 s; `reorient` is O(d²), not the old 2^(d-1) enumeration).
- **End-to-end**: `select(set_conditioning_set(B))` → `simulate_conditional` reproduces the conditioning columns.
- **Default path byte-identical** to the pre-refactor baseline (golden harness, 28 configs, dump + trace) with an empty conditioning set.
- Debug + ASan/UBSan and **precompiled release** suites pass (incl. VineCopula R-parity `select_finds_right_structure_*`); `clang-format-14` clean.

## Scope / follow-ups

Requires an MST `tree_algorithm` and a non-truncated fit in this version; `random_*` and truncated re-orientation are follow-ups (the weight bonus makes negative inverse-weights for the random spanning tree; truncated `reorient` needs completing the array to independence first). Additive API — no breaks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
