### PR TITLE
feat(bicop,vinecop): scores/gradient/Hessian on Bicop and parameter-vectorized scores/Hessian

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -9,19 +9,21 @@
   aggregations of `logpdf_deriv`/`logpdf_deriv2`, mirroring the `Vinecop`
   asymptotic API. As for the derivatives, they require parametric families and
   continuous variable types. Each also has a per-row-parameter overload that
-  evaluates at a different parameter set per row of `u` (#697)
-* Add per-observation-parameter overloads of `Vinecop::scores`, `scores_full`,
-  `gradient`, `hessian`, `hessian_full`, and `scores_cov`, taking an
-  n x npars matrix `parameters` (one full-vine parameter vector per
-  observation, columns in the `(tree, edge, parameter)` order of `scores()`).
-  Row i is evaluated as if the vine carried that row's parameters, enabling
-  scores/Hessians for conditional/covariate vine models where the pair-copula
-  parameters vary by observation. Continuous, all-parametric models only
-  (discrete variables and nonparametric pair copulas are rejected). The
-  default fixed-parameter path is unchanged: the shared forward walk
-  (`build_deriv_cache`) simply switches each edge's evaluations to the
-  matching per-row `Bicop` overloads when a parameter matrix is supplied, so
-  models that do not need this feature pay nothing (#697)
+  evaluates at a different parameter set per row of `u` (#699)
+* Add per-observation-parameter overloads to `Vinecop`: `pdf`, `pdf_full`,
+  `loglik`, `scores`, `scores_full`, `gradient`, `hessian`, `hessian_full`, and
+  `scores_cov` all take an n x npars matrix `parameters` (one full-vine
+  parameter vector per observation, columns in the `(tree, edge, parameter)`
+  order of `scores()`). Row i is evaluated as if the vine carried that row's
+  parameters, enabling the density, log-likelihood, scores, and Hessians for
+  conditional/covariate vine models where the pair-copula parameters vary by
+  observation. Continuous, all-parametric models only (discrete variables and
+  nonparametric pair copulas are rejected). The default fixed-parameter path is
+  unchanged: the shared forward walks (`build_deriv_cache` and `pdf_full`)
+  switch each edge's evaluations to the matching per-row `Bicop` overloads only
+  when a parameter matrix is supplied, so models that do not need this feature
+  pay nothing. Also give `Bicop::loglik(u, parameters)` a default
+  `num_threads = 1`, consistent with the other per-row overloads (#699)
 * Add `Vinecop::simulate_conditional()` for sampling from the conditional
   distribution given fixed values of a subset of variables. The conditioning
   variables are the last `k` of the vine order `get_order()` (the columns of

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,26 @@
 
 ### NEW FEATURES
 
+* Add scores, gradient, and Hessian of the log-likelihood to `Bicop`:
+  `scores` (the n x p per-observation score matrix), `gradient` (its
+  observation-average), `hessian` and `hessian_full` (the averaged and
+  per-observation p x p Hessians), `scores_cov`, and `scores_full` — thin
+  aggregations of `logpdf_deriv`/`logpdf_deriv2`, mirroring the `Vinecop`
+  asymptotic API. As for the derivatives, they require parametric families and
+  continuous variable types. Each also has a per-row-parameter overload that
+  evaluates at a different parameter set per row of `u` (#697)
+* Add per-observation-parameter overloads of `Vinecop::scores`, `scores_full`,
+  `gradient`, `hessian`, `hessian_full`, and `scores_cov`, taking an
+  n x npars matrix `parameters` (one full-vine parameter vector per
+  observation, columns in the `(tree, edge, parameter)` order of `scores()`).
+  Row i is evaluated as if the vine carried that row's parameters, enabling
+  scores/Hessians for conditional/covariate vine models where the pair-copula
+  parameters vary by observation. Continuous, all-parametric models only
+  (discrete variables and nonparametric pair copulas are rejected). The
+  default fixed-parameter path is unchanged: the shared forward walk
+  (`build_deriv_cache`) simply switches each edge's evaluations to the
+  matching per-row `Bicop` overloads when a parameter matrix is supplied, so
+  models that do not need this feature pay nothing (#697)
 * Add `Vinecop::simulate_conditional()` for sampling from the conditional
   distribution given fixed values of a subset of variables. The conditioning
   variables are the last `k` of the vine order `get_order()` (the columns of

--- a/include/vinecopulib/bicop/class.hpp
+++ b/include/vinecopulib/bicop/class.hpp
@@ -169,7 +169,7 @@ public:
 
   double loglik(const Eigen::MatrixXd& u,
                 const Eigen::MatrixXd& parameters,
-                const size_t num_threads) const;
+                const size_t num_threads = 1) const;
 
   // Derivatives of the density and h-functions w.r.t. parameters/arguments
   Eigen::VectorXd pdf_deriv(const Eigen::MatrixXd& u,

--- a/include/vinecopulib/bicop/class.hpp
+++ b/include/vinecopulib/bicop/class.hpp
@@ -237,6 +237,55 @@ public:
                                 const Eigen::MatrixXd& parameters,
                                 const size_t num_threads = 1) const;
 
+  // Scores, gradient, and Hessian of the log-likelihood (parametric,
+  // continuous families only)
+
+  //! @brief Bundles the per-observation scores.
+  //!
+  //! @details Mirrors `Vinecop::ScoresResult`; a single pair copula has no
+  //! cascade caches to expose, so only the score matrix is carried.
+  struct ScoresResult
+  {
+    Eigen::MatrixXd scores;
+  };
+
+  Eigen::MatrixXd scores(const Eigen::MatrixXd& u) const;
+
+  Eigen::VectorXd gradient(const Eigen::MatrixXd& u) const;
+
+  Eigen::MatrixXd hessian(const Eigen::MatrixXd& u) const;
+
+  std::vector<Eigen::MatrixXd> hessian_full(const Eigen::MatrixXd& u) const;
+
+  Eigen::MatrixXd scores_cov(const Eigen::MatrixXd& u) const;
+
+  ScoresResult scores_full(const Eigen::MatrixXd& u) const;
+
+  // Scores, gradient, and Hessian with per-row parameters
+  Eigen::MatrixXd scores(const Eigen::MatrixXd& u,
+                         const Eigen::MatrixXd& parameters,
+                         const size_t num_threads = 1) const;
+
+  Eigen::VectorXd gradient(const Eigen::MatrixXd& u,
+                           const Eigen::MatrixXd& parameters,
+                           const size_t num_threads = 1) const;
+
+  Eigen::MatrixXd hessian(const Eigen::MatrixXd& u,
+                          const Eigen::MatrixXd& parameters,
+                          const size_t num_threads = 1) const;
+
+  std::vector<Eigen::MatrixXd> hessian_full(const Eigen::MatrixXd& u,
+                                            const Eigen::MatrixXd& parameters,
+                                            const size_t num_threads = 1) const;
+
+  Eigen::MatrixXd scores_cov(const Eigen::MatrixXd& u,
+                             const Eigen::MatrixXd& parameters,
+                             const size_t num_threads = 1) const;
+
+  ScoresResult scores_full(const Eigen::MatrixXd& u,
+                           const Eigen::MatrixXd& parameters,
+                           const size_t num_threads = 1) const;
+
   Eigen::MatrixXd simulate(
     const size_t& n,
     const bool qrng = false,

--- a/include/vinecopulib/bicop/implementation/class.ipp
+++ b/include/vinecopulib/bicop/implementation/class.ipp
@@ -1060,6 +1060,231 @@ Bicop::logpdf_deriv2(const Eigen::MatrixXd& u,
 }
 //! @}
 
+//! @name Scores, gradient, and Hessian of the log-likelihood
+//!
+//! @details These methods aggregate the log-density parameter derivatives into
+//! the score (the gradient of each observation's log-density contribution), its
+//! observation-average (`gradient`), and the Hessian. They are thin wrappers
+//! around `logpdf_deriv()` / `logpdf_deriv2()`: with `p = get_parameters()`
+//! parameters, the score of observation `i` w.r.t. parameter `k` is
+//! \f$ \partial \log c(u_i; \theta) / \partial \theta_k \f$, and the (per-obs
+//! and averaged) Hessians collect the second log-density derivatives. Like the
+//! derivatives they build on, they require parametric families and continuous
+//! variable types; nonparametric or discrete models throw.
+//!
+//! The per-row-parameter overloads evaluate at a different parameter set per
+//! row of `u` (see the corresponding `pdf()` overload for the layout and
+//! validation rules).
+//!
+//! @param u An \f$ n \times 2 \f$ matrix of observations contained in
+//!   \f$ (0, 1)^2 \f$.
+//! @{
+
+//! @brief Evaluates the per-observation scores.
+//!
+//! @return An \f$ n \times p \f$ matrix whose column `k` is
+//! \f$ \partial \log c / \partial \theta_{k+1} \f$.
+inline Eigen::MatrixXd
+Bicop::scores(const Eigen::MatrixXd& u) const
+{
+  check_data(u);
+  check_deriv_preconditions();
+  const Eigen::Index p = static_cast<Eigen::Index>(deriv_npars());
+  Eigen::MatrixXd s(u.rows(), p);
+  for (Eigen::Index k = 0; k < p; ++k) {
+    s.col(k) = logpdf_deriv(u, "par" + std::to_string(k + 1));
+  }
+  return s;
+}
+
+//! @brief Evaluates the gradient of the average log-likelihood.
+//!
+//! @return The observation-average of `scores()`, a vector of length `p`.
+inline Eigen::VectorXd
+Bicop::gradient(const Eigen::MatrixXd& u) const
+{
+  return scores(u).colwise().mean().transpose();
+}
+
+//! @brief Evaluates the Hessian of the average log-likelihood.
+//!
+//! @return A symmetric \f$ p \times p \f$ matrix whose entry \f$ (a, b) \f$ is
+//! the observation-average of
+//! \f$ \partial^2 \log c / \partial \theta_{a+1} \partial \theta_{b+1} \f$.
+inline Eigen::MatrixXd
+Bicop::hessian(const Eigen::MatrixXd& u) const
+{
+  check_data(u);
+  check_deriv_preconditions();
+  const Eigen::Index p = static_cast<Eigen::Index>(deriv_npars());
+  Eigen::MatrixXd h(p, p);
+  for (Eigen::Index a = 0; a < p; ++a) {
+    for (Eigen::Index b = a; b < p; ++b) {
+      h(a, b) =
+        logpdf_deriv2(
+          u, "par" + std::to_string(a + 1) + "par" + std::to_string(b + 1))
+          .mean();
+      h(b, a) = h(a, b);
+    }
+  }
+  return h;
+}
+
+//! @brief Evaluates the per-observation Hessians.
+//!
+//! @return A vector of `n` symmetric \f$ p \times p \f$ matrices; entry `i`'s
+//! \f$ (a, b) \f$ element is
+//! \f$ \partial^2 \log c(u_i; \theta) / \partial \theta_{a+1} \partial
+//! \theta_{b+1} \f$.
+inline std::vector<Eigen::MatrixXd>
+Bicop::hessian_full(const Eigen::MatrixXd& u) const
+{
+  check_data(u);
+  check_deriv_preconditions();
+  const Eigen::Index n = u.rows();
+  const Eigen::Index p = static_cast<Eigen::Index>(deriv_npars());
+  std::vector<Eigen::MatrixXd> hess(static_cast<size_t>(n),
+                                    Eigen::MatrixXd(p, p));
+  for (Eigen::Index a = 0; a < p; ++a) {
+    for (Eigen::Index b = a; b < p; ++b) {
+      Eigen::VectorXd d = logpdf_deriv2(
+        u, "par" + std::to_string(a + 1) + "par" + std::to_string(b + 1));
+      for (Eigen::Index i = 0; i < n; ++i) {
+        hess[static_cast<size_t>(i)](a, b) = d(i);
+        hess[static_cast<size_t>(i)](b, a) = d(i);
+      }
+    }
+  }
+  return hess;
+}
+
+//! @brief Computes the covariance matrix of the scores.
+//!
+//! @return The mean-centered, divided-by-`n` covariance of `scores()`, a
+//! \f$ p \times p \f$ matrix.
+inline Eigen::MatrixXd
+Bicop::scores_cov(const Eigen::MatrixXd& u) const
+{
+  Eigen::MatrixXd s = scores(u);
+  // materialize the centered scores; a lazy expression would be evaluated
+  // twice by the product below
+  Eigen::MatrixXd sc = s.rowwise() - s.colwise().mean();
+  return (sc.adjoint() * sc) / static_cast<double>(s.rows());
+}
+
+//! @brief Evaluates the scores, bundled in a `ScoresResult`.
+//!
+//! @details Provided for parity with `Vinecop::scores_full()`; a single pair
+//! copula has no cascade caches, so the result only carries the score matrix.
+inline Bicop::ScoresResult
+Bicop::scores_full(const Eigen::MatrixXd& u) const
+{
+  ScoresResult result;
+  result.scores = scores(u);
+  return result;
+}
+
+//! @brief Evaluates the per-observation scores with per-row parameters.
+inline Eigen::MatrixXd
+Bicop::scores(const Eigen::MatrixXd& u,
+              const Eigen::MatrixXd& parameters,
+              const size_t num_threads) const
+{
+  check_deriv_preconditions();
+  const Eigen::Index p = static_cast<Eigen::Index>(deriv_npars());
+  Eigen::MatrixXd s(u.rows(), p);
+  for (Eigen::Index k = 0; k < p; ++k) {
+    s.col(k) =
+      logpdf_deriv(u, "par" + std::to_string(k + 1), parameters, num_threads);
+  }
+  return s;
+}
+
+//! @brief Evaluates the gradient of the average log-likelihood with per-row
+//! parameters.
+inline Eigen::VectorXd
+Bicop::gradient(const Eigen::MatrixXd& u,
+                const Eigen::MatrixXd& parameters,
+                const size_t num_threads) const
+{
+  return scores(u, parameters, num_threads).colwise().mean().transpose();
+}
+
+//! @brief Evaluates the Hessian of the average log-likelihood with per-row
+//! parameters.
+inline Eigen::MatrixXd
+Bicop::hessian(const Eigen::MatrixXd& u,
+               const Eigen::MatrixXd& parameters,
+               const size_t num_threads) const
+{
+  check_deriv_preconditions();
+  const Eigen::Index p = static_cast<Eigen::Index>(deriv_npars());
+  Eigen::MatrixXd h(p, p);
+  for (Eigen::Index a = 0; a < p; ++a) {
+    for (Eigen::Index b = a; b < p; ++b) {
+      h(a, b) = logpdf_deriv2(u,
+                              "par" + std::to_string(a + 1) + "par" +
+                                std::to_string(b + 1),
+                              parameters,
+                              num_threads)
+                  .mean();
+      h(b, a) = h(a, b);
+    }
+  }
+  return h;
+}
+
+//! @brief Evaluates the per-observation Hessians with per-row parameters.
+inline std::vector<Eigen::MatrixXd>
+Bicop::hessian_full(const Eigen::MatrixXd& u,
+                    const Eigen::MatrixXd& parameters,
+                    const size_t num_threads) const
+{
+  check_deriv_preconditions();
+  const Eigen::Index n = u.rows();
+  const Eigen::Index p = static_cast<Eigen::Index>(deriv_npars());
+  std::vector<Eigen::MatrixXd> hess(static_cast<size_t>(n),
+                                    Eigen::MatrixXd(p, p));
+  for (Eigen::Index a = 0; a < p; ++a) {
+    for (Eigen::Index b = a; b < p; ++b) {
+      Eigen::VectorXd d = logpdf_deriv2(u,
+                                        "par" + std::to_string(a + 1) + "par" +
+                                          std::to_string(b + 1),
+                                        parameters,
+                                        num_threads);
+      for (Eigen::Index i = 0; i < n; ++i) {
+        hess[static_cast<size_t>(i)](a, b) = d(i);
+        hess[static_cast<size_t>(i)](b, a) = d(i);
+      }
+    }
+  }
+  return hess;
+}
+
+//! @brief Computes the covariance matrix of the scores with per-row parameters.
+inline Eigen::MatrixXd
+Bicop::scores_cov(const Eigen::MatrixXd& u,
+                  const Eigen::MatrixXd& parameters,
+                  const size_t num_threads) const
+{
+  Eigen::MatrixXd s = scores(u, parameters, num_threads);
+  Eigen::MatrixXd sc = s.rowwise() - s.colwise().mean();
+  return (sc.adjoint() * sc) / static_cast<double>(s.rows());
+}
+
+//! @brief Evaluates the scores with per-row parameters, bundled in a
+//! `ScoresResult`.
+inline Bicop::ScoresResult
+Bicop::scores_full(const Eigen::MatrixXd& u,
+                   const Eigen::MatrixXd& parameters,
+                   const size_t num_threads) const
+{
+  ScoresResult result;
+  result.scores = scores(u, parameters, num_threads);
+  return result;
+}
+//! @}
+
 //! checks that derivatives are available for the model (parametric family,
 //! continuous variable types).
 inline void

--- a/include/vinecopulib/bicop/implementation/class.ipp
+++ b/include/vinecopulib/bicop/implementation/class.ipp
@@ -1060,6 +1060,61 @@ Bicop::logpdf_deriv2(const Eigen::MatrixXd& u,
 }
 //! @}
 
+//! @brief Assembles an \f$ n \times p \f$ score matrix from a per-parameter
+//! column evaluator (`col(k)` returns column `k`). Shared by the fixed- and
+//! per-row-parameter `scores()` overloads so each keeps its own optimal
+//! `logpdf_deriv()` path (broadcast vs. per-row) while the loop lives once.
+inline Eigen::MatrixXd
+assemble_scores(Eigen::Index n,
+                Eigen::Index p,
+                const std::function<Eigen::VectorXd(Eigen::Index)>& col)
+{
+  Eigen::MatrixXd s(n, p);
+  for (Eigen::Index k = 0; k < p; ++k) {
+    s.col(k) = col(k);
+  }
+  return s;
+}
+
+//! @brief Assembles the averaged, symmetric \f$ p \times p \f$ Hessian from a
+//! per-\f$ (a, b) \f$ second-derivative column evaluator (upper triangle only).
+inline Eigen::MatrixXd
+assemble_hessian(
+  Eigen::Index p,
+  const std::function<Eigen::VectorXd(Eigen::Index, Eigen::Index)>& col)
+{
+  Eigen::MatrixXd h(p, p);
+  for (Eigen::Index a = 0; a < p; ++a) {
+    for (Eigen::Index b = a; b < p; ++b) {
+      h(a, b) = col(a, b).mean();
+      h(b, a) = h(a, b);
+    }
+  }
+  return h;
+}
+
+//! @brief Assembles the per-observation, symmetric \f$ p \times p \f$ Hessians
+//! (one per row of `u`) from the same per-\f$ (a, b) \f$ column evaluator.
+inline std::vector<Eigen::MatrixXd>
+assemble_hessian_full(
+  Eigen::Index n,
+  Eigen::Index p,
+  const std::function<Eigen::VectorXd(Eigen::Index, Eigen::Index)>& col)
+{
+  std::vector<Eigen::MatrixXd> hess(static_cast<size_t>(n),
+                                    Eigen::MatrixXd(p, p));
+  for (Eigen::Index a = 0; a < p; ++a) {
+    for (Eigen::Index b = a; b < p; ++b) {
+      Eigen::VectorXd d = col(a, b);
+      for (Eigen::Index i = 0; i < n; ++i) {
+        hess[static_cast<size_t>(i)](a, b) = d(i);
+        hess[static_cast<size_t>(i)](b, a) = d(i);
+      }
+    }
+  }
+  return hess;
+}
+
 //! @name Scores, gradient, and Hessian of the log-likelihood
 //!
 //! @details These methods aggregate the log-density parameter derivatives into
@@ -1089,12 +1144,10 @@ Bicop::scores(const Eigen::MatrixXd& u) const
 {
   check_data(u);
   check_deriv_preconditions();
-  const Eigen::Index p = static_cast<Eigen::Index>(deriv_npars());
-  Eigen::MatrixXd s(u.rows(), p);
-  for (Eigen::Index k = 0; k < p; ++k) {
-    s.col(k) = logpdf_deriv(u, "par" + std::to_string(k + 1));
-  }
-  return s;
+  return assemble_scores(
+    u.rows(), static_cast<Eigen::Index>(deriv_npars()), [&](Eigen::Index k) {
+      return logpdf_deriv(u, "par" + std::to_string(k + 1));
+    });
 }
 
 //! @brief Evaluates the gradient of the average log-likelihood.
@@ -1116,18 +1169,12 @@ Bicop::hessian(const Eigen::MatrixXd& u) const
 {
   check_data(u);
   check_deriv_preconditions();
-  const Eigen::Index p = static_cast<Eigen::Index>(deriv_npars());
-  Eigen::MatrixXd h(p, p);
-  for (Eigen::Index a = 0; a < p; ++a) {
-    for (Eigen::Index b = a; b < p; ++b) {
-      h(a, b) =
-        logpdf_deriv2(
-          u, "par" + std::to_string(a + 1) + "par" + std::to_string(b + 1))
-          .mean();
-      h(b, a) = h(a, b);
-    }
-  }
-  return h;
+  return assemble_hessian(
+    static_cast<Eigen::Index>(deriv_npars()),
+    [&](Eigen::Index a, Eigen::Index b) {
+      return logpdf_deriv2(
+        u, "par" + std::to_string(a + 1) + "par" + std::to_string(b + 1));
+    });
 }
 
 //! @brief Evaluates the per-observation Hessians.
@@ -1141,21 +1188,13 @@ Bicop::hessian_full(const Eigen::MatrixXd& u) const
 {
   check_data(u);
   check_deriv_preconditions();
-  const Eigen::Index n = u.rows();
-  const Eigen::Index p = static_cast<Eigen::Index>(deriv_npars());
-  std::vector<Eigen::MatrixXd> hess(static_cast<size_t>(n),
-                                    Eigen::MatrixXd(p, p));
-  for (Eigen::Index a = 0; a < p; ++a) {
-    for (Eigen::Index b = a; b < p; ++b) {
-      Eigen::VectorXd d = logpdf_deriv2(
+  return assemble_hessian_full(
+    u.rows(),
+    static_cast<Eigen::Index>(deriv_npars()),
+    [&](Eigen::Index a, Eigen::Index b) {
+      return logpdf_deriv2(
         u, "par" + std::to_string(a + 1) + "par" + std::to_string(b + 1));
-      for (Eigen::Index i = 0; i < n; ++i) {
-        hess[static_cast<size_t>(i)](a, b) = d(i);
-        hess[static_cast<size_t>(i)](b, a) = d(i);
-      }
-    }
-  }
-  return hess;
+    });
 }
 
 //! @brief Computes the covariance matrix of the scores.
@@ -1191,13 +1230,11 @@ Bicop::scores(const Eigen::MatrixXd& u,
               const size_t num_threads) const
 {
   check_deriv_preconditions();
-  const Eigen::Index p = static_cast<Eigen::Index>(deriv_npars());
-  Eigen::MatrixXd s(u.rows(), p);
-  for (Eigen::Index k = 0; k < p; ++k) {
-    s.col(k) =
-      logpdf_deriv(u, "par" + std::to_string(k + 1), parameters, num_threads);
-  }
-  return s;
+  return assemble_scores(
+    u.rows(), static_cast<Eigen::Index>(deriv_npars()), [&](Eigen::Index k) {
+      return logpdf_deriv(
+        u, "par" + std::to_string(k + 1), parameters, num_threads);
+    });
 }
 
 //! @brief Evaluates the gradient of the average log-likelihood with per-row
@@ -1218,20 +1255,15 @@ Bicop::hessian(const Eigen::MatrixXd& u,
                const size_t num_threads) const
 {
   check_deriv_preconditions();
-  const Eigen::Index p = static_cast<Eigen::Index>(deriv_npars());
-  Eigen::MatrixXd h(p, p);
-  for (Eigen::Index a = 0; a < p; ++a) {
-    for (Eigen::Index b = a; b < p; ++b) {
-      h(a, b) = logpdf_deriv2(u,
-                              "par" + std::to_string(a + 1) + "par" +
-                                std::to_string(b + 1),
-                              parameters,
-                              num_threads)
-                  .mean();
-      h(b, a) = h(a, b);
-    }
-  }
-  return h;
+  return assemble_hessian(static_cast<Eigen::Index>(deriv_npars()),
+                          [&](Eigen::Index a, Eigen::Index b) {
+                            return logpdf_deriv2(u,
+                                                 "par" + std::to_string(a + 1) +
+                                                   "par" +
+                                                   std::to_string(b + 1),
+                                                 parameters,
+                                                 num_threads);
+                          });
 }
 
 //! @brief Evaluates the per-observation Hessians with per-row parameters.
@@ -1241,24 +1273,16 @@ Bicop::hessian_full(const Eigen::MatrixXd& u,
                     const size_t num_threads) const
 {
   check_deriv_preconditions();
-  const Eigen::Index n = u.rows();
-  const Eigen::Index p = static_cast<Eigen::Index>(deriv_npars());
-  std::vector<Eigen::MatrixXd> hess(static_cast<size_t>(n),
-                                    Eigen::MatrixXd(p, p));
-  for (Eigen::Index a = 0; a < p; ++a) {
-    for (Eigen::Index b = a; b < p; ++b) {
-      Eigen::VectorXd d = logpdf_deriv2(u,
-                                        "par" + std::to_string(a + 1) + "par" +
-                                          std::to_string(b + 1),
-                                        parameters,
-                                        num_threads);
-      for (Eigen::Index i = 0; i < n; ++i) {
-        hess[static_cast<size_t>(i)](a, b) = d(i);
-        hess[static_cast<size_t>(i)](b, a) = d(i);
-      }
-    }
-  }
-  return hess;
+  return assemble_hessian_full(u.rows(),
+                               static_cast<Eigen::Index>(deriv_npars()),
+                               [&](Eigen::Index a, Eigen::Index b) {
+                                 return logpdf_deriv2(
+                                   u,
+                                   "par" + std::to_string(a + 1) + "par" +
+                                     std::to_string(b + 1),
+                                   parameters,
+                                   num_threads);
+                               });
 }
 
 //! @brief Computes the covariance matrix of the scores with per-row parameters.

--- a/include/vinecopulib/vinecop/class.hpp
+++ b/include/vinecopulib/vinecop/class.hpp
@@ -274,6 +274,37 @@ public:
                              bool step_wise = true,
                              const size_t num_threads = 1);
 
+  // Scores, gradient, and Hessian with per-observation parameters. `parameters`
+  // is an n x npars matrix, one full-vine parameter vector per observation,
+  // with columns in the (tree, edge, parameter) order of scores(). Continuous,
+  // all-parametric models only.
+  ScoresResult scores_full(Eigen::MatrixXd u,
+                           const Eigen::MatrixXd& parameters,
+                           bool step_wise = true,
+                           const size_t num_threads = 1,
+                           const bool keep_all = true);
+  Eigen::MatrixXd scores(Eigen::MatrixXd u,
+                         const Eigen::MatrixXd& parameters,
+                         bool step_wise = true,
+                         const size_t num_threads = 1);
+  Eigen::VectorXd gradient(Eigen::MatrixXd u,
+                           const Eigen::MatrixXd& parameters,
+                           bool step_wise = true,
+                           const size_t num_threads = 1);
+  Eigen::MatrixXd hessian(Eigen::MatrixXd u,
+                          const Eigen::MatrixXd& parameters,
+                          bool step_wise = true,
+                          const size_t num_threads = 1);
+  TriangularArray<std::vector<Eigen::MatrixXd>> hessian_full(
+    Eigen::MatrixXd u,
+    const Eigen::MatrixXd& parameters,
+    bool step_wise = true,
+    const size_t num_threads = 1);
+  Eigen::MatrixXd scores_cov(Eigen::MatrixXd u,
+                             const Eigen::MatrixXd& parameters,
+                             bool step_wise = true,
+                             const size_t num_threads = 1);
+
 private:
   // Per-edge derivative caches shared by the analytic score/gradient/Hessian
   // cascades. One forward walk over the vine (build_deriv_cache) fills them;
@@ -325,14 +356,25 @@ private:
   };
   // one forward walk over the rows [begin, begin + size) of `u`, filling the
   // per-edge derivative caches (second-order fields only when `second_order`).
-  TriangularArray<DerivCache> build_deriv_cache(const Eigen::MatrixXd& u,
-                                                size_t begin,
-                                                size_t size,
-                                                bool second_order) const;
+  // When `per_obs_params` is non-empty (an n x npars matrix), each edge reads
+  // its own per-observation parameters from the matching column block instead
+  // of the pair copula's stored parameters; an empty matrix (the default)
+  // leaves the fixed-parameter fast path unchanged.
+  TriangularArray<DerivCache> build_deriv_cache(
+    const Eigen::MatrixXd& u,
+    size_t begin,
+    size_t size,
+    bool second_order,
+    const Eigen::MatrixXd& per_obs_params = Eigen::MatrixXd()) const;
 
   // throws if any pair copula is nonparametric (differentiating w.r.t. an
   // interpolation grid is meaningless); `fn` names the calling method.
   void check_parametric(const char* fn) const;
+
+  // validates a per-observation parameter matrix for the score/Hessian
+  // overloads: rejects discrete variables and checks the n x npars shape.
+  void check_per_obs_params(const Eigen::MatrixXd& u,
+                            const Eigen::MatrixXd& per_obs_params) const;
 
 protected:
   size_t d_{ 1 };

--- a/include/vinecopulib/vinecop/class.hpp
+++ b/include/vinecopulib/vinecop/class.hpp
@@ -175,6 +175,19 @@ public:
                                const size_t num_threads,
                                const bool keep_all = true) const;
 
+  // Stats methods with per-observation parameters. `parameters` is an
+  // n x npars matrix, one full-vine parameter vector per observation, with
+  // columns in the (tree, edge, parameter) order of scores(). Continuous,
+  // all-parametric models only.
+  Eigen::VectorXd pdf(Eigen::MatrixXd u,
+                      const Eigen::MatrixXd& parameters,
+                      const size_t num_threads = 1) const;
+
+  PdfWithHfuncsResult pdf_full(Eigen::MatrixXd u,
+                               const Eigen::MatrixXd& parameters,
+                               const size_t num_threads,
+                               const bool keep_all = true) const;
+
   Eigen::VectorXd cdf(const Eigen::MatrixXd& u,
                       const size_t N = 1e4,
                       const size_t num_threads = 1,
@@ -220,6 +233,12 @@ public:
   double get_npars() const;
 
   double loglik(const Eigen::MatrixXd& u = Eigen::MatrixXd(),
+                const size_t num_threads = 1) const;
+
+  //! Log-likelihood with per-observation parameters (see the per-observation
+  //! `pdf()` overload for the `parameters` layout and restrictions).
+  double loglik(const Eigen::MatrixXd& u,
+                const Eigen::MatrixXd& parameters,
                 const size_t num_threads = 1) const;
 
   double aic(const Eigen::MatrixXd& u = Eigen::MatrixXd(),

--- a/include/vinecopulib/vinecop/implementation/class.ipp
+++ b/include/vinecopulib/vinecop/implementation/class.ipp
@@ -1142,6 +1142,31 @@ Vinecop::check_parametric(const char* fn) const
   }
 }
 
+//! validates a per-observation parameter matrix: the analytic cascade requires
+//! continuous variables (discrete would need finite differences that mutate
+//! shared parameters), and `parameters` must be n x npars, one full-vine
+//! parameter vector per observation in the (tree, edge, param) order of
+//! scores().
+inline void
+Vinecop::check_per_obs_params(const Eigen::MatrixXd& u,
+                              const Eigen::MatrixXd& per_obs_params) const
+{
+  if (get_n_discrete() > 0) {
+    throw std::runtime_error(
+      "per-observation parameters are only supported for continuous "
+      "variables");
+  }
+  if (per_obs_params.rows() != u.rows()) {
+    throw std::runtime_error("parameters must have one row per row of u "
+                             "(parameters.rows() must equal u.rows()).");
+  }
+  if (per_obs_params.cols() != static_cast<Eigen::Index>(this->get_npars())) {
+    throw std::runtime_error(
+      "parameters must have get_npars() columns, in the (tree, edge, "
+      "parameter) order of scores().");
+  }
+}
+
 //! first-order chain-rule push-forward of an argument perturbation through
 //! an h-function output: `∂h/∂u1 · v1 + ∂h/∂u2 · v2` (shared by the gradient
 //! cascade and the Hessian's hat/til propagations).
@@ -1167,7 +1192,8 @@ inline TriangularArray<Vinecop::DerivCache>
 Vinecop::build_deriv_cache(const Eigen::MatrixXd& u,
                            size_t begin,
                            size_t size,
-                           bool second_order) const
+                           bool second_order,
+                           const Eigen::MatrixXd& per_obs_params) const
 {
   size_t trunc_lvl = rvine_structure_.get_trunc_lvl();
   auto order = rvine_structure_.get_order();
@@ -1180,6 +1206,12 @@ Vinecop::build_deriv_cache(const Eigen::MatrixXd& u,
     hfunc2.col(j) = u.block(begin, order[j] - 1, m, 1);
   }
   auto sel = [](size_t p) { return "par" + std::to_string(p + 1); };
+
+  // per-observation parameters: when supplied, each edge reads its own n x np
+  // column block (in the same (t, e) order the flat scores() index follows);
+  // `par_offset` tracks that column start. Empty => fixed-parameter fast path.
+  const bool per_obs = per_obs_params.size() > 0;
+  size_t par_offset = 0;
 
   Eigen::MatrixXd u_e;
   for (size_t t = 0; t < trunc_lvl; ++t) {
@@ -1200,12 +1232,57 @@ Vinecop::build_deriv_cache(const Eigen::MatrixXd& u,
       u_e.col(1) = ce.arg2_is_h2 ? hfunc2.col(ce.arg2_col - 1)
                                  : hfunc1.col(ce.arg2_col - 1);
 
-      ce.c = ec.pdf(u_e);
-      ce.du1 = ec.logpdf_deriv(u_e, "u1");
-      ce.du2 = ec.logpdf_deriv(u_e, "u2");
+      // per-edge dispatch: on the fixed path (per_obs == false) each helper
+      // calls the pair copula's stored-parameter method exactly as before; on
+      // the per-observation path it forwards this edge's n x np parameter slice
+      // to the matching per-row overload. Every evaluation (density,
+      // h-functions, and their derivatives) must use the slice so the deeper
+      // trees see pseudo-observations consistent with the per-obs parameters.
+      Eigen::MatrixXd pars_e;
+      if (per_obs) {
+        pars_e = per_obs_params.block(begin, par_offset, m, np);
+      }
+      auto PDF = [&]() { return per_obs ? ec.pdf(u_e, pars_e) : ec.pdf(u_e); };
+      auto LPD = [&](const std::string& s) {
+        return per_obs ? ec.logpdf_deriv(u_e, s, pars_e)
+                       : ec.logpdf_deriv(u_e, s);
+      };
+      auto PD = [&](const std::string& s) {
+        return per_obs ? ec.pdf_deriv(u_e, s, pars_e) : ec.pdf_deriv(u_e, s);
+      };
+      auto LPD2 = [&](const std::string& s) {
+        return per_obs ? ec.logpdf_deriv2(u_e, s, pars_e)
+                       : ec.logpdf_deriv2(u_e, s);
+      };
+      auto H1 = [&]() {
+        return per_obs ? ec.hfunc1(u_e, pars_e) : ec.hfunc1(u_e);
+      };
+      auto H2 = [&]() {
+        return per_obs ? ec.hfunc2(u_e, pars_e) : ec.hfunc2(u_e);
+      };
+      auto H1D = [&](const std::string& s) {
+        return per_obs ? ec.hfunc1_deriv(u_e, s, pars_e)
+                       : ec.hfunc1_deriv(u_e, s);
+      };
+      auto H2D = [&](const std::string& s) {
+        return per_obs ? ec.hfunc2_deriv(u_e, s, pars_e)
+                       : ec.hfunc2_deriv(u_e, s);
+      };
+      auto H1D2 = [&](const std::string& s) {
+        return per_obs ? ec.hfunc1_deriv2(u_e, s, pars_e)
+                       : ec.hfunc1_deriv2(u_e, s);
+      };
+      auto H2D2 = [&](const std::string& s) {
+        return per_obs ? ec.hfunc2_deriv2(u_e, s, pars_e)
+                       : ec.hfunc2_deriv2(u_e, s);
+      };
+
+      ce.c = PDF();
+      ce.du1 = LPD("u1");
+      ce.du2 = LPD("u2");
       ce.dpar.resize(np);
       for (size_t p = 0; p < np; ++p) {
-        ce.dpar[p] = ec.logpdf_deriv(u_e, sel(p));
+        ce.dpar[p] = LPD(sel(p));
       }
 
       // ∂c/∂u1, ∂c/∂u2, ∂c/∂θ are shared by the two h-outputs' 2nd-order
@@ -1213,23 +1290,23 @@ Vinecop::build_deriv_cache(const Eigen::MatrixXd& u,
       Eigen::VectorXd c_u1, c_u2;
       std::vector<Eigen::VectorXd> c_par;
       if (second_order) {
-        c_u1 = ec.pdf_deriv(u_e, "u1");
-        c_u2 = ec.pdf_deriv(u_e, "u2");
+        c_u1 = PD("u1");
+        c_u2 = PD("u2");
         c_par.resize(np);
         for (size_t p = 0; p < np; ++p) {
-          c_par[p] = ec.pdf_deriv(u_e, sel(p));
+          c_par[p] = PD(sel(p));
         }
-        ce.du1u1 = ec.logpdf_deriv2(u_e, "u1u1");
-        ce.du1u2 = ec.logpdf_deriv2(u_e, "u1u2");
-        ce.du2u2 = ec.logpdf_deriv2(u_e, "u2u2");
+        ce.du1u1 = LPD2("u1u1");
+        ce.du1u2 = LPD2("u1u2");
+        ce.du2u2 = LPD2("u2u2");
         ce.dpar_u1.resize(np);
         ce.dpar_u2.resize(np);
         ce.dpar_par.assign(np, std::vector<Eigen::VectorXd>(np));
         for (size_t p = 0; p < np; ++p) {
-          ce.dpar_u1[p] = ec.logpdf_deriv2(u_e, sel(p) + "u1");
-          ce.dpar_u2[p] = ec.logpdf_deriv2(u_e, sel(p) + "u2");
+          ce.dpar_u1[p] = LPD2(sel(p) + "u1");
+          ce.dpar_u2[p] = LPD2(sel(p) + "u2");
           for (size_t q = p; q < np; ++q) {
-            ce.dpar_par[p][q] = ec.logpdf_deriv2(u_e, sel(p) + sel(q));
+            ce.dpar_par[p][q] = LPD2(sel(p) + sel(q));
             ce.dpar_par[q][p] = ce.dpar_par[p][q];
           }
         }
@@ -1241,23 +1318,23 @@ Vinecop::build_deriv_cache(const Eigen::MatrixXd& u,
         DerivLeaf& leaf = ce.h2;
         leaf.active = true;
         leaf.du1 = ce.c;
-        leaf.du2 = ec.hfunc2_deriv(u_e, "u2");
+        leaf.du2 = H2D("u2");
         leaf.dpar.resize(np);
         for (size_t p = 0; p < np; ++p) {
-          leaf.dpar[p] = ec.hfunc2_deriv(u_e, sel(p));
+          leaf.dpar[p] = H2D(sel(p));
         }
         if (second_order) {
           leaf.du1u1 = c_u1;
           leaf.du1u2 = c_u2;
-          leaf.du2u2 = ec.hfunc2_deriv2(u_e, "u2u2");
+          leaf.du2u2 = H2D2("u2u2");
           leaf.dpar_u1.resize(np);
           leaf.dpar_u2.resize(np);
           leaf.dpar_par.assign(np, std::vector<Eigen::VectorXd>(np));
           for (size_t p = 0; p < np; ++p) {
             leaf.dpar_u1[p] = c_par[p]; // ∂²h2/∂θ∂u1 = ∂c/∂θ
-            leaf.dpar_u2[p] = ec.hfunc2_deriv2(u_e, sel(p) + "u2");
+            leaf.dpar_u2[p] = H2D2(sel(p) + "u2");
             for (size_t q = p; q < np; ++q) {
-              leaf.dpar_par[p][q] = ec.hfunc2_deriv2(u_e, sel(p) + sel(q));
+              leaf.dpar_par[p][q] = H2D2(sel(p) + sel(q));
               leaf.dpar_par[q][p] = leaf.dpar_par[p][q];
             }
           }
@@ -1267,24 +1344,24 @@ Vinecop::build_deriv_cache(const Eigen::MatrixXd& u,
       if (has_deeper_tree && rvine_structure_.needed_hfunc1(t, e)) {
         DerivLeaf& leaf = ce.h1;
         leaf.active = true;
-        leaf.du1 = ec.hfunc1_deriv(u_e, "u1");
+        leaf.du1 = H1D("u1");
         leaf.du2 = ce.c;
         leaf.dpar.resize(np);
         for (size_t p = 0; p < np; ++p) {
-          leaf.dpar[p] = ec.hfunc1_deriv(u_e, sel(p));
+          leaf.dpar[p] = H1D(sel(p));
         }
         if (second_order) {
-          leaf.du1u1 = ec.hfunc1_deriv2(u_e, "u1u1");
+          leaf.du1u1 = H1D2("u1u1");
           leaf.du1u2 = c_u1; // ∂²h1/∂u1∂u2 = ∂c/∂u1
           leaf.du2u2 = c_u2; // ∂²h1/∂u2²   = ∂c/∂u2
           leaf.dpar_u1.resize(np);
           leaf.dpar_u2.resize(np);
           leaf.dpar_par.assign(np, std::vector<Eigen::VectorXd>(np));
           for (size_t p = 0; p < np; ++p) {
-            leaf.dpar_u1[p] = ec.hfunc1_deriv2(u_e, sel(p) + "u1");
+            leaf.dpar_u1[p] = H1D2(sel(p) + "u1");
             leaf.dpar_u2[p] = c_par[p]; // ∂²h1/∂θ∂u2 = ∂c/∂θ
             for (size_t q = p; q < np; ++q) {
-              leaf.dpar_par[p][q] = ec.hfunc1_deriv2(u_e, sel(p) + sel(q));
+              leaf.dpar_par[p][q] = H1D2(sel(p) + sel(q));
               leaf.dpar_par[q][p] = leaf.dpar_par[p][q];
             }
           }
@@ -1292,11 +1369,13 @@ Vinecop::build_deriv_cache(const Eigen::MatrixXd& u,
       }
 
       if (rvine_structure_.needed_hfunc1(t, e)) {
-        hfunc1.col(e) = ec.hfunc1(u_e);
+        hfunc1.col(e) = H1();
       }
       if (rvine_structure_.needed_hfunc2(t, e)) {
-        hfunc2.col(e) = ec.hfunc2(u_e);
+        hfunc2.col(e) = H2();
       }
+
+      par_offset += np;
     }
   }
   return cache;
@@ -1352,6 +1431,25 @@ Vinecop::scores_full(Eigen::MatrixXd u,
                      const size_t num_threads,
                      const bool keep_all)
 {
+  return scores_full(
+    std::move(u), Eigen::MatrixXd(), step_wise, num_threads, keep_all);
+}
+
+//! @brief Evaluates the score function with per-observation parameters.
+//!
+//! Same as `scores_full()`, but each observation uses its own full-vine
+//! parameter vector, supplied as an \f$ n \times \mathrm{npars} \f$ matrix
+//! `parameters` whose columns follow the (tree, edge, parameter) order of
+//! `scores()`. Continuous, all-parametric models only; discrete variables are
+//! rejected (they would require finite differences that mutate shared
+//! parameters).
+inline Vinecop::ScoresResult
+Vinecop::scores_full(Eigen::MatrixXd u,
+                     const Eigen::MatrixXd& per_obs_params,
+                     bool step_wise,
+                     const size_t num_threads,
+                     const bool keep_all)
+{
   check_data(u);
   u = collapse_data(u);
 
@@ -1362,6 +1460,11 @@ Vinecop::scores_full(Eigen::MatrixXd u,
   const size_t n = static_cast<size_t>(u.rows());
 
   check_parametric("scores()");
+
+  const bool per_obs = per_obs_params.size() > 0;
+  if (per_obs) {
+    check_per_obs_params(u, per_obs_params);
+  }
 
   ScoresResult result;
   result.scores =
@@ -1473,7 +1576,7 @@ Vinecop::scores_full(Eigen::MatrixXd u,
     }
 
     auto do_batch = [&](const tools_batch::Batch& b) {
-      auto cache = build_deriv_cache(u, b.begin, b.size, false);
+      auto cache = build_deriv_cache(u, b.begin, b.size, false, per_obs_params);
 
       if (keep_all) {
         for (size_t t = 0; t < trunc_lvl; ++t) {
@@ -1670,13 +1773,22 @@ Vinecop::scores_full(Eigen::MatrixXd u,
         }
 
         auto pars = edge_copula.get_parameters();
+        // this edge's per-observation parameter slice (its columns start at the
+        // current flat index `ipar`, which equals edge_par0(tree, edge) here)
+        Eigen::MatrixXd pars_e;
+        if (per_obs) {
+          pars_e = per_obs_params.block(b.begin, ipar, b.size, pars.size());
+        }
         if (var_types == std::vector<std::string>{ "c", "c" }) {
           // analytic per-edge gradient of the log-density (closed forms for
           // bicop_families::analytic_derivs, internal finite differences of
           // the density otherwise); nonparametric edges were rejected above
           for (size_t p = 0; p < static_cast<size_t>(pars.size()); p++) {
             Eigen::VectorXd col =
-              edge_copula.logpdf_deriv(u_e, "par" + std::to_string(p + 1));
+              per_obs
+                ? edge_copula.logpdf_deriv(
+                    u_e, "par" + std::to_string(p + 1), pars_e)
+                : edge_copula.logpdf_deriv(u_e, "par" + std::to_string(p + 1));
             result.scores.col(ipar).segment(b.begin, b.size) = col;
             if (keep_all) {
               result.logpdf_deriv_pars(tree, edge)[p].segment(b.begin, b.size) =
@@ -1713,9 +1825,12 @@ Vinecop::scores_full(Eigen::MatrixXd u,
           }
         }
 
-        // h-functions are only evaluated if needed in next step
+        // h-functions are only evaluated if needed in next step (per_obs uses
+        // the edge slice so deeper trees stay consistent; discrete sub-columns
+        // never arise on the per_obs path, which requires continuous variables)
         if (rvine_structure_.needed_hfunc1(tree, edge)) {
-          hfunc1.col(edge) = edge_copula.hfunc1(u_e);
+          hfunc1.col(edge) =
+            per_obs ? edge_copula.hfunc1(u_e, pars_e) : edge_copula.hfunc1(u_e);
           if (var_types[1] == "d") {
             u_e_sub = u_e;
             u_e_sub.col(1) = u_e.col(3);
@@ -1723,7 +1838,8 @@ Vinecop::scores_full(Eigen::MatrixXd u,
           }
         }
         if (rvine_structure_.needed_hfunc2(tree, edge)) {
-          hfunc2.col(edge) = edge_copula.hfunc2(u_e);
+          hfunc2.col(edge) =
+            per_obs ? edge_copula.hfunc2(u_e, pars_e) : edge_copula.hfunc2(u_e);
           if (var_types[0] == "d") {
             u_e_sub = u_e;
             u_e_sub.col(0) = u_e.col(2);
@@ -1762,6 +1878,20 @@ Vinecop::scores(Eigen::MatrixXd u, bool step_wise, const size_t num_threads)
   return scores_full(std::move(u), step_wise, num_threads, false).scores;
 }
 
+//! @brief Evaluates the score function with per-observation parameters.
+//!
+//! Per-observation counterpart of `scores()`; see the per-observation
+//! `scores_full()` overload for the `parameters` layout and restrictions.
+inline Eigen::MatrixXd
+Vinecop::scores(Eigen::MatrixXd u,
+                const Eigen::MatrixXd& parameters,
+                bool step_wise,
+                const size_t num_threads)
+{
+  return scores_full(std::move(u), parameters, step_wise, num_threads, false)
+    .scores;
+}
+
 //! @brief Evaluates the gradient of the average log-likelihood.
 //!
 //! Returns the observation-average of `scores()` as a vector of length
@@ -1780,6 +1910,23 @@ inline Eigen::VectorXd
 Vinecop::gradient(Eigen::MatrixXd u, bool step_wise, const size_t num_threads)
 {
   return this->scores(std::move(u), step_wise, num_threads)
+    .colwise()
+    .mean()
+    .transpose();
+}
+
+//! @brief Evaluates the gradient of the average log-likelihood with
+//! per-observation parameters.
+//!
+//! Per-observation counterpart of `gradient()`; the return is the
+//! observation-average of the per-observation `scores()`.
+inline Eigen::VectorXd
+Vinecop::gradient(Eigen::MatrixXd u,
+                  const Eigen::MatrixXd& parameters,
+                  bool step_wise,
+                  const size_t num_threads)
+{
+  return this->scores(std::move(u), parameters, step_wise, num_threads)
     .colwise()
     .mean()
     .transpose();
@@ -1814,12 +1961,31 @@ Vinecop::hessian_full(Eigen::MatrixXd u,
                       bool step_wise,
                       const size_t num_threads)
 {
+  return hessian_full(std::move(u), Eigen::MatrixXd(), step_wise, num_threads);
+}
+
+//! @brief Evaluates the per-observation Hessians with per-observation
+//! parameters.
+//!
+//! Per-observation counterpart of `hessian_full()`; see the per-observation
+//! `scores_full()` overload for the `parameters` layout and restrictions.
+inline TriangularArray<std::vector<Eigen::MatrixXd>>
+Vinecop::hessian_full(Eigen::MatrixXd u,
+                      const Eigen::MatrixXd& per_obs_params,
+                      bool step_wise,
+                      const size_t num_threads)
+{
   check_data(u);
   u = collapse_data(u);
 
   size_t trunc_lvl = rvine_structure_.get_trunc_lvl();
 
   check_parametric("hessian()");
+
+  const bool per_obs = per_obs_params.size() > 0;
+  if (per_obs) {
+    check_per_obs_params(u, per_obs_params);
+  }
 
   TriangularArray<std::vector<Eigen::MatrixXd>> hess(d_);
 
@@ -1890,7 +2056,7 @@ Vinecop::hessian_full(Eigen::MatrixXd u,
     // ("bar") propagation is needed. Upper-triangular in the flat order.
     auto do_batch = [&](const tools_batch::Batch& b) {
       const size_t m = b.size;
-      auto cache = build_deriv_cache(u, b.begin, m, true);
+      auto cache = build_deriv_cache(u, b.begin, m, true, per_obs_params);
 
       // dh1/dh2 and h1_affected/h2_affected play the same role as in the
       // gradient cascade of scores_full: per storage column, the current
@@ -1982,7 +2148,7 @@ Vinecop::hessian_full(Eigen::MatrixXd u,
   auto do_batch = [&](const tools_batch::Batch& b) {
     const size_t m = b.size;
     // one forward walk fills every per-edge first- and second-order leaf
-    auto cache = build_deriv_cache(u, b.begin, m, true);
+    auto cache = build_deriv_cache(u, b.begin, m, true, per_obs_params);
 
     // Second-order cascade for each parameter pair (only the upper triangle;
     // H is symmetric). Per storage column e (suffix 1 = the column's hfunc1
@@ -2124,6 +2290,26 @@ Vinecop::hessian_full(Eigen::MatrixXd u,
 inline Eigen::MatrixXd
 Vinecop::hessian(Eigen::MatrixXd u, bool step_wise, const size_t num_threads)
 {
+  return hessian(std::move(u), Eigen::MatrixXd(), step_wise, num_threads);
+}
+
+//! @brief Evaluates the averaged Hessian with per-observation parameters.
+//!
+//! Per-observation counterpart of `hessian()`; see the per-observation
+//! `scores_full()` overload for the `parameters` layout and restrictions.
+inline Eigen::MatrixXd
+Vinecop::hessian(Eigen::MatrixXd u,
+                 const Eigen::MatrixXd& parameters,
+                 bool step_wise,
+                 const size_t num_threads)
+{
+  const bool per_obs = parameters.size() > 0;
+  // validate up front so the per-chunk parameters.middleRows() slices below
+  // are always in range (hessian_full re-validates each chunk, but only after
+  // the slice is taken)
+  if (per_obs) {
+    check_per_obs_params(u, parameters);
+  }
   const size_t npars = static_cast<size_t>(this->get_npars());
   Eigen::MatrixXd H = Eigen::MatrixXd::Zero(npars, npars);
   const size_t n = static_cast<size_t>(u.rows());
@@ -2144,7 +2330,12 @@ Vinecop::hessian(Eigen::MatrixXd u, bool step_wise, const size_t num_threads)
   for (size_t begin = 0; begin < n; begin += chunk) {
     size_t size = std::min(chunk, n - begin);
     auto hess =
-      this->hessian_full(u.middleRows(begin, size), step_wise, num_threads);
+      per_obs
+        ? this->hessian_full(u.middleRows(begin, size),
+                             parameters.middleRows(begin, size),
+                             step_wise,
+                             num_threads)
+        : this->hessian_full(u.middleRows(begin, size), step_wise, num_threads);
     size_t ipar = 0;
     for (size_t t = 0; t < trunc_lvl; t++) {
       for (size_t e = 0; e < d_ - 1 - t; e++) {
@@ -2178,6 +2369,22 @@ Vinecop::scores_cov(Eigen::MatrixXd u, bool step_wise, const size_t num_threads)
   auto s = this->scores(u, step_wise, num_threads);
   // materialize the centered scores; a lazy expression would be evaluated
   // twice by the product below
+  Eigen::MatrixXd sc = s.rowwise() - s.colwise().mean();
+  return (sc.adjoint() * sc) / static_cast<double>(s.rows());
+}
+
+//! @brief Computes the covariance matrix of scores with per-observation
+//! parameters.
+//!
+//! Per-observation counterpart of `scores_cov()`; see the per-observation
+//! `scores_full()` overload for the `parameters` layout and restrictions.
+inline Eigen::MatrixXd
+Vinecop::scores_cov(Eigen::MatrixXd u,
+                    const Eigen::MatrixXd& parameters,
+                    bool step_wise,
+                    const size_t num_threads)
+{
+  auto s = this->scores(u, parameters, step_wise, num_threads);
   Eigen::MatrixXd sc = s.rowwise() - s.colwise().mean();
   return (sc.adjoint() * sc) / static_cast<double>(s.rows());
 }

--- a/include/vinecopulib/vinecop/implementation/class.ipp
+++ b/include/vinecopulib/vinecop/implementation/class.ipp
@@ -1242,47 +1242,49 @@ Vinecop::build_deriv_cache(const Eigen::MatrixXd& u,
       if (per_obs) {
         pars_e = per_obs_params.block(begin, par_offset, m, np);
       }
-      auto PDF = [&]() { return per_obs ? ec.pdf(u_e, pars_e) : ec.pdf(u_e); };
-      auto LPD = [&](const std::string& s) {
+      auto ec_pdf = [&]() {
+        return per_obs ? ec.pdf(u_e, pars_e) : ec.pdf(u_e);
+      };
+      auto ec_logpdf_deriv = [&](const std::string& s) {
         return per_obs ? ec.logpdf_deriv(u_e, s, pars_e)
                        : ec.logpdf_deriv(u_e, s);
       };
-      auto PD = [&](const std::string& s) {
+      auto ec_pdf_deriv = [&](const std::string& s) {
         return per_obs ? ec.pdf_deriv(u_e, s, pars_e) : ec.pdf_deriv(u_e, s);
       };
-      auto LPD2 = [&](const std::string& s) {
+      auto ec_logpdf_deriv2 = [&](const std::string& s) {
         return per_obs ? ec.logpdf_deriv2(u_e, s, pars_e)
                        : ec.logpdf_deriv2(u_e, s);
       };
-      auto H1 = [&]() {
+      auto ec_hfunc1 = [&]() {
         return per_obs ? ec.hfunc1(u_e, pars_e) : ec.hfunc1(u_e);
       };
-      auto H2 = [&]() {
+      auto ec_hfunc2 = [&]() {
         return per_obs ? ec.hfunc2(u_e, pars_e) : ec.hfunc2(u_e);
       };
-      auto H1D = [&](const std::string& s) {
+      auto ec_hfunc1_deriv = [&](const std::string& s) {
         return per_obs ? ec.hfunc1_deriv(u_e, s, pars_e)
                        : ec.hfunc1_deriv(u_e, s);
       };
-      auto H2D = [&](const std::string& s) {
+      auto ec_hfunc2_deriv = [&](const std::string& s) {
         return per_obs ? ec.hfunc2_deriv(u_e, s, pars_e)
                        : ec.hfunc2_deriv(u_e, s);
       };
-      auto H1D2 = [&](const std::string& s) {
+      auto ec_hfunc1_deriv2 = [&](const std::string& s) {
         return per_obs ? ec.hfunc1_deriv2(u_e, s, pars_e)
                        : ec.hfunc1_deriv2(u_e, s);
       };
-      auto H2D2 = [&](const std::string& s) {
+      auto ec_hfunc2_deriv2 = [&](const std::string& s) {
         return per_obs ? ec.hfunc2_deriv2(u_e, s, pars_e)
                        : ec.hfunc2_deriv2(u_e, s);
       };
 
-      ce.c = PDF();
-      ce.du1 = LPD("u1");
-      ce.du2 = LPD("u2");
+      ce.c = ec_pdf();
+      ce.du1 = ec_logpdf_deriv("u1");
+      ce.du2 = ec_logpdf_deriv("u2");
       ce.dpar.resize(np);
       for (size_t p = 0; p < np; ++p) {
-        ce.dpar[p] = LPD(sel(p));
+        ce.dpar[p] = ec_logpdf_deriv(sel(p));
       }
 
       // ∂c/∂u1, ∂c/∂u2, ∂c/∂θ are shared by the two h-outputs' 2nd-order
@@ -1290,23 +1292,23 @@ Vinecop::build_deriv_cache(const Eigen::MatrixXd& u,
       Eigen::VectorXd c_u1, c_u2;
       std::vector<Eigen::VectorXd> c_par;
       if (second_order) {
-        c_u1 = PD("u1");
-        c_u2 = PD("u2");
+        c_u1 = ec_pdf_deriv("u1");
+        c_u2 = ec_pdf_deriv("u2");
         c_par.resize(np);
         for (size_t p = 0; p < np; ++p) {
-          c_par[p] = PD(sel(p));
+          c_par[p] = ec_pdf_deriv(sel(p));
         }
-        ce.du1u1 = LPD2("u1u1");
-        ce.du1u2 = LPD2("u1u2");
-        ce.du2u2 = LPD2("u2u2");
+        ce.du1u1 = ec_logpdf_deriv2("u1u1");
+        ce.du1u2 = ec_logpdf_deriv2("u1u2");
+        ce.du2u2 = ec_logpdf_deriv2("u2u2");
         ce.dpar_u1.resize(np);
         ce.dpar_u2.resize(np);
         ce.dpar_par.assign(np, std::vector<Eigen::VectorXd>(np));
         for (size_t p = 0; p < np; ++p) {
-          ce.dpar_u1[p] = LPD2(sel(p) + "u1");
-          ce.dpar_u2[p] = LPD2(sel(p) + "u2");
+          ce.dpar_u1[p] = ec_logpdf_deriv2(sel(p) + "u1");
+          ce.dpar_u2[p] = ec_logpdf_deriv2(sel(p) + "u2");
           for (size_t q = p; q < np; ++q) {
-            ce.dpar_par[p][q] = LPD2(sel(p) + sel(q));
+            ce.dpar_par[p][q] = ec_logpdf_deriv2(sel(p) + sel(q));
             ce.dpar_par[q][p] = ce.dpar_par[p][q];
           }
         }
@@ -1318,23 +1320,23 @@ Vinecop::build_deriv_cache(const Eigen::MatrixXd& u,
         DerivLeaf& leaf = ce.h2;
         leaf.active = true;
         leaf.du1 = ce.c;
-        leaf.du2 = H2D("u2");
+        leaf.du2 = ec_hfunc2_deriv("u2");
         leaf.dpar.resize(np);
         for (size_t p = 0; p < np; ++p) {
-          leaf.dpar[p] = H2D(sel(p));
+          leaf.dpar[p] = ec_hfunc2_deriv(sel(p));
         }
         if (second_order) {
           leaf.du1u1 = c_u1;
           leaf.du1u2 = c_u2;
-          leaf.du2u2 = H2D2("u2u2");
+          leaf.du2u2 = ec_hfunc2_deriv2("u2u2");
           leaf.dpar_u1.resize(np);
           leaf.dpar_u2.resize(np);
           leaf.dpar_par.assign(np, std::vector<Eigen::VectorXd>(np));
           for (size_t p = 0; p < np; ++p) {
             leaf.dpar_u1[p] = c_par[p]; // ∂²h2/∂θ∂u1 = ∂c/∂θ
-            leaf.dpar_u2[p] = H2D2(sel(p) + "u2");
+            leaf.dpar_u2[p] = ec_hfunc2_deriv2(sel(p) + "u2");
             for (size_t q = p; q < np; ++q) {
-              leaf.dpar_par[p][q] = H2D2(sel(p) + sel(q));
+              leaf.dpar_par[p][q] = ec_hfunc2_deriv2(sel(p) + sel(q));
               leaf.dpar_par[q][p] = leaf.dpar_par[p][q];
             }
           }
@@ -1344,24 +1346,24 @@ Vinecop::build_deriv_cache(const Eigen::MatrixXd& u,
       if (has_deeper_tree && rvine_structure_.needed_hfunc1(t, e)) {
         DerivLeaf& leaf = ce.h1;
         leaf.active = true;
-        leaf.du1 = H1D("u1");
+        leaf.du1 = ec_hfunc1_deriv("u1");
         leaf.du2 = ce.c;
         leaf.dpar.resize(np);
         for (size_t p = 0; p < np; ++p) {
-          leaf.dpar[p] = H1D(sel(p));
+          leaf.dpar[p] = ec_hfunc1_deriv(sel(p));
         }
         if (second_order) {
-          leaf.du1u1 = H1D2("u1u1");
+          leaf.du1u1 = ec_hfunc1_deriv2("u1u1");
           leaf.du1u2 = c_u1; // ∂²h1/∂u1∂u2 = ∂c/∂u1
           leaf.du2u2 = c_u2; // ∂²h1/∂u2²   = ∂c/∂u2
           leaf.dpar_u1.resize(np);
           leaf.dpar_u2.resize(np);
           leaf.dpar_par.assign(np, std::vector<Eigen::VectorXd>(np));
           for (size_t p = 0; p < np; ++p) {
-            leaf.dpar_u1[p] = H1D2(sel(p) + "u1");
+            leaf.dpar_u1[p] = ec_hfunc1_deriv2(sel(p) + "u1");
             leaf.dpar_u2[p] = c_par[p]; // ∂²h1/∂θ∂u2 = ∂c/∂θ
             for (size_t q = p; q < np; ++q) {
-              leaf.dpar_par[p][q] = H1D2(sel(p) + sel(q));
+              leaf.dpar_par[p][q] = ec_hfunc1_deriv2(sel(p) + sel(q));
               leaf.dpar_par[q][p] = leaf.dpar_par[p][q];
             }
           }
@@ -1369,10 +1371,10 @@ Vinecop::build_deriv_cache(const Eigen::MatrixXd& u,
       }
 
       if (rvine_structure_.needed_hfunc1(t, e)) {
-        hfunc1.col(e) = H1();
+        hfunc1.col(e) = ec_hfunc1();
       }
       if (rvine_structure_.needed_hfunc2(t, e)) {
-        hfunc2.col(e) = H2();
+        hfunc2.col(e) = ec_hfunc2();
       }
 
       par_offset += np;

--- a/include/vinecopulib/vinecop/implementation/class.ipp
+++ b/include/vinecopulib/vinecop/implementation/class.ipp
@@ -953,8 +953,31 @@ Vinecop::pdf_full(Eigen::MatrixXd u,
                   const size_t num_threads,
                   const bool keep_all) const
 {
+  return pdf_full(std::move(u), Eigen::MatrixXd(), num_threads, keep_all);
+}
+
+//! @brief Evaluates the copula density (and per-edge quantities) with
+//! per-observation parameters.
+//!
+//! Same as `pdf_full()`, but each observation uses its own full-vine parameter
+//! vector, supplied as an \f$ n \times \mathrm{npars} \f$ matrix `parameters`
+//! whose columns follow the (tree, edge, parameter) order of `scores()`.
+//! Continuous, all-parametric models only (discrete variables and nonparametric
+//! pair copulas are rejected).
+inline Vinecop::PdfWithHfuncsResult
+Vinecop::pdf_full(Eigen::MatrixXd u,
+                  const Eigen::MatrixXd& parameters,
+                  const size_t num_threads,
+                  const bool keep_all) const
+{
   check_data(u);
   collapse_data_inplace(u);
+
+  const bool per_obs = parameters.size() > 0;
+  if (per_obs) {
+    check_parametric("pdf()/loglik() with per-observation parameters");
+    check_per_obs_params(u, parameters);
+  }
 
   // info about the vine structure (reverse rows (!) for more natural indexing)
   size_t trunc_lvl = rvine_structure_.get_trunc_lvl();
@@ -1014,6 +1037,10 @@ Vinecop::pdf_full(Eigen::MatrixXd u,
       }
     }
 
+    // running column offset of the current edge's parameters within the flat
+    // (tree, edge, parameter) order of `parameters` (per-observation path only)
+    size_t par_offset = 0;
+
     for (size_t tree = 0; tree < trunc_lvl; ++tree) {
       tools_interface::check_user_interrupt(
         static_cast<double>(u.rows()) * static_cast<double>(d_) > 1e5);
@@ -1043,13 +1070,37 @@ Vinecop::pdf_full(Eigen::MatrixXd u,
           }
         }
 
-        Eigen::VectorXd edge_pdf = edge_copula->pdf(u_e);
+        // per-edge dispatch: on the per-observation path each helper slices
+        // this edge's n x np parameter block and routes to the per-row Bicop
+        // overload; on the fixed path it calls the stored-parameter method
+        // unchanged. Discrete never arises here (per-observation requires
+        // continuous), so the _sub h-functions stay on the scalar path.
+        Eigen::MatrixXd pars_e;
+        if (per_obs) {
+          size_t np = static_cast<size_t>(edge_copula->get_parameters().size());
+          pars_e = parameters.block(b.begin, par_offset, b.size, np);
+          par_offset += np;
+        }
+        auto ec_pdf = [&]() {
+          return per_obs ? edge_copula->pdf(u_e, pars_e)
+                         : edge_copula->pdf(u_e);
+        };
+        auto ec_hfunc1 = [&]() {
+          return per_obs ? edge_copula->hfunc1(u_e, pars_e)
+                         : edge_copula->hfunc1(u_e);
+        };
+        auto ec_hfunc2 = [&]() {
+          return per_obs ? edge_copula->hfunc2(u_e, pars_e)
+                         : edge_copula->hfunc2(u_e);
+        };
+
+        Eigen::VectorXd edge_pdf = ec_pdf();
         result.pdf.segment(b.begin, b.size) =
           result.pdf.segment(b.begin, b.size).cwiseProduct(edge_pdf);
 
         // h-functions are only evaluated if needed in next step
         if (rvine_structure_.needed_hfunc1(tree, edge)) {
-          hfunc1.col(edge) = edge_copula->hfunc1(u_e);
+          hfunc1.col(edge) = ec_hfunc1();
           if (var_types[1] == "d") {
             u_e_sub = u_e;
             u_e_sub.col(1) = u_e.col(3);
@@ -1057,7 +1108,7 @@ Vinecop::pdf_full(Eigen::MatrixXd u,
           }
         }
         if (rvine_structure_.needed_hfunc2(tree, edge)) {
-          hfunc2.col(edge) = edge_copula->hfunc2(u_e);
+          hfunc2.col(edge) = ec_hfunc2();
           if (var_types[0] == "d") {
             u_e_sub = u_e;
             u_e_sub.col(0) = u_e.col(2);
@@ -1123,6 +1174,18 @@ inline Eigen::VectorXd
 Vinecop::pdf(Eigen::MatrixXd u, const size_t num_threads) const
 {
   return pdf_full(std::move(u), num_threads, false).pdf;
+}
+
+//! @brief Evaluates the copula density with per-observation parameters.
+//!
+//! Per-observation counterpart of `pdf()`; see the per-observation
+//! `pdf_full()` overload for the `parameters` layout and restrictions.
+inline Eigen::VectorXd
+Vinecop::pdf(Eigen::MatrixXd u,
+             const Eigen::MatrixXd& parameters,
+             const size_t num_threads) const
+{
+  return pdf_full(std::move(u), parameters, num_threads, false).pdf;
 }
 
 //! throws if the model has a nonparametric pair copula (see scores()).
@@ -2629,6 +2692,20 @@ Vinecop::loglik(const Eigen::MatrixXd& u, const size_t num_threads) const
   } else {
     return pdf(u, num_threads).array().log().sum();
   }
+}
+
+//! @brief Evaluates the log-likelihood with per-observation parameters.
+//!
+//! Per-observation counterpart of `loglik()`: the sum over observations of
+//! \f$ \log c(u_i; \theta_i) \f$, where row `i` of `parameters` is
+//! \f$ \theta_i \f$. See the per-observation `pdf_full()` overload for the
+//! `parameters` layout and restrictions.
+inline double
+Vinecop::loglik(const Eigen::MatrixXd& u,
+                const Eigen::MatrixXd& parameters,
+                const size_t num_threads) const
+{
+  return pdf(u, parameters, num_threads).array().log().sum();
 }
 
 //! @brief Evaluates the Akaike information criterion (AIC).

--- a/test/src_test/include/test_bicop_parametric.hpp
+++ b/test/src_test/include/test_bicop_parametric.hpp
@@ -637,6 +637,209 @@ TEST_P(ParBicopTest, derivatives_per_row_parameters_match_loop)
   EXPECT_ANY_THROW(bicop_.pdf_deriv(u, "par1", P.topRows(n - 1)));
 }
 
+// Bicop scores/gradient/Hessian are thin aggregations of the log-density
+// parameter derivatives. Verify the definitional identities (scores columns
+// are logpdf_deriv, gradient is their mean, hessian averages hessian_full),
+// the covariance/bundled-result helpers, and independent finite-difference
+// checks of the averaged gradient and Hessian.
+TEST_P(ParBicopTest, scores_gradient_hessian_match_derivatives)
+{
+  if (!needs_check_)
+    return;
+
+  auto family = bicop_.get_family();
+  auto rotation = bicop_.get_rotation();
+
+  // deterministic interior grid (derivatives explode at the boundary)
+  const Eigen::Index m = 9;
+  Eigen::MatrixXd u(m * m, 2);
+  for (Eigen::Index i = 0; i < m; ++i) {
+    for (Eigen::Index j = 0; j < m; ++j) {
+      u(i * m + j, 0) = 0.05 + 0.1 * static_cast<double>(i);
+      u(i * m + j, 1) = 0.05 + 0.1 * static_cast<double>(j);
+    }
+  }
+  const Eigen::Index n = u.rows();
+  const Eigen::Index p = bicop_.get_parameters().size();
+
+  // parameters strictly inside the bounds for stable finite differences
+  Eigen::VectorXd par(p), lb(p), ub(p);
+  if (p > 0) {
+    par = bicop_.get_parameters();
+    lb = bicop_.get_parameters_lower_bounds();
+    ub = bicop_.get_parameters_upper_bounds();
+    for (Eigen::Index k = 0; k < p; ++k) {
+      par(k) = std::min(std::max(par(k), lb(k) + 1e-2), ub(k) - 1e-2);
+    }
+  }
+  Bicop cop(family, rotation, par);
+
+  Eigen::MatrixXd s = cop.scores(u);
+  ASSERT_EQ(s.rows(), n);
+  ASSERT_EQ(s.cols(), p);
+
+  // scores columns are the log-density parameter derivatives
+  for (Eigen::Index k = 0; k < p; ++k) {
+    ASSERT_TRUE(
+      all_close(s.col(k), cop.logpdf_deriv(u, "par" + std::to_string(k + 1))))
+      << cop.str();
+  }
+
+  // gradient = observation-average of the scores; scores_full carries the same
+  // matrix; scores_cov is the mean-centered covariance
+  ASSERT_TRUE(all_close(
+    cop.gradient(u), s.colwise().mean().transpose().eval(), 1e-12, 1e-12))
+    << cop.str();
+  ASSERT_TRUE(all_close(cop.scores_full(u).scores, s)) << cop.str();
+  Eigen::MatrixXd sc = s.rowwise() - s.colwise().mean();
+  ASSERT_TRUE(
+    all_close(cop.scores_cov(u), (sc.adjoint() * sc) / static_cast<double>(n)))
+    << cop.str();
+
+  // hessian: symmetric, equals the mean of the per-observation Hessians
+  Eigen::MatrixXd H = cop.hessian(u);
+  ASSERT_EQ(H.rows(), p);
+  ASSERT_EQ(H.cols(), p);
+  ASSERT_TRUE(all_close(H, H.transpose().eval())) << cop.str();
+
+  auto hess_full = cop.hessian_full(u);
+  ASSERT_EQ(static_cast<Eigen::Index>(hess_full.size()), n);
+  Eigen::MatrixXd H_avg = Eigen::MatrixXd::Zero(p, p);
+  for (Eigen::Index i = 0; i < n; ++i) {
+    ASSERT_TRUE(all_close(hess_full[i], hess_full[i].transpose().eval()))
+      << cop.str();
+    H_avg += hess_full[i];
+  }
+  if (n > 0)
+    H_avg /= static_cast<double>(n);
+  ASSERT_TRUE(all_close(H, H_avg, 1e-12, 1e-12)) << cop.str();
+
+  if (p > 0) {
+    // gradient against a finite difference of the mean log-density
+    for (Eigen::Index k = 0; k < p; ++k) {
+      double h = 1e-4 * std::max(1.0, std::abs(par(k)));
+      Eigen::VectorXd par_p = par, par_m = par;
+      par_p(k) += h;
+      par_m(k) -= h;
+      Bicop cop_p(family, rotation, par_p), cop_m(family, rotation, par_m);
+      double fd = (cop_p.pdf(u).array().log().mean() -
+                   cop_m.pdf(u).array().log().mean()) /
+                  (2 * h);
+      ASSERT_NEAR(cop.gradient(u)(k), fd, 1e-3 * (1.0 + std::abs(fd)))
+        << cop.str();
+    }
+
+    // hessian against a finite difference of the averaged scores
+    for (Eigen::Index a = 0; a < p; ++a) {
+      for (Eigen::Index b = 0; b < p; ++b) {
+        double h = 1e-4 * std::max(1.0, std::abs(par(b)));
+        Eigen::VectorXd par_p = par, par_m = par;
+        par_p(b) += h;
+        par_m(b) -= h;
+        Bicop cop_p(family, rotation, par_p), cop_m(family, rotation, par_m);
+        double fd =
+          (cop_p.scores(u).col(a).mean() - cop_m.scores(u).col(a).mean()) /
+          (2 * h);
+        ASSERT_NEAR(H(a, b), fd, 5e-3 * (1.0 + std::abs(fd))) << cop.str();
+      }
+    }
+  }
+}
+
+// Per-row-parameter scores/gradient/Hessian must match a loop over
+// single-parameter Bicops, be thread-count-invariant, and reduce to the
+// stored-parameter path when a single parameter set is broadcast.
+TEST_P(ParBicopTest, scores_per_row_parameters_match_loop)
+{
+  if (!needs_check_)
+    return;
+  if (bicop_.get_parameters().size() == 0)
+    return;
+
+  auto family = bicop_.get_family();
+  auto rotation = bicop_.get_rotation();
+  auto var_types = bicop_.get_var_types();
+  Eigen::Index n = 100;
+  Eigen::MatrixXd u =
+    bicop_.simulate(static_cast<size_t>(n), false, { 1, 2, 3, 4, 5 });
+
+  Eigen::VectorXd lb = bicop_.get_parameters_lower_bounds();
+  Eigen::VectorXd ub = bicop_.get_parameters_upper_bounds();
+  Eigen::Index p = lb.size();
+  Eigen::VectorXd a = lb + 0.2 * (ub - lb);
+  Eigen::VectorXd c = lb + 0.6 * (ub - lb);
+  Eigen::MatrixXd P(n, p);
+  for (Eigen::Index i = 0; i < n; ++i) {
+    double w = static_cast<double>(i % 5) / 4.0;
+    P.row(i) = ((1 - w) * a + w * c).transpose();
+  }
+
+  // scores(u, P): row i is the score at (u_i, P_i)
+  Eigen::MatrixXd s = bicop_.scores(u, P);
+  ASSERT_EQ(s.rows(), n);
+  ASSERT_EQ(s.cols(), p);
+  for (Eigen::Index k = 0; k < p; ++k) {
+    ASSERT_TRUE(all_close(
+      s.col(k), bicop_.logpdf_deriv(u, "par" + std::to_string(k + 1), P)))
+      << bicop_.str();
+  }
+
+  // ground truth: loop over single-parameter Bicops
+  Eigen::MatrixXd Href = Eigen::MatrixXd::Zero(p, p);
+  auto hess_full = bicop_.hessian_full(u, P);
+  ASSERT_EQ(static_cast<Eigen::Index>(hess_full.size()), n);
+  for (Eigen::Index i = 0; i < n; ++i) {
+    Bicop bi(family, rotation, P.row(i).transpose().eval(), var_types);
+    Eigen::MatrixXd ui = u.row(i);
+    ASSERT_TRUE(all_close(s.row(i), bi.scores(ui).row(0), 1e-8, 1e-8))
+      << bicop_.str();
+    ASSERT_TRUE(all_close(hess_full[i], bi.hessian(ui), 1e-8, 1e-8))
+      << bicop_.str();
+    Href += hess_full[i];
+  }
+  Href /= static_cast<double>(n);
+  ASSERT_TRUE(all_close(bicop_.hessian(u, P), Href, 1e-10, 1e-10))
+    << bicop_.str();
+
+  // threading parity
+  ASSERT_TRUE(
+    all_close(bicop_.scores(u, P, 3), bicop_.scores(u, P, 1), 1e-12, 1e-12))
+    << bicop_.str();
+
+  // broadcasting the stored parameters matches the single-argument path
+  Eigen::MatrixXd Pb = bicop_.get_parameters().transpose().replicate(n, 1);
+  ASSERT_TRUE(all_close(bicop_.scores(u, Pb), bicop_.scores(u), 1e-10, 1e-10))
+    << bicop_.str();
+  ASSERT_TRUE(
+    all_close(bicop_.gradient(u, Pb), bicop_.gradient(u), 1e-10, 1e-10))
+    << bicop_.str();
+  ASSERT_TRUE(all_close(bicop_.hessian(u, Pb), bicop_.hessian(u), 1e-10, 1e-10))
+    << bicop_.str();
+
+  // validation errors propagate through format_parameters
+  EXPECT_ANY_THROW(bicop_.scores(u, P.topRows(n - 1)));
+}
+
+// scores/gradient/Hessian require parametric families and continuous
+// variables, mirroring the derivative preconditions.
+TEST(BicopScores, reject_discrete_and_nonparametric)
+{
+  Eigen::MatrixXd u(3, 2);
+  u << 0.2, 0.3, 0.5, 0.6, 0.7, 0.4;
+
+  Bicop tll(BicopFamily::tll);
+  EXPECT_ANY_THROW(tll.scores(u));
+  EXPECT_ANY_THROW(tll.hessian(u));
+
+  Bicop cl(BicopFamily::clayton, 0, Eigen::VectorXd::Constant(1, 2.0));
+  cl.set_var_types({ "d", "d" });
+  Eigen::MatrixXd u4(3, 4);
+  u4.leftCols(2) = u;
+  u4.rightCols(2) = (u.array() * 0.9).matrix();
+  EXPECT_ANY_THROW(cl.scores(u4));
+  EXPECT_ANY_THROW(cl.hessian_full(u4));
+}
+
 // Derivatives must match the VineCopula R implementation (BiCopDeriv,
 // BiCopDeriv2, BiCopHfuncDeriv, BiCopHfuncDeriv2). VineCopula encodes
 // rotations in the family code with negated parameters, so parameter

--- a/test/src_test/include/test_bicop_parametric.hpp
+++ b/test/src_test/include/test_bicop_parametric.hpp
@@ -840,6 +840,17 @@ TEST(BicopScores, reject_discrete_and_nonparametric)
   EXPECT_ANY_THROW(cl.hessian_full(u4));
 }
 
+// The per-row loglik overload takes num_threads by default (it was the only
+// per-row method lacking the default); calling it without the argument must
+// compile and equal the explicit single-threaded call.
+TEST(BicopPerRowParameters, loglik_default_num_threads)
+{
+  Bicop cop(BicopFamily::clayton, 0, Eigen::VectorXd::Constant(1, 2.0));
+  Eigen::MatrixXd u = cop.simulate(20, false, { 1 });
+  Eigen::MatrixXd P = cop.get_parameters().transpose().replicate(u.rows(), 1);
+  EXPECT_NEAR(cop.loglik(u, P), cop.loglik(u, P, 1), 1e-12);
+}
+
 // Derivatives must match the VineCopula R implementation (BiCopDeriv,
 // BiCopDeriv2, BiCopHfuncDeriv, BiCopHfuncDeriv2). VineCopula encodes
 // rotations in the family code with negated parameters, so parameter

--- a/test/src_test/include/test_vinecop_class.hpp
+++ b/test/src_test/include/test_vinecop_class.hpp
@@ -1306,10 +1306,14 @@ TEST(VinecopDerivatives, per_obs_rejects_discrete_and_bad_shape)
     }
   }
   EXPECT_NO_THROW(vc.scores(u, P, false, 1));
+  EXPECT_NO_THROW(vc.pdf(u, P));
+  EXPECT_NO_THROW(vc.loglik(u, P));
 
   // wrong number of columns / rows
   EXPECT_ANY_THROW(vc.scores(u, P.leftCols(npars - 1)));
   EXPECT_ANY_THROW(vc.scores(u, P.topRows(u.rows() - 1)));
+  EXPECT_ANY_THROW(vc.pdf(u, P.leftCols(npars - 1)));
+  EXPECT_ANY_THROW(vc.loglik(u, P.topRows(u.rows() - 1)));
 
   // discrete variables are rejected on the per-observation path
   Vinecop vc_disc(DVineStructure({ 1, 2, 3 }), pcs);
@@ -1319,6 +1323,99 @@ TEST(VinecopDerivatives, per_obs_rejects_discrete_and_bad_shape)
   u4.col(3) = (u.col(1).array() * 0.9).matrix();
   EXPECT_ANY_THROW(vc_disc.scores(u4, P, true, 1));
   EXPECT_ANY_THROW(vc_disc.hessian(u4, P, false, 1));
+  EXPECT_ANY_THROW(vc_disc.pdf(u4, P));
+  EXPECT_ANY_THROW(vc_disc.loglik(u4, P));
+}
+
+// Per-observation-parameter pdf/pdf_full/loglik must (a) reduce to the fixed
+// path when a single parameter vector is broadcast to every row and (b) for
+// heterogeneous per-observation parameters reproduce row i from a vine built
+// with observation i's parameter vector (and loglik = sum of those log
+// densities) — the same ground truth used for the per-observation scores.
+TEST(VinecopDerivatives, per_obs_pdf_and_loglik)
+{
+  auto P1 = [](double v) { return Eigen::VectorXd::Constant(1, v).eval(); };
+  auto pcs = Vinecop::make_pair_copula_store(5);
+  pcs[0][0] = Bicop(BicopFamily::gaussian, 0, P1(0.6));
+  pcs[0][1] = Bicop(BicopFamily::clayton, 90, P1(2.5));
+  pcs[0][2] = Bicop(BicopFamily::gumbel, 180, P1(1.8));
+  pcs[0][3] = Bicop(BicopFamily::joe, 270, P1(2.2));
+  pcs[1][0] = Bicop(BicopFamily::frank, 0, P1(4.0));
+  Eigen::VectorXd st_par(2);
+  st_par << 0.5, 6.0;
+  pcs[1][1] = Bicop(BicopFamily::student, 0, st_par);
+  pcs[1][2] = Bicop(BicopFamily::clayton, 180, P1(1.2));
+  pcs[2][0] = Bicop(BicopFamily::gumbel, 0, P1(1.4));
+  pcs[2][1] = Bicop(BicopFamily::gaussian, 0, P1(-0.3));
+  pcs[3][0] = Bicop(BicopFamily::gaussian, 0, P1(0.2));
+  Vinecop vc(DVineStructure({ 1, 2, 3, 4, 5 }), pcs);
+  auto u = vc.simulate(50, false, 1, { 42, 1, 2 });
+  const Eigen::Index n = u.rows();
+  const size_t npars = static_cast<size_t>(vc.get_npars());
+
+  Eigen::VectorXd theta0(npars), lb_flat(npars), ub_flat(npars);
+  {
+    size_t idx = 0;
+    for (size_t t = 0; t < 4; ++t) {
+      for (size_t e = 0; e < 4 - t; ++e) {
+        auto pr = pcs[t][e].get_parameters();
+        auto lb = pcs[t][e].get_parameters_lower_bounds();
+        auto ub = pcs[t][e].get_parameters_upper_bounds();
+        for (Eigen::Index p = 0; p < pr.size(); ++p) {
+          theta0(idx) = pr(p);
+          lb_flat(idx) = lb(p);
+          ub_flat(idx) = ub(p);
+          idx++;
+        }
+      }
+    }
+  }
+
+  // (a) broadcasting the stored parameters reduces to the fixed-parameter path
+  Eigen::MatrixXd P0 = theta0.transpose().replicate(n, 1);
+  EXPECT_TRUE(all_close(vc.pdf(u, P0), vc.pdf(u), 1e-10, 1e-10));
+  EXPECT_TRUE(all_close(vc.pdf_full(u, P0, 1).pdf, vc.pdf(u), 1e-10, 1e-10));
+  double ll_fixed = vc.loglik(u);
+  EXPECT_NEAR(vc.loglik(u, P0), ll_fixed, 1e-8 * (1.0 + std::abs(ll_fixed)));
+  // threading determinism on the per-observation path
+  EXPECT_TRUE(all_close(vc.pdf(u, P0, 3), vc.pdf(u, P0, 1), 1e-12));
+
+  // (b) heterogeneous per-observation parameters (interior-clamped), compared
+  // row by row against a vine rebuilt with that observation's parameters
+  Eigen::MatrixXd P(n, npars);
+  for (Eigen::Index i = 0; i < n; ++i) {
+    double w = 0.85 + 0.30 * static_cast<double>(i % 4) / 3.0; // [0.85, 1.15]
+    for (size_t k = 0; k < npars; ++k) {
+      double lo = lb_flat(k) + 1e-2 * (ub_flat(k) - lb_flat(k));
+      double hi = ub_flat(k) - 1e-2 * (ub_flat(k) - lb_flat(k));
+      P(i, k) = std::min(std::max(theta0(k) * w, lo), hi);
+    }
+  }
+
+  Eigen::VectorXd pdf_po = vc.pdf(u, P, 1);
+  double ll_po = vc.loglik(u, P, 1);
+  EXPECT_TRUE(
+    all_close(vc.pdf(u, P, 3), pdf_po, 1e-12)); // threading determinism
+  double ll_ref = 0.0;
+  for (Eigen::Index i = 0; i < n; ++i) {
+    auto pcs_i = pcs;
+    size_t idx = 0;
+    for (size_t t = 0; t < 4; ++t) {
+      for (size_t e = 0; e < 4 - t; ++e) {
+        Eigen::VectorXd pr = pcs_i[t][e].get_parameters();
+        for (Eigen::Index p = 0; p < pr.size(); ++p) {
+          pr(p) = P(i, idx++);
+        }
+        pcs_i[t][e].set_parameters(pr);
+      }
+    }
+    Vinecop vc_i(vc.get_rvine_structure(), pcs_i);
+    double pdf_i = vc_i.pdf(u.row(i))(0);
+    EXPECT_NEAR(pdf_po(i), pdf_i, 1e-9 * (1.0 + std::abs(pdf_i)))
+      << "row " << i;
+    ll_ref += std::log(pdf_i);
+  }
+  EXPECT_NEAR(ll_po, ll_ref, 1e-8 * (1.0 + std::abs(ll_ref)));
 }
 
 TEST_F(VinecopTest, aic_bic_are_correct)

--- a/test/src_test/include/test_vinecop_class.hpp
+++ b/test/src_test/include/test_vinecop_class.hpp
@@ -1157,6 +1157,170 @@ TEST(VinecopDerivatives, fallback_paths_run)
   EXPECT_TRUE(s_disc_full.allFinite());
 }
 
+// The per-observation-parameter overloads must (a) reduce to the fixed-
+// parameter path when a single parameter vector is broadcast to every row and
+// (b) for heterogeneous per-observation parameters, reproduce row i from a
+// vine built with observation i's parameter vector — the unforgiving ground
+// truth that the whole per-observation cascade is correct, for both
+// step_wise settings and for scores and the (per-observation) Hessian.
+TEST(VinecopDerivatives, per_obs_scores_and_hessian)
+{
+  auto P1 = [](double v) { return Eigen::VectorXd::Constant(1, v).eval(); };
+  auto pcs = Vinecop::make_pair_copula_store(5);
+  pcs[0][0] = Bicop(BicopFamily::gaussian, 0, P1(0.6));
+  pcs[0][1] = Bicop(BicopFamily::clayton, 90, P1(2.5));
+  pcs[0][2] = Bicop(BicopFamily::gumbel, 180, P1(1.8));
+  pcs[0][3] = Bicop(BicopFamily::joe, 270, P1(2.2));
+  pcs[1][0] = Bicop(BicopFamily::frank, 0, P1(4.0));
+  Eigen::VectorXd st_par(2);
+  st_par << 0.5, 6.0;
+  pcs[1][1] = Bicop(BicopFamily::student, 0, st_par);
+  pcs[1][2] = Bicop(BicopFamily::clayton, 180, P1(1.2));
+  pcs[2][0] = Bicop(BicopFamily::gumbel, 0, P1(1.4));
+  pcs[2][1] = Bicop(BicopFamily::gaussian, 0, P1(-0.3));
+  pcs[3][0] = Bicop(BicopFamily::gaussian, 0, P1(0.2));
+  Vinecop vc(DVineStructure({ 1, 2, 3, 4, 5 }), pcs);
+  auto u = vc.simulate(50, false, 1, { 42, 1, 2 });
+  const Eigen::Index n = u.rows();
+  const size_t npars = static_cast<size_t>(vc.get_npars());
+
+  // flatten the stored parameters (and their bounds) in the (t, e, p) column
+  // order that scores() and the `parameters` argument share
+  Eigen::VectorXd theta0(npars), lb_flat(npars), ub_flat(npars);
+  {
+    size_t idx = 0;
+    for (size_t t = 0; t < 4; ++t) {
+      for (size_t e = 0; e < 4 - t; ++e) {
+        auto pr = pcs[t][e].get_parameters();
+        auto lb = pcs[t][e].get_parameters_lower_bounds();
+        auto ub = pcs[t][e].get_parameters_upper_bounds();
+        for (Eigen::Index p = 0; p < pr.size(); ++p) {
+          theta0(idx) = pr(p);
+          lb_flat(idx) = lb(p);
+          ub_flat(idx) = ub(p);
+          idx++;
+        }
+      }
+    }
+  }
+
+  // (a) broadcasting the stored parameters reduces to the fixed-parameter path
+  Eigen::MatrixXd P0 = theta0.transpose().replicate(n, 1);
+  for (bool sw : { true, false }) {
+    EXPECT_TRUE(
+      all_close(vc.scores(u, P0, sw, 1), vc.scores(u, sw, 1), 1e-10, 1e-10));
+    EXPECT_TRUE(all_close(
+      vc.gradient(u, P0, sw, 1), vc.gradient(u, sw, 1), 1e-10, 1e-10));
+    EXPECT_TRUE(
+      all_close(vc.hessian(u, P0, sw, 1), vc.hessian(u, sw, 1), 1e-10, 1e-10));
+    EXPECT_TRUE(all_close(
+      vc.scores_cov(u, P0, sw, 1), vc.scores_cov(u, sw, 1), 1e-10, 1e-10));
+    auto hf_pr = vc.hessian_full(u, P0, sw, 1);
+    auto hf_fx = vc.hessian_full(u, sw, 1);
+    for (size_t t = 0; t < 4; ++t) {
+      for (size_t e = 0; e < 4 - t; ++e) {
+        for (size_t p = 0; p < hf_fx(t, e).size(); ++p) {
+          EXPECT_TRUE(all_close(hf_pr(t, e)[p], hf_fx(t, e)[p], 1e-10, 1e-10));
+        }
+      }
+    }
+  }
+
+  // threading determinism on the per-observation path
+  EXPECT_TRUE(
+    all_close(vc.scores(u, P0, false, 3), vc.scores(u, P0, false, 1), 1e-12));
+  EXPECT_TRUE(
+    all_close(vc.scores(u, P0, true, 3), vc.scores(u, P0, true, 1), 1e-12));
+
+  // (b) heterogeneous per-observation parameters (interior-clamped), compared
+  // row by row against a vine rebuilt with that observation's parameters
+  Eigen::MatrixXd P(n, npars);
+  for (Eigen::Index i = 0; i < n; ++i) {
+    double w = 0.85 + 0.30 * static_cast<double>(i % 4) / 3.0; // [0.85, 1.15]
+    for (size_t k = 0; k < npars; ++k) {
+      double lo = lb_flat(k) + 1e-2 * (ub_flat(k) - lb_flat(k));
+      double hi = ub_flat(k) - 1e-2 * (ub_flat(k) - lb_flat(k));
+      P(i, k) = std::min(std::max(theta0(k) * w, lo), hi);
+    }
+  }
+
+  for (bool sw : { true, false }) {
+    Eigen::MatrixXd s = vc.scores(u, P, sw, 1);
+    auto hf = vc.hessian_full(u, P, sw, 1);
+    // threading determinism with heterogeneous parameters
+    EXPECT_TRUE(all_close(vc.scores(u, P, sw, 3), s, 1e-12));
+    for (Eigen::Index i = 0; i < n; ++i) {
+      auto pcs_i = pcs;
+      size_t idx = 0;
+      for (size_t t = 0; t < 4; ++t) {
+        for (size_t e = 0; e < 4 - t; ++e) {
+          Eigen::VectorXd pr = pcs_i[t][e].get_parameters();
+          for (Eigen::Index p = 0; p < pr.size(); ++p) {
+            pr(p) = P(i, idx++);
+          }
+          pcs_i[t][e].set_parameters(pr);
+        }
+      }
+      Vinecop vc_i(vc.get_rvine_structure(), pcs_i);
+      Eigen::MatrixXd ui = u.row(i);
+      EXPECT_TRUE(
+        all_close(s.row(i), vc_i.scores(ui, sw, 1).row(0), 1e-9, 1e-9))
+        << "row " << i;
+      auto hi = vc_i.hessian_full(ui, sw, 1);
+      for (size_t t = 0; t < 4; ++t) {
+        for (size_t e = 0; e < 4 - t; ++e) {
+          for (size_t p = 0; p < hi(t, e).size(); ++p) {
+            EXPECT_TRUE(
+              all_close(hf(t, e)[p].row(i), hi(t, e)[p].row(0), 1e-9, 1e-9))
+              << "row " << i << " edge (" << t << ", " << e << ") par " << p;
+          }
+        }
+      }
+    }
+  }
+}
+
+// The per-observation path rejects discrete variables (its finite-difference
+// fallback would mutate shared parameters) and validates the n x npars shape.
+TEST(VinecopDerivatives, per_obs_rejects_discrete_and_bad_shape)
+{
+  auto P1 = [](double v) { return Eigen::VectorXd::Constant(1, v).eval(); };
+  auto pcs = Vinecop::make_pair_copula_store(3);
+  pcs[0][0] = Bicop(BicopFamily::clayton, 0, P1(2.0));
+  pcs[0][1] = Bicop(BicopFamily::gaussian, 0, P1(0.5));
+  pcs[1][0] = Bicop(BicopFamily::gumbel, 0, P1(1.5));
+  Vinecop vc(DVineStructure({ 1, 2, 3 }), pcs);
+  auto u = vc.simulate(30, false, 1, { 5 });
+  const size_t npars = static_cast<size_t>(vc.get_npars());
+
+  Eigen::MatrixXd P(u.rows(), npars);
+  {
+    size_t idx = 0;
+    for (size_t t = 0; t < 2; ++t) {
+      for (size_t e = 0; e < 2 - t; ++e) {
+        auto pr = pcs[t][e].get_parameters();
+        for (Eigen::Index p = 0; p < pr.size(); ++p) {
+          P.col(idx++).setConstant(pr(p));
+        }
+      }
+    }
+  }
+  EXPECT_NO_THROW(vc.scores(u, P, false, 1));
+
+  // wrong number of columns / rows
+  EXPECT_ANY_THROW(vc.scores(u, P.leftCols(npars - 1)));
+  EXPECT_ANY_THROW(vc.scores(u, P.topRows(u.rows() - 1)));
+
+  // discrete variables are rejected on the per-observation path
+  Vinecop vc_disc(DVineStructure({ 1, 2, 3 }), pcs);
+  vc_disc.set_var_types({ "c", "d", "c" });
+  Eigen::MatrixXd u4(u.rows(), 4);
+  u4.leftCols(3) = u;
+  u4.col(3) = (u.col(1).array() * 0.9).matrix();
+  EXPECT_ANY_THROW(vc_disc.scores(u4, P, true, 1));
+  EXPECT_ANY_THROW(vc_disc.hessian(u4, P, false, 1));
+}
+
 TEST_F(VinecopTest, aic_bic_are_correct)
 {
   int d = 7;


### PR DESCRIPTION
## Summary

Fills two gaps left by the recent derivative work (#675/#681/#683/#687):

1. **`Bicop` scores/gradient/Hessian.** The per-observation analytic derivatives existed, but there was no aggregated score/gradient/Hessian API on the bivariate facade — only on `Vinecop`. Adds `scores` (n×p), `gradient` (p), `hessian` / `hessian_full` (averaged and per-observation p×p), `scores_cov`, and `scores_full` as thin aggregations of `logpdf_deriv`/`logpdf_deriv2`, mirroring the `Vinecop` asymptotic API. Each also has a **per-row-parameter** overload. Parametric families with continuous variables only (inherits the existing derivative preconditions).

2. **Parameter-vectorized scores/Hessian.** Adds per-observation-parameter overloads of `Vinecop::scores`, `scores_full`, `gradient`, `hessian`, `hessian_full`, and `scores_cov`, taking an `n × npars` matrix (one full-vine parameter vector per observation, columns in the `(tree, edge, parameter)` order of `scores()`). Row `i` is evaluated as if the vine carried that row's parameters — enabling scores/Hessians for conditional/covariate vine models where the pair-copula parameters vary by observation. Continuous, all-parametric models only (discrete variables and nonparametric pair copulas are rejected).

## No regression to the fixed-parameter path

The shared forward walk `build_deriv_cache` gains an optional per-observation parameter matrix. When supplied, each edge's density, h-function, **and** derivative evaluations switch to the matching per-row `Bicop` overloads; when empty (the default), the existing scalar path runs unchanged, so the 99% of users who don't need per-observation parameters pay nothing. All downstream cascades (scores, both Hessian variants, `scores_cov`) and the `DerivCache`/`ScoresResult` data structures are reused unchanged.

## Tests

- **Bicop:** scores/gradient/Hessian vs finite differences and vs a per-row loop over single-parameter copulas, for all parametric families × rotations; threading parity, broadcast reduction, discrete/nonparametric rejection.
- **Vinecop:** per-observation `scores` and `hessian_full` checked row-by-row against a vine rebuilt with that observation's parameters (both `step_wise` settings); fixed-path parity when a single parameter vector is broadcast; thread-count determinism; discrete/shape rejection. All pre-existing derivative tests continue to pass unchanged.

Locally: `clang-format-14` clean; Debug (ASAN) build; 97 Bicop + 11 Vinecop targeted tests pass (the R-oracle parity test is left to CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)