### PR TITLE
fix(bicop): handle edge-case parameter shapes in per-row evaluation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -134,6 +134,15 @@
 
 ### BUG FIXES
 
+* Fix out-of-bounds parameter indexing in the per-row bivariate evaluation of
+  discrete leaves (`pdf_c_d`, `pdf_d_d`, and the discrete branches of `hfunc1` /
+  `hfunc2`) for families whose parameter matrix is neither `1 x p` nor `n x p`:
+  parameterless families (independence, `0 x 0`) and nonparametric families
+  (TLL, a `p x p` grid). Also validate parameter rows and columns
+  unconditionally in `check_parameters`, so a same-size-but-transposed shape
+  (`1 x p` vs `p x 1`) is rejected instead of reaching the coefficient-wise
+  bound checks (#700)
+
 * Fix an out-of-bounds memory access in the bivariate h-inverse for mixed
   discrete/continuous copulas whose inverse is computed numerically (e.g. Frank,
   the BB families, Tawn): a continuous h-inverse re-entered the discrete

--- a/include/vinecopulib/bicop/implementation/abstract.ipp
+++ b/include/vinecopulib/bicop/implementation/abstract.ipp
@@ -284,9 +284,10 @@ AbstractBicop::pdf_c_d(const Eigen::MatrixXd& u,
     udiff = (u.col(1) - u.col(3)).cwiseAbs();
   }
 
-  const bool bc = (parameters.rows() == 1);
+  const bool bc = (parameters.rows() != u.rows());
   for (Eigen::Index i = 0; i < u.rows(); i++) {
-    const Eigen::MatrixXd par_i = parameters.row(bc ? 0 : i);
+    const Eigen::MatrixXd par_i =
+        parameters.rows() == 0 ? parameters : parameters.row(bc ? 0 : i);
     if (udiff(i) > 5e-5) {
       if (var_types_[0] != "c") {
         pdf(i) =
@@ -312,9 +313,10 @@ AbstractBicop::pdf_d_d(const Eigen::MatrixXd& u,
   Eigen::MatrixXd umin = u.rightCols(2);
   Eigen::MatrixXd udiff = (umax - umin).cwiseAbs();
 
-  const bool bc = (parameters.rows() == 1);
+  const bool bc = (parameters.rows() != u.rows());
   for (Eigen::Index i = 0; i < u.rows(); i++) {
-    const Eigen::MatrixXd par_i = parameters.row(bc ? 0 : i);
+    const Eigen::MatrixXd par_i =
+        parameters.rows() == 0 ? parameters : parameters.row(bc ? 0 : i);
     // the difference quotient can be instable, use derivative if denominator
     // too small
     if (udiff.row(i).maxCoeff() < 5e-5) {
@@ -352,9 +354,10 @@ AbstractBicop::hfunc1(const Eigen::MatrixXd& u,
     auto u1diff = (uu.col(0) - uu.col(2)).cwiseAbs();
     Eigen::VectorXd h(u.rows());
 
-    const bool bc = (parameters.rows() == 1);
+    const bool bc = (parameters.rows() != u.rows());
     for (Eigen::Index i = 0; i < u.rows(); i++) {
-      const Eigen::MatrixXd par_i = parameters.row(bc ? 0 : i);
+      const Eigen::MatrixXd par_i =
+        parameters.rows() == 0 ? parameters : parameters.row(bc ? 0 : i);
       if (std::abs(u1diff(i)) > 5e-5) {
         h(i) = cdf(uu.row(i).leftCols(2), par_i)(0) -
                cdf(uu.row(i).rightCols(2), par_i)(0);
@@ -380,9 +383,10 @@ AbstractBicop::hfunc2(const Eigen::MatrixXd& u,
     auto u2diff = (uu.col(1) - uu.col(3)).cwiseAbs();
     Eigen::VectorXd h(u.rows());
 
-    const bool bc = (parameters.rows() == 1);
+    const bool bc = (parameters.rows() != u.rows());
     for (Eigen::Index i = 0; i < u.rows(); i++) {
-      const Eigen::MatrixXd par_i = parameters.row(bc ? 0 : i);
+      const Eigen::MatrixXd par_i =
+        parameters.rows() == 0 ? parameters : parameters.row(bc ? 0 : i);
       if (u2diff(i) > 5e-5) {
         h(i) = cdf(uu.row(i).leftCols(2), par_i)(0) -
                cdf(uu.row(i).rightCols(2), par_i)(0);

--- a/include/vinecopulib/bicop/implementation/abstract.ipp
+++ b/include/vinecopulib/bicop/implementation/abstract.ipp
@@ -287,7 +287,7 @@ AbstractBicop::pdf_c_d(const Eigen::MatrixXd& u,
   const bool bc = (parameters.rows() != u.rows());
   for (Eigen::Index i = 0; i < u.rows(); i++) {
     const Eigen::MatrixXd par_i =
-        parameters.rows() == 0 ? parameters : parameters.row(bc ? 0 : i);
+      parameters.rows() == 0 ? parameters : parameters.row(bc ? 0 : i);
     if (udiff(i) > 5e-5) {
       if (var_types_[0] != "c") {
         pdf(i) =
@@ -316,7 +316,7 @@ AbstractBicop::pdf_d_d(const Eigen::MatrixXd& u,
   const bool bc = (parameters.rows() != u.rows());
   for (Eigen::Index i = 0; i < u.rows(); i++) {
     const Eigen::MatrixXd par_i =
-        parameters.rows() == 0 ? parameters : parameters.row(bc ? 0 : i);
+      parameters.rows() == 0 ? parameters : parameters.row(bc ? 0 : i);
     // the difference quotient can be instable, use derivative if denominator
     // too small
     if (udiff.row(i).maxCoeff() < 5e-5) {

--- a/include/vinecopulib/bicop/implementation/parametric.ipp
+++ b/include/vinecopulib/bicop/implementation/parametric.ipp
@@ -271,23 +271,25 @@ ParBicop::check_parameters(const Eigen::MatrixXd& parameters)
 inline void
 ParBicop::check_parameters_size(const Eigen::MatrixXd& parameters)
 {
-  if (parameters.size() != parameters_.size()) {
-    if (parameters.rows() != parameters_.rows()) {
-      std::stringstream message;
-      message << "parameters have has wrong number of rows "
-              << "for " << get_family_name() << " copula; "
-              << "expected: " << parameters_.rows() << ", "
-              << "actual: " << parameters.rows() << std::endl;
-      throw std::runtime_error(message.str().c_str());
-    }
-    if (parameters.cols() != parameters_.cols()) {
-      std::stringstream message;
-      message << "parameters have wrong number of columns "
-              << "for " << get_family_name() << " copula; "
-              << "expected: " << parameters_.cols() << ", "
-              << "actual: " << parameters.cols() << std::endl;
-      throw std::runtime_error(message.str().c_str());
-    }
+  // Validate rows and cols unconditionally: a same-size-but-transposed shape
+  // (e.g. 1 x p vs p x 1) would otherwise slip through and reach the
+  // coefficient-wise bound comparisons in check_parameters_lower/_upper with
+  // mismatched shapes (an out-of-bounds read under NDEBUG).
+  if (parameters.rows() != parameters_.rows()) {
+    std::stringstream message;
+    message << "parameters have has wrong number of rows "
+            << "for " << get_family_name() << " copula; "
+            << "expected: " << parameters_.rows() << ", "
+            << "actual: " << parameters.rows() << std::endl;
+    throw std::runtime_error(message.str().c_str());
+  }
+  if (parameters.cols() != parameters_.cols()) {
+    std::stringstream message;
+    message << "parameters have wrong number of columns "
+            << "for " << get_family_name() << " copula; "
+            << "expected: " << parameters_.cols() << ", "
+            << "actual: " << parameters.cols() << std::endl;
+    throw std::runtime_error(message.str().c_str());
   }
 }
 

--- a/test/src_test/include/test_bicop_sanity_checks.hpp
+++ b/test/src_test/include/test_bicop_sanity_checks.hpp
@@ -25,6 +25,19 @@ TEST(bicop_sanity_checks, catches_wrong_parameter_size)
   }
 }
 
+TEST(bicop_sanity_checks, catches_transposed_parameter_shape)
+{
+  // Regression test for PR #700: a same-size but transposed shape (1 x 2
+  // instead of the expected 2 x 1) must be rejected up front. It used to slip
+  // past the size check (equal total size) and reach the coefficient-wise
+  // bound comparisons with mismatched dimensions (an out-of-bounds read).
+  auto par = (Eigen::MatrixXd(2, 1) << 0.5, 4.0).finished();
+  auto bc = Bicop(BicopFamily::student, 0, par);
+  Eigen::MatrixXd transposed = bc.get_parameters().transpose(); // 1 x 2
+  ASSERT_EQ(transposed.size(), bc.get_parameters().size());
+  EXPECT_ANY_THROW(bc.set_parameters(transposed));
+}
+
 TEST(bicop_sanity_checks, catches_parameters_out_of_bounds)
 {
   auto cop = Bicop(BicopFamily::gaussian);

--- a/test/src_test/include/test_discrete.hpp
+++ b/test/src_test/include/test_discrete.hpp
@@ -334,4 +334,67 @@ TEST(discrete, check_d_d_stability)
   EXPECT_NEAR(vine2, bicop, 1e-2);
 }
 
+// Regression test for PR #700: the per-row parameter evaluation in the
+// discrete leaves (pdf_c_d, pdf_d_d and the discrete branches of hfunc1 /
+// hfunc2) must not index the parameter matrix row-by-row for families whose
+// parameter matrix is neither 1 x p nor n x p. Two such shapes exist:
+//   - a parameterless family (independence, 0 x 0 parameters); and
+//   - a nonparametric family (tll, a 30 x 30 interpolation grid).
+// Both used to read out of bounds (Eigen abort with assertions on, silent UB
+// under -DNDEBUG) whenever a discrete variable was involved.
+TEST(discrete, edge_case_parameter_shapes)
+{
+  // Discretized sample from a Clayton copula.
+  auto clayton =
+    Bicop(BicopFamily::clayton, 0, Eigen::VectorXd::Constant(1, 3));
+  auto u = clayton.simulate(200, true, { 1 });
+
+  Eigen::MatrixXd u_disc(u.rows(), 4);
+  u_disc.col(0) = (u.col(0).array() * 5).ceil() / 5;
+  u_disc.col(2) = (u.col(0).array() * 5).floor() / 5;
+  u_disc.col(1) = (u.col(1).array() * 5).ceil() / 5;
+  u_disc.col(3) = (u.col(1).array() * 5).floor() / 5;
+
+  // d_c / c_d layouts reuse the discrete corner columns.
+  Eigen::MatrixXd u_dc(u.rows(), 3);
+  u_dc.col(0) = u_disc.col(0);
+  u_dc.col(1) = u.col(1);
+  u_dc.col(2) = u_disc.col(2);
+
+  Eigen::MatrixXd u_cd(u.rows(), 4);
+  u_cd.col(0) = u.col(0);
+  u_cd.col(2) = u.col(0);
+  u_cd.col(1) = u_disc.col(1);
+  u_cd.col(3) = u_disc.col(3);
+
+  // Parameterless family: independence has a 0 x 0 parameter matrix. Its
+  // density is 1 everywhere, discrete margins included, in every layout.
+  auto check_indep = [](const std::vector<std::string>& var_types,
+                        const Eigen::MatrixXd& uu) {
+    auto indep = Bicop(BicopFamily::indep);
+    indep.set_var_types(var_types);
+    Eigen::VectorXd pdf;
+    ASSERT_NO_THROW(pdf = indep.pdf(uu));
+    EXPECT_LE((pdf.array() - 1.0).abs().maxCoeff(), 1e-10);
+    EXPECT_NO_THROW(indep.hfunc1(uu));
+    EXPECT_NO_THROW(indep.hfunc2(uu));
+  };
+  check_indep({ "d", "d" }, u_disc);
+  check_indep({ "c", "d" }, u_cd);
+  check_indep({ "d", "c" }, u_dc);
+
+  // Nonparametric family: tll stores a 30 x 30 grid. Evaluating on more than
+  // 30 rows must not index the grid row-by-row.
+  ASSERT_GT(u_disc.rows(), 30);
+  auto tll = Bicop();
+  tll.set_var_types({ "d", "d" });
+  tll.select(u_disc, FitControlsBicop({ BicopFamily::tll }));
+  Eigen::VectorXd pdf_tll;
+  ASSERT_NO_THROW(pdf_tll = tll.pdf(u_disc));
+  EXPECT_GE(pdf_tll.minCoeff(), 0);
+  EXPECT_TRUE(pdf_tll.allFinite());
+  EXPECT_NO_THROW(tll.hfunc1(u_disc));
+  EXPECT_NO_THROW(tll.hfunc2(u_disc));
+}
+
 }


### PR DESCRIPTION
The per-row parameter evaluation added for vectorized parameters mishandled two parameter-matrix shapes.

**Discrete leaves** (`pdf_c_d`, `pdf_d_d`, discrete branches of `hfunc1`/`hfunc2` in `abstract.ipp`) index the parameter matrix per row assuming 1 or `n` rows. A parameterless family (independence — `get_parameters()` is `0×0`) or a nonparametric family (tll — `p×p` grid with `p ≠ n`) reads out of bounds: a hard abort under Eigen assertions, silent UB under `-DNDEBUG`. Now broadcasts unless there is exactly one parameter set per row, and passes the empty matrix through for parameterless families (indep/kernel ignore it anyway).

**`check_parameters_size`** only compared rows/cols when the total size differed, so a same-size transposed shape (`1×p` vs `p×1`) reached the coefficient-wise comparisons in `check_parameters_lower`/`_upper` — an out-of-bounds read under `-DNDEBUG`. Now validates rows and cols unconditionally.

### Tests

Both cases are covered by regression tests that abort (out-of-bounds row access / Eigen assertion) on the pre-fix code:

- `discrete.edge_case_parameter_shapes` — evaluates the discrete leaves for independence (`0×0` parameters; density must be 1 in every `d_d`/`c_d`/`d_c` layout) and for a fitted tll copula on more rows than the `30×30` grid.
- `bicop_sanity_checks.catches_transposed_parameter_shape` — a same-size transposed shape (`1×2` vs `2×1`) must throw rather than reach the bound checks.

Surfaced while debugging vectorized parameters in the R interface; companion PR: vinecopulib/rvinecopulib#322.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
