### PR TITLE
perf(vinecop): speed up the RVineTrees peel (byte-identical)

### DIFF
--- a/include/vinecopulib/misc/tools_stl.hpp
+++ b/include/vinecopulib/misc/tools_stl.hpp
@@ -51,6 +51,17 @@ intersect(std::vector<T> x, std::vector<T> y)
   return common;
 }
 
+//! @brief Inserts `x` into the sorted vector `v`, keeping it sorted and unique
+//! (mirrors `std::set::insert`).
+template<class T>
+void
+insert_sorted(std::vector<T>& v, const T& x)
+{
+  auto it = std::lower_bound(v.begin(), v.end(), x);
+  if (it == v.end() || *it != x)
+    v.insert(it, x);
+}
+
 template<class T>
 size_t
 find_position(T x, const std::vector<T>& vec)

--- a/include/vinecopulib/vinecop/implementation/rvine_trees.ipp
+++ b/include/vinecopulib/vinecop/implementation/rvine_trees.ipp
@@ -21,9 +21,10 @@ inline RVineTrees::RVineTrees(const std::vector<size_t>& order,
   trees_.resize(trunc_lvl_);
   for (size_t t = 0; t < trunc_lvl_; ++t) {
     for (size_t e = 0; e < d_ - 1 - t; ++e) {
-      std::set<size_t> conditioning;
+      std::vector<size_t> conditioning;
+      conditioning.reserve(t);
       for (size_t k = 0; k < t; ++k)
-        conditioning.insert(struct_array(k, e));
+        conditioning.push_back(struct_array(k, e));
       trees_[t].push_back(Edge(order[e], struct_array(t, e), conditioning));
     }
   }
@@ -48,9 +49,10 @@ inline RVineTrees::RVineTrees(
   trees_.resize(trunc_lvl_);
   for (size_t t = 0; t < trunc_lvl_; ++t) {
     for (size_t e = 0; e < d_ - 1 - t; ++e) {
-      std::set<size_t> conditioning;
+      std::vector<size_t> conditioning;
+      conditioning.reserve(t);
       for (size_t k = 0; k < t; ++k)
-        conditioning.insert(struct_array(k, e));
+        conditioning.push_back(struct_array(k, e));
       trees_[t].push_back(
         Edge(order[e], struct_array(t, e), conditioning, pair_copulas[t][e]));
     }
@@ -135,11 +137,13 @@ RVineTrees::peel(const DiagonalPolicy& diagonal_policy,
     // its leaf endpoint(s) as diagonal options (endpoint `a` before `b`)
     std::vector<std::vector<size_t>> leaf_edges;
     for (const auto& e : tree.edges) {
-      const Edge& ed = std::get<2>(e);
+      if (e.consumed)
+        continue;
+      const Edge& ed = *e.edge;
       std::vector<size_t> options;
-      if (tree.degrees[std::get<0>(e)] == 1)
+      if (tree.degrees[e.node1] == 1)
         options.push_back(ed.a);
-      if (tree.degrees[std::get<1>(e)] == 1)
+      if (tree.degrees[e.node2] == 1)
         options.push_back(ed.b);
       if (!options.empty())
         leaf_edges.push_back(std::move(options));
@@ -153,12 +157,14 @@ RVineTrees::peel(const DiagonalPolicy& diagonal_policy,
 
     // locate the (unique) leaf edge carrying `diag`, consume it, and seed the
     // running conditioning set for the descent
-    std::set<size_t> check_set;
+    std::vector<size_t> check_set;
     bool found = false;
-    for (auto it = tree.edges.begin(); it != tree.edges.end(); ++it) {
-      const Edge& ed = std::get<2>(*it);
-      bool as_a = (tree.degrees[std::get<0>(*it)] == 1) && (ed.a == diag);
-      bool as_b = (tree.degrees[std::get<1>(*it)] == 1) && (ed.b == diag);
+    for (auto& e : tree.edges) {
+      if (e.consumed)
+        continue;
+      const Edge& ed = *e.edge;
+      bool as_a = (tree.degrees[e.node1] == 1) && (ed.a == diag);
+      bool as_b = (tree.degrees[e.node2] == 1) && (ed.b == diag);
       if (!as_a && !as_b)
         continue;
       struct_array(t - 1, col) = as_a ? ed.b : ed.a;
@@ -168,9 +174,9 @@ RVineTrees::peel(const DiagonalPolicy& diagonal_policy,
           pair_copulas[t - 1][col].flip();
       }
       check_set = ed.C;
-      tree.degrees[std::get<0>(*it)]--;
-      tree.degrees[std::get<1>(*it)]--;
-      tree.edges.erase(it);
+      tree.degrees[e.node1]--;
+      tree.degrees[e.node2]--;
+      e.consumed = true;
       found = true;
       break;
     }
@@ -184,14 +190,13 @@ RVineTrees::peel(const DiagonalPolicy& diagonal_policy,
     for (size_t k = 1; k < t; ++k) {
       size_t tree_idx = t - 1 - k;
       AugmentedTree& ltree = augmented[tree_idx];
-      check_set.insert(diag);
+      tools_stl::insert_sorted(check_set, diag);
       bool matched = false;
-      for (auto it = ltree.edges.begin(); it != ltree.edges.end(); ++it) {
-        const Edge& ed = std::get<2>(*it);
-        std::set<size_t> all_indices = ed.C;
-        all_indices.insert(ed.a);
-        all_indices.insert(ed.b);
-        if (all_indices != check_set)
+      for (auto& e : ltree.edges) {
+        if (e.consumed)
+          continue;
+        const Edge& ed = *e.edge;
+        if (ed.all_indices != check_set)
           continue;
         struct_array(tree_idx, col) = (ed.a == diag) ? ed.b : ed.a;
         if (carry_copulas) {
@@ -200,9 +205,9 @@ RVineTrees::peel(const DiagonalPolicy& diagonal_policy,
             pair_copulas[tree_idx][col].flip();
         }
         check_set = ed.C;
-        ltree.degrees[std::get<0>(*it)]--;
-        ltree.degrees[std::get<1>(*it)]--;
-        ltree.edges.erase(it);
+        ltree.degrees[e.node1]--;
+        ltree.degrees[e.node2]--;
+        e.consumed = true;
         matched = true;
         break;
       }
@@ -221,19 +226,18 @@ RVineTrees::peel(const DiagonalPolicy& diagonal_policy,
 
 //! @brief Builds the map from `(variable, conditioning ∪ partner)` to the edge
 //! index in the previous tree (i.e. the incident node in the line graph).
-inline std::map<std::pair<size_t, std::set<size_t>>, size_t>
-RVineTrees::build_lookup(
-  const std::vector<std::tuple<size_t, size_t, Edge>>& edges) const
+inline std::map<std::pair<size_t, std::vector<size_t>>, size_t>
+RVineTrees::build_lookup(const std::vector<AugmentedEdge>& edges) const
 {
-  std::map<std::pair<size_t, std::set<size_t>>, size_t> lookup;
+  std::map<std::pair<size_t, std::vector<size_t>>, size_t> lookup;
   for (size_t i = 0; i < edges.size(); ++i) {
-    const Edge& ed = std::get<2>(edges[i]);
-    std::set<size_t> key_a = ed.C;
-    key_a.insert(ed.b);
-    lookup[{ ed.a, key_a }] = i;
-    std::set<size_t> key_b = ed.C;
-    key_b.insert(ed.a);
-    lookup[{ ed.b, key_b }] = i;
+    const Edge& ed = *edges[i].edge;
+    std::vector<size_t> key = ed.C; // already sorted ascending
+    tools_stl::insert_sorted(key, ed.b);
+    lookup[{ ed.a, key }] = i;
+    key = ed.C;
+    tools_stl::insert_sorted(key, ed.a);
+    lookup[{ ed.b, key }] = i;
   }
   return lookup;
 }
@@ -272,10 +276,12 @@ RVineTrees::trees_to_augmented() const
   for (size_t t = 0; t < trunc_lvl_; ++t) {
     const Tree& edges = trees_[t];
     AugmentedTree atree;
+    atree.edges.reserve(edges.size());
     if (t == 0) {
       check_missing_vars(edges, d_);
       for (const auto& ed : edges)
-        atree.edges.push_back(std::make_tuple(ed.a, ed.b, ed));
+        atree.edges.push_back({ ed.a, ed.b, &ed, false });
+      atree.degrees.assign(d_ + 1, 0); // 1-based labels; index 0 unused
     } else {
       auto lookup = build_lookup(augmented[t - 1].edges);
       for (size_t i = 0; i < edges.size(); ++i) {
@@ -292,12 +298,13 @@ RVineTrees::trees_to_augmented() const
           problem += ")";
           throw std::runtime_error(problem);
         }
-        atree.edges.push_back(std::make_tuple(it1->second, it2->second, ed));
+        atree.edges.push_back({ it1->second, it2->second, &ed, false });
       }
+      atree.degrees.assign(augmented[t - 1].edges.size(), 0);
     }
     for (const auto& e : atree.edges) {
-      atree.degrees[std::get<0>(e)]++;
-      atree.degrees[std::get<1>(e)]++;
+      atree.degrees[e.node1]++;
+      atree.degrees[e.node2]++;
     }
     augmented[t] = std::move(atree);
   }

--- a/include/vinecopulib/vinecop/implementation/tools_select.ipp
+++ b/include/vinecopulib/vinecop/implementation/tools_select.ipp
@@ -713,9 +713,10 @@ VinecopSelector::finalize_unknown_structure(size_t trunc_lvl)
     tools_interface::check_user_interrupt();
     for (auto e : boost::edges(trees_[t])) {
       const auto& edge = trees_[t][e];
-      std::set<size_t> conditioning;
+      std::vector<size_t> conditioning;
+      conditioning.reserve(edge.conditioning.size());
       for (auto c : edge.conditioning)
-        conditioning.insert(c + 1);
+        conditioning.push_back(c + 1);
       tree_list[t - 1].push_back(RVineTrees::Edge(edge.conditioned[0] + 1,
                                                   edge.conditioned[1] + 1,
                                                   conditioning,

--- a/include/vinecopulib/vinecop/rvine_trees.hpp
+++ b/include/vinecopulib/vinecop/rvine_trees.hpp
@@ -6,12 +6,13 @@
 
 #pragma once
 
+#include <algorithm>
 #include <functional>
 #include <map>
-#include <set>
 #include <tuple>
 #include <vector>
 #include <vinecopulib/bicop/class.hpp>
+#include <vinecopulib/misc/tools_stl.hpp>
 #include <vinecopulib/misc/triangular_array.hpp>
 
 namespace vinecopulib {
@@ -35,24 +36,39 @@ public:
   //! and the associated pair-copula (independence by default).
   struct Edge
   {
-    size_t a{ 0 };        //!< first conditioned variable (pair-copula arg1)
-    size_t b{ 0 };        //!< second conditioned variable
-    std::set<size_t> C{}; //!< conditioning set
-    Bicop pair_copula{};  //!< pair-copula (independence by default)
+    size_t a{ 0 };           //!< first conditioned variable (arg1)
+    size_t b{ 0 };           //!< second conditioned variable
+    std::vector<size_t> C{}; //!< conditioning set, kept sorted ascending
+    std::vector<size_t> all_indices{}; //!< sorted {a} ∪ {b} ∪ C (precomputed)
+    Bicop pair_copula{}; //!< pair-copula (independence by default)
 
     Edge() = default;
-    Edge(size_t a_arg, size_t b_arg, std::set<size_t> c_arg)
+    Edge(size_t a_arg, size_t b_arg, std::vector<size_t> c_arg)
       : a(a_arg)
       , b(b_arg)
       , C(std::move(c_arg))
     {
+      finalize();
     }
-    Edge(size_t a_arg, size_t b_arg, std::set<size_t> c_arg, Bicop pc)
+    Edge(size_t a_arg, size_t b_arg, std::vector<size_t> c_arg, Bicop pc)
       : a(a_arg)
       , b(b_arg)
       , C(std::move(c_arg))
       , pair_copula(std::move(pc))
     {
+      finalize();
+    }
+
+  private:
+    //! Canonicalizes `C` (sort + unique) and precomputes `all_indices`.
+    void finalize()
+    {
+      std::sort(C.begin(), C.end());
+      C.erase(std::unique(C.begin(), C.end()), C.end());
+      all_indices = C;
+      all_indices.reserve(C.size() + 2);
+      tools_stl::insert_sorted(all_indices, a);
+      tools_stl::insert_sorted(all_indices, b);
     }
   };
   using Tree = std::vector<Edge>;
@@ -74,11 +90,22 @@ public:
     std::vector<std::vector<Bicop>> pair_copulas; //!< indexed `[tree][edge]`
   };
 
+  //! @brief One edge of the augmented (line-graph) view: its two incident node
+  //! ids plus a non-owning pointer to the underlying `Edge` (in `trees_`).
+  struct AugmentedEdge
+  {
+    size_t node1{ 0 };
+    size_t node2{ 0 };
+    const Edge* edge{ nullptr };
+    bool consumed{ false };
+  };
+
   //! @brief The augmented (line-graph) view of a tree used during conversion.
+  //! `degrees` is indexed by node id (contiguous), avoiding a `std::map`.
   struct AugmentedTree
   {
-    std::vector<std::tuple<size_t, size_t, Edge>> edges;
-    std::map<size_t, size_t> degrees;
+    std::vector<AugmentedEdge> edges;
+    std::vector<size_t> degrees;
   };
 
   RVineTrees()
@@ -109,8 +136,8 @@ private:
   size_t trunc_lvl_;
   std::vector<Tree> trees_;
 
-  std::map<std::pair<size_t, std::set<size_t>>, size_t> build_lookup(
-    const std::vector<std::tuple<size_t, size_t, Edge>>& edges) const;
+  std::map<std::pair<size_t, std::vector<size_t>>, size_t> build_lookup(
+    const std::vector<AugmentedEdge>& edges) const;
   void check_missing_vars(const std::vector<Edge>& edges, size_t d) const;
   std::vector<AugmentedTree> trees_to_augmented() const;
   Decomposition peel(const DiagonalPolicy& diagonal_policy,


### PR DESCRIPTION
## What

`RVineTrees` (the shared leaf-peeling primitive behind `Vinecop::reorient()` and `select()`'s `finalize`, added in #698) reorganized the hand-rolled peel but ran **~3.6× slower** — purely from data-structure choices out of step with the rest of the vine code (which uses `std::vector<size_t>` + `tools_stl`, never `std::set`). This optimizes the internals **with byte-for-byte identical output** — no algorithm change.

## Changes

- **`Edge::C`**: `std::set<size_t>` → **sorted `std::vector<size_t>`** (the codebase idiom), plus a precomputed sorted **`all_indices`** so the descent no longer rebuilds a set per candidate.
- **`AugmentedTree`**: each augmented edge now holds a **non-owning `const Edge*`** instead of a copy of the whole `Edge` — a `Bicop` copy is a *deep* copy (`AbstractBicop::create` + parameter-matrix copy), so this removes **~d²/2 deep `Bicop` copies per peel** (the dominant cost). `degrees` is a `std::vector` indexed by node id instead of a `std::map`.
- **`peel`**: edges are marked `consumed` with a flag instead of `erase()` — preserving iteration order, so the leaf choice, descent match, and flips are unchanged; `check_set` is a sorted vector.
- **`build_lookup`**: sorted-vector keys instead of `std::set` keys.
- **`finalize_unknown_structure`** builds its conditioning as a `std::vector`.

## Performance (`reorient`, D-vine, isolated, median ms)

| d | before (`std::set`) | after | speedup |
|--:|--:|--:|--:|
| 5  | 0.13 | 0.09 | 1.6× |
| 10 | 0.79 | 0.45 | 1.8× |
| 20 | 1.99 | 0.99 | 2.0× |
| 30 | 5.45 | 2.24 | 2.4× |
| 50 | **23.8** | **7.2** | **3.3×** |

Back to ~pre-refactor (hand-rolled) parity. `select()`'s `finalize` benefits proportionally to its (small) share of a fit.

## Byte-identical — verified

The `select()` default path routes through the peel, so output must not move. `std::set` ⟺ sorted `std::vector` (same canonical order), `consumed`-flag ⟺ `erase` (same survivor order → same leaf/descent choices), pointer-vs-copy doesn't change values, precomputed `all_indices` reproduces `set(C)∪{a,b}` exactly.

- **Golden harness** (28 configs: all tree criteria/algorithms incl. random+seeds, sparse/threshold, truncated, discrete, weights): `select()` structure + hexfloat loglik/mBICv/params **dump *and* trace byte-identical** before/after.
- `rvine_trees_works` (round-trip `(order, struct_array)` identity + `RVineStructure` round-trips), `rvine_trees_sanity_checks` (throws), `reorient_preserves_model` (pdf 1e-6, tail==B), `conditional_select_empty_equals_plain` (**exact `get_matrix()` equality** vs plain select), `conditional_select_places_conditioning_set_at_tail`, `simulate_conditional_discrete_is_correct` — all pass.
- Debug `STRICT_COMPILER=ON` build clean; `clang-format-14` clean. Full `test_all` (precompiled, sanitizers, R-parity) left to CI.

No `NEWS.md` change — behaviour is identical (#698's bullet already says "byte-for-byte unchanged").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
