### PR TITLE
refactor(vinecop): unify the R-vine diagonal on conditioned[0] (flip-free finalize)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -175,6 +175,18 @@
 
 * Add score and Hessian support (#645)
 
+* Unify the R-vine matrix diagonal convention on the `conditioned[0]` endpoint:
+  `Vinecop::select()` / `from_data()` now finalize with the same
+  (first-leaf-edge, `conditioned[0]`) diagonal policy as
+  `RVineStructure::get_trees()` and the `RVineTrees` default, so structure
+  selection and the `get_trees()` round-trip share one convention. Because each
+  edge stores its pair copula with the first argument on `conditioned[0]`, the
+  finalization is now flip-free — selected pair copulas are placed exactly as
+  fitted, and no longer flipped onto the `conditioned[1]` diagonal. The result
+  is the same vine (identical density, log-likelihood, and per-tree conditioned
+  sets); only the matrix / order representation and the per-edge orientation of
+  the pair copulas in the both-endpoints-are-leaves columns change (#702)
+
 ### BUG FIXES
 
 * Fix out-of-bounds parameter indexing in the per-row bivariate evaluation of

--- a/include/vinecopulib/vinecop/implementation/rvine_structure.ipp
+++ b/include/vinecopulib/vinecop/implementation/rvine_structure.ipp
@@ -64,8 +64,8 @@ inline RVineStructure::RVineStructure(
 //! @param check Whether `trees` shall be checked for validity.
 inline RVineStructure::RVineStructure(const RVineTrees& trees, bool check)
   : RVineStructure([&]() {
-    auto array = trees.to_struct_array();
-    return RVineStructure(std::get<0>(array), std::get<1>(array), false, check);
+    auto dec = trees.to_struct_array();
+    return RVineStructure(dec.order, dec.struct_array, false, check);
   }())
 {
 }

--- a/include/vinecopulib/vinecop/implementation/rvine_trees.ipp
+++ b/include/vinecopulib/vinecop/implementation/rvine_trees.ipp
@@ -70,27 +70,15 @@ inline RVineTrees::RVineTrees(size_t d, std::vector<Tree> trees)
 {
 }
 
-//! @brief Converts back to an `(order, struct_array)` representation.
-//! @details Leaves are peeled in edge-iteration order; validates the proximity
-//! condition. Throws if a tree does not have the expected number of edges.
-inline std::tuple<std::vector<size_t>, TriangularArray<size_t>>
-RVineTrees::to_struct_array() const
+//! @brief The default diagonal policy: the `conditioned[0]` (first) leaf
+//! endpoint of the first leaf edge — flip-free, and shared by `select()`
+//! finalization and the `RVineStructure` round-trip.
+inline RVineTrees::DiagonalPolicy
+RVineTrees::default_diagonal_policy()
 {
-  for (size_t t = 0; t < trunc_lvl_; ++t) {
-    if (trees_[t].size() != d_ - 1 - t) {
-      throw std::runtime_error(
-        "Tree " + std::to_string(t) +
-        " does not have the correct number of edges. Expected " +
-        std::to_string(d_ - 1 - t) + " edges, but got " +
-        std::to_string(trees_[t].size()) + ".");
-    }
-  }
-  auto dec = peel(
-    [](size_t, const std::vector<std::vector<size_t>>& leaf_edges) {
-      return leaf_edges[0][0];
-    },
-    false);
-  return std::make_tuple(std::move(dec.order), std::move(dec.struct_array));
+  return [](size_t, const std::vector<std::vector<size_t>>& leaf_edges) {
+    return leaf_edges[0][0];
+  };
 }
 
 //! @brief Converts back to matrix form, choosing diagonals with a policy and

--- a/include/vinecopulib/vinecop/implementation/tools_select.ipp
+++ b/include/vinecopulib/vinecop/implementation/tools_select.ipp
@@ -691,11 +691,13 @@ VinecopSelector::finalize_known_structure(size_t trunc_lvl)
 //! @details Rebuilds the R-vine via the shared `RVineTrees` primitive: the
 //! fitted trees are converted into a list-of-trees decomposition (1-based
 //! labels, carrying the fitted pair copulas), then peeled back into an
-//! `(order, struct_array, pair_copulas)` triple. The peeling reproduces the
-//! former hand-rolled `fill_structure_column`: leaves are taken in
-//! graph-iteration order, the `conditioned[1]` endpoint goes on the diagonal,
-//! and each pair copula is flipped when its stored orientation no longer
-//! matches its new position.
+//! `(order, struct_array, pair_copulas)` triple, using the same
+//! (first-leaf-edge, `conditioned[0]` endpoint on the diagonal) policy as the
+//! default `RVineTrees::to_struct_array()`. Since each edge stores its
+//! pair copula with the first argument on `conditioned[0]`, placing
+//! `conditioned[0]` on the diagonal keeps the finalization flip-free: pair
+//! copulas are placed exactly as fitted, and `select()` and the structure
+//! round-trip (`RVineStructure::get_trees()`) share one diagonal convention.
 inline void
 VinecopSelector::finalize_unknown_structure(size_t trunc_lvl)
 {
@@ -724,14 +726,10 @@ VinecopSelector::finalize_unknown_structure(size_t trunc_lvl)
     }
   }
 
-  // "first leaf edge, diagonal = conditioned[1] endpoint" ==
-  // fill_structure_column
-  auto dec =
-    RVineTrees(d_, std::move(tree_list))
-      .to_struct_array(
-        [](size_t, const std::vector<std::vector<size_t>>& leaf_edges) {
-          return leaf_edges[0].back();
-        });
+  // Finalize with the default (flip-free, conditioned[0]) diagonal policy — the
+  // same convention as the RVineStructure round-trip, so no bespoke policy is
+  // needed here.
+  auto dec = RVineTrees(d_, std::move(tree_list)).to_struct_array();
   vine_struct_ = RVineStructure(dec.order, dec.struct_array);
   pair_copulas_ = std::move(dec.pair_copulas);
 }

--- a/include/vinecopulib/vinecop/rvine_trees.hpp
+++ b/include/vinecopulib/vinecop/rvine_trees.hpp
@@ -124,9 +124,18 @@ public:
 
   const std::vector<Tree>& get_trees() const { return trees_; }
 
-  std::tuple<std::vector<size_t>, TriangularArray<size_t>> to_struct_array()
-    const;
-  Decomposition to_struct_array(const DiagonalPolicy& diagonal_policy) const;
+  //! @brief The default diagonal policy: the `conditioned[0]` (first) leaf
+  //! endpoint of the first leaf edge. It is flip-free — each edge stores its
+  //! pair copula aligned to `conditioned[0]`, so placing that endpoint on the
+  //! diagonal needs no flip — and it is the convention shared by `select()`
+  //! finalization and the `RVineStructure` round-trip.
+  static DiagonalPolicy default_diagonal_policy();
+
+  //! @brief Converts back to matrix form, choosing diagonals with
+  //! `diagonal_policy` (default: `default_diagonal_policy()`) and
+  //! carrying/flipping the pair-copulas.
+  Decomposition to_struct_array(
+    const DiagonalPolicy& diagonal_policy = default_diagonal_policy()) const;
 
   size_t get_dim() const { return d_; }
   size_t get_trunc_lvl() const { return trunc_lvl_; }

--- a/test/src_test/include/test_rvine_structure.hpp
+++ b/test/src_test/include/test_rvine_structure.hpp
@@ -87,8 +87,8 @@ TEST(rvine_structure, rvine_trees_works)
 
   // trees -> (order, struct_array) round-trip is the identity here
   auto rt = rvt.to_struct_array();
-  EXPECT_EQ(order, std::get<0>(rt));
-  EXPECT_EQ(struct_array, std::get<1>(rt));
+  EXPECT_EQ(order, rt.order);
+  EXPECT_EQ(struct_array, rt.struct_array);
 
   // RVineStructure <-> RVineTrees round-trips
   RVineStructure rvs(order, struct_array);
@@ -105,8 +105,8 @@ TEST(rvine_structure, rvine_trees_works)
   EXPECT_NO_THROW(RVineTrees(order, truncated_array));
   RVineTrees rvt_trunc(order, truncated_array);
   auto rt_trunc = rvt_trunc.to_struct_array();
-  EXPECT_EQ(order, std::get<0>(rt_trunc));
-  EXPECT_EQ(truncated_array, std::get<1>(rt_trunc));
+  EXPECT_EQ(order, rt_trunc.order);
+  EXPECT_EQ(truncated_array, rt_trunc.struct_array);
   EXPECT_EQ(rvs_trunc, RVineStructure(rvt_trunc));
   EXPECT_EQ(rvs_trunc, RVineStructure(rvs_trunc.get_trees()));
 }


### PR DESCRIPTION
## Summary

`Vinecop::select()` finalized structures with the `conditioned[1]` endpoint on the diagonal (the historical `fill_structure_column` convention, reproduced byte-for-byte by #698), while `RVineTrees::to_struct_array()` and the `RVineStructure(RVineTrees)` round-trip use `conditioned[0]`. This unifies everything on `conditioned[0]`:

- `RVineTrees::to_struct_array()` collapses to a **single** overload whose diagonal policy **defaults** to `RVineTrees::default_diagonal_policy()` (first leaf edge, `conditioned[0]` endpoint). `reorient()` keeps its bespoke `to_tail` policy — now the only non-default `DiagonalPolicy` use.
- `finalize_unknown_structure()` drops its custom `leaf_edges[0].back()` lambda and calls the default. Because each edge stores its pair copula aligned to `conditioned[0]`, finalization is now **flip-free**: selected pair copulas are placed exactly as fitted, rather than flipped onto the `conditioned[1]` diagonal.

## Why

The `conditioned[1]` choice was historical (Dissmann leaf-peeling with a `b`-endpoint tie-break), not a VineCopula-compatibility decision — vinecopulib's matrix notation is already documented as *different* from VineCopula's (`docs/overview-vinecop.dox`), and the VineCopula parity tests are set-based per tree (diagonal-invariant). `conditioned[0]` is the genuinely simpler convention: it is flip-free (the matrix stores pair copulas as fitted) and it is the one `get_trees()`/the round-trip already use, so `select()` and `RVineStructure::get_trees()` now share a single convention.

## Behavior

Same vine — **identical density, log-likelihood, and per-tree conditioned sets**. Only the matrix/order representation and the per-edge orientation of the pair copulas in the both-endpoints-are-leaves columns change (tree-equivalent). `get_matrix()` / `get_order()` / per-edge rotations of *selected* vines may therefore differ from prior releases.

## Validation

Behavior verified through the downstream pyvinecopulib suite (structure-selection parity `VinecopBase.select().matrix == Vinecop.from_data().structure.matrix` with pdf parity; `get_trees` round-trip; full bicop/vinecop/torch cascades). The `test_rvine_structure` round-trip test is updated for the collapsed `to_struct_array()` return type; VineCopula parity tests are unaffected.

## Note

Stacks on `feature/rvine-trees-perf` (the current tip the downstream pin uses); retarget to `dev` once that branch merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)