### PR TITLE
ci: rebuild the CI, release, and analysis workflows

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,4 +1,7 @@
-﻿---
+# clang-format 14 (pinned in .github/workflows/continuous_integration.yml as
+# CLANG_FORMAT_VERSION; install the identical binary locally with
+#   pipx install "clang-format==14.0.6"
+# Mozilla style is what gives this codebase its return-type-on-its-own-line
+# layout (AlwaysBreakAfterReturnType: TopLevel) and its 80-column limit.
+---
 BasedOnStyle: Mozilla
-
-...

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,20 +1,13 @@
-# clang-tidy 14 (matching the clang-format version pinned in CI).
+# clang-tidy 14, matching the clang-format version pinned in CI.
 #
-# The previous configuration enabled eight wildcard groups with
-# `WarningsAsErrors: ''` and drove a CI job that was commented out, so nothing
-# was ever enforced. Wholesale `cppcoreguidelines-*` + `hicpp-*` +
-# `readability-*` on an Eigen-heavy numerical codebase yields thousands of
-# findings (magic numbers, identifier length, pro-bounds, signed bitwise), which
-# is precisely why it was never turned on.
+# A curated list, not wildcard groups: every check here is one we are willing to
+# fail a pull request over, and WarningsAsErrors is '*' so there is no
+# reported-but-tolerated tier. The CI job runs on the pull-request diff, so a new
+# check does not require fixing the whole tree at once.
 #
-# This is a curated list instead: every check below is one we are willing to fail
-# a pull request over. The CI job runs it on the pull-request diff only (see
-# .github/workflows/continuous_integration.yml), so adding a check does not
-# require fixing the whole tree at once.
-#
-# To propose a new check: add it here, run
+# To propose a check: add it, run
 #   run-clang-tidy-14 -p <build-dir> -checks='-*,<the-new-check>' include/
-# and either fix the findings in the same pull request or leave the check out.
+# and either fix the findings in the same pull request or leave it out.
 
 Checks: >
   -*,
@@ -90,18 +83,11 @@ Checks: >
   readability-static-definition-in-anonymous-namespace,
   readability-string-compare
 
-# '*' means "every check enabled above is an error". Spelling the list out twice
-# would just let the two copies drift; anything worth reporting here is worth
-# failing on, so there is deliberately no reported-but-tolerated tier.
 WarningsAsErrors: '*'
 
-# clang-tidy matches this against each header's *absolute* path, so the previous
-# '^(/)?(include|test|examples)/' could never match anything under /home/... and
-# every header diagnostic was silently dropped. Anchor on the repository
-# subdirectories instead. The vendored nlohmann_json.hpp and the generated
-# tools_stats_sobol.hpp / tools_stats_ghalton.hpp tables are excluded by the
-# alternation rather than by a second regex, because
-# ExcludeHeaderFilterRegex only exists in clang-tidy 18 and later.
+# Matched against each header's *absolute* path, so this must not be anchored at
+# the repository root. The vendored and generated headers are left out via the
+# alternation; ExcludeHeaderFilterRegex needs clang-tidy 18.
 HeaderFilterRegex: '.*/(include/vinecopulib/(bicop|vinecop)|include/vinecopulib/misc/(tools_(eigen|stl|stats|serialization|interpolation|optimization|transforms|integration|thread|interface|batch|constants|optional)|triangular_array|fit_controls)|test/src_test|benchmarks/src)'
 
 FormatStyle: file

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,16 +1,107 @@
+# clang-tidy 14 (matching the clang-format version pinned in CI).
+#
+# The previous configuration enabled eight wildcard groups with
+# `WarningsAsErrors: ''` and drove a CI job that was commented out, so nothing
+# was ever enforced. Wholesale `cppcoreguidelines-*` + `hicpp-*` +
+# `readability-*` on an Eigen-heavy numerical codebase yields thousands of
+# findings (magic numbers, identifier length, pro-bounds, signed bitwise), which
+# is precisely why it was never turned on.
+#
+# This is a curated list instead: every check below is one we are willing to fail
+# a pull request over. The CI job runs it on the pull-request diff only (see
+# .github/workflows/continuous_integration.yml), so adding a check does not
+# require fixing the whole tree at once.
+#
+# To propose a new check: add it here, run
+#   run-clang-tidy-14 -p <build-dir> -checks='-*,<the-new-check>' include/
+# and either fix the findings in the same pull request or leave the check out.
+
 Checks: >
   -*,
-  bugprone-*,
-  performance-*,
-  readability-*,
-  modernize-*,
-  cppcoreguidelines-*,
-  portability-*,
-  clang-analyzer-*,
-  misc-*,
-  hicpp-*
+  bugprone-argument-comment,
+  bugprone-assert-side-effect,
+  bugprone-bool-pointer-implicit-conversion,
+  bugprone-copy-constructor-init,
+  bugprone-dangling-handle,
+  bugprone-fold-init-type,
+  bugprone-forward-declaration-namespace,
+  bugprone-inaccurate-erase,
+  bugprone-incorrect-roundings,
+  bugprone-integer-division,
+  bugprone-macro-repeated-side-effects,
+  bugprone-misplaced-widening-cast,
+  bugprone-move-forwarding-reference,
+  bugprone-multiple-statement-macro,
+  bugprone-parent-virtual-call,
+  bugprone-redundant-branch-condition,
+  bugprone-string-constructor,
+  bugprone-string-integer-assignment,
+  bugprone-suspicious-memset-usage,
+  bugprone-suspicious-semicolon,
+  bugprone-suspicious-string-compare,
+  bugprone-swapped-arguments,
+  bugprone-terminating-continue,
+  bugprone-undefined-memory-manipulation,
+  bugprone-undelegated-constructor,
+  bugprone-unused-raii,
+  bugprone-unused-return-value,
+  bugprone-use-after-move,
+  bugprone-virtual-near-miss,
+  misc-misplaced-const,
+  misc-redundant-expression,
+  misc-static-assert,
+  misc-uniqueptr-reset-release,
+  misc-unused-alias-decls,
+  misc-unused-using-decls,
+  modernize-deprecated-headers,
+  modernize-loop-convert,
+  modernize-make-shared,
+  modernize-make-unique,
+  modernize-redundant-void-arg,
+  modernize-use-bool-literals,
+  modernize-use-emplace,
+  modernize-use-equals-default,
+  modernize-use-equals-delete,
+  modernize-use-nullptr,
+  modernize-use-override,
+  modernize-use-using,
+  performance-faster-string-find,
+  performance-for-range-copy,
+  performance-implicit-conversion-in-loop,
+  performance-inefficient-algorithm,
+  performance-inefficient-string-concatenation,
+  performance-inefficient-vector-operation,
+  performance-move-const-arg,
+  performance-move-constructor-init,
+  performance-no-automatic-move,
+  performance-noexcept-move-constructor,
+  performance-trivially-destructible,
+  performance-unnecessary-copy-initialization,
+  performance-unnecessary-value-param,
+  readability-const-return-type,
+  readability-container-size-empty,
+  readability-delete-null-pointer,
+  readability-misleading-indentation,
+  readability-redundant-control-flow,
+  readability-redundant-smartptr-get,
+  readability-redundant-string-cstr,
+  readability-redundant-string-init,
+  readability-simplify-boolean-expr,
+  readability-static-definition-in-anonymous-namespace,
+  readability-string-compare
 
-WarningsAsErrors: ''
+# '*' means "every check enabled above is an error". Spelling the list out twice
+# would just let the two copies drift; anything worth reporting here is worth
+# failing on, so there is deliberately no reported-but-tolerated tier.
+WarningsAsErrors: '*'
 
-HeaderFilterRegex: '^(/)?(include|test|examples)/'
+# clang-tidy matches this against each header's *absolute* path, so the previous
+# '^(/)?(include|test|examples)/' could never match anything under /home/... and
+# every header diagnostic was silently dropped. Anchor on the repository
+# subdirectories instead. The vendored nlohmann_json.hpp and the generated
+# tools_stats_sobol.hpp / tools_stats_ghalton.hpp tables are excluded by the
+# alternation rather than by a second regex, because
+# ExcludeHeaderFilterRegex only exists in clang-tidy 18 and later.
+HeaderFilterRegex: '.*/(include/vinecopulib/(bicop|vinecop)|include/vinecopulib/misc/(tools_(eigen|stl|stats|serialization|interpolation|optimization|transforms|integration|thread|interface|batch|constants|optional)|triangular_array|fit_controls)|test/src_test|benchmarks/src)'
+
 FormatStyle: file

--- a/.codacy.yml
+++ b/.codacy.yml
@@ -1,8 +1,0 @@
----
-engines:
- cppcheck:
-   enabled: true
-   language: c++
-exclude_paths:
-  - '**.md'
-  - 'include/vinecopulib/misc/nlohmann_json.hpp'

--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -117,8 +117,11 @@ runs:
     - name: Install wdm (pinned to ${{inputs.wdm_ref}})
       if: inputs.wdm == 'true'
       run: |
-          git clone https://github.com/tnagler/wdm.git ${{runner.temp}}/wdm
-          cd ${{runner.temp}}/wdm
+          # Clone into a relative path, not ${{runner.temp}}: on Windows that
+          # expands to a backslash path (D:\a\_temp) and bash swallows the
+          # backslashes, so `cd` lands on a nonexistent `D:a_temp/wdm`.
+          git clone https://github.com/tnagler/wdm.git wdm
+          cd wdm
           git checkout --detach ${{ inputs.wdm_ref }}
           mkdir release && cd release
           if [ "${{ inputs.os }}" != "windows-latest" ]; then
@@ -128,6 +131,7 @@ runs:
             cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release
             cmake --build . --target install
           fi
+          cd ../.. && rm -rf wdm
       shell: bash
 
     - name: Install lcov

--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -34,13 +34,17 @@ inputs:
     required: false
     default: '3.4.0'
   wdm:
-    description: 'Whether to install WDM'
+    description: 'Whether to install wdm'
     required: false
     default: 'true'
-  # wdm_install_dir:
-  #   description: 'The directory to install WDM to'
-  #   required: false
-  #   default: '/home/runner/work'
+  wdm_ref:
+    description: >
+      The wdm commit to install. Keep this in sync with the FetchContent GIT_TAG
+      in cmake/findDependencies.cmake: CI used to clone the default branch, so a
+      wdm master commit could break an unrelated vinecopulib pull request, and
+      CI silently tested a different wdm than a FetchContent build would use.
+    required: false
+    default: 'c837460853570690ccd9367c059e41b851d6f816'
   lcov:
     description: 'Whether to install lcov'
     required: false
@@ -60,9 +64,10 @@ outputs:
   EIGEN3_ROOT:
     description: 'The path to the eigen installation, e.g. to be used in CMake'
     value: ${{ inputs.eigen_install_dir }}/eigen
-  WDM_ROOT:
-    description: 'The path to the wdm installation, e.g. to be used in CMake'
-    value: ${{ inputs.wdm_install_dir }}/wdm
+  # There used to be a WDM_ROOT output here built from a `wdm_install_dir` input
+  # that was commented out, so it always evaluated to the literal '/wdm'.
+  # Nothing consumed it -- wdm is installed to the system prefix below and found
+  # via find_package -- so it has been removed rather than fixed.
 runs:
   using: 'composite'
   steps:
@@ -85,6 +90,18 @@ runs:
           boost_version: ${{inputs.boost_version}}
           boost_install_dir: ${{ inputs.boost_install_dir }}
 
+    # NOTE: left exactly as it was, deliberately. Eigen is cloned *and* built
+    # from git on every non-Windows leg, which is worth caching -- but the
+    # install prefix here is `eigen_install_dir` while the EIGEN3_ROOT output
+    # below is `eigen_install_dir/eigen`, so the EIGEN3_INCLUDE_DIR the workflow
+    # derives from it points at a directory that does not exist. Configuration
+    # succeeds anyway because cmake/findDependencies.cmake reads the bare CMake
+    # variable, not $ENV{EIGEN3_INCLUDE_DIR}, so that env var is inert here and
+    # find_package(Eigen3 CONFIG) locates Eigen on its own. Fixing the Eigen
+    # handling in findDependencies.cmake (deriving EIGEN3_INCLUDE_DIR from the
+    # Eigen3::Eigen target, as pyvinecopulib had to do downstream) is a
+    # prerequisite for caching this sensibly, so both are left to the CMake
+    # modernization rather than bolted on here.
     - name: Install Eigen ${{inputs.eigen_version}}
       if: inputs.eigen == 'true'
       run: |
@@ -97,20 +114,20 @@ runs:
           fi
       shell: bash
 
-    - name: Install wdm
+    - name: Install wdm (pinned to ${{inputs.wdm_ref}})
       if: inputs.wdm == 'true'
       run: |
-          git clone https://github.com/tnagler/wdm.git
-          cd wdm && mkdir release && cd release
+          git clone https://github.com/tnagler/wdm.git ${{runner.temp}}/wdm
+          cd ${{runner.temp}}/wdm
+          git checkout --detach ${{ inputs.wdm_ref }}
+          mkdir release && cd release
           if [ "${{ inputs.os }}" != "windows-latest" ]; then
             cmake .. -DCMAKE_BUILD_TYPE=Release
             sudo make install
-          elif [ "${{ inputs.os }}" == "windows-latest" ]; then
-            cmake .. -G Ninja \
-              -DCMAKE_BUILD_TYPE=Release
+          else
+            cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release
             cmake --build . --target install
           fi
-          cd ../.. && rm -rf wdm
       shell: bash
 
     - name: Install lcov
@@ -133,16 +150,19 @@ runs:
         # set here too so the action stays self-contained)
         GITHUB_PAT: ${{ github.token }}
       run: |
-        if [ "${{ inputs.os }}" == "ubuntu-latest" ]; then
-            sudo apt-get install --no-install-recommends -y libgsl0-dev
-        elif [ "${{ inputs.os }}" == "macos-latest" ]; then
-            brew install gsl
-        fi
+        # GSL is a VineCopula build dependency when it compiles from source. The
+        # previous macOS branch tested for 'macos-latest', which this action is
+        # never called with (the matrix passes macos-15 and macos-15-intel), so
+        # brew install gsl never ran; match any macOS runner instead.
+        case "${{ inputs.os }}" in
+          ubuntu-*) sudo apt-get install --no-install-recommends -y libgsl0-dev ;;
+          macos-*)  brew install gsl ;;
+        esac
         # Install the CRAN release first (pulls in every dependency as a
         # binary), then upgrade VineCopula itself to the GitHub version: 2.6.2
         # is required by the derivative parity tests (RVineGrad / RVineHessian
         # rotation + sample-size fixes, tnagler/VineCopula #101, #102) but is
         # not on CRAN yet, so only VineCopula compiles from source.
-        Rscript -e "install.packages(c('VineCopula', 'remotes'), repos='http://cran.rstudio.com/')"
+        Rscript -e "install.packages(c('VineCopula', 'remotes'), repos='https://cloud.r-project.org')"
         Rscript -e "remotes::install_github('tnagler/VineCopula', upgrade = 'never')"
       shell: bash

--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -39,10 +39,8 @@ inputs:
     default: 'true'
   wdm_ref:
     description: >
-      The wdm commit to install. Keep this in sync with the FetchContent GIT_TAG
-      in cmake/findDependencies.cmake: CI used to clone the default branch, so a
-      wdm master commit could break an unrelated vinecopulib pull request, and
-      CI silently tested a different wdm than a FetchContent build would use.
+      The wdm commit to install. Keep in sync with the FetchContent GIT_TAG in
+      cmake/findDependencies.cmake.
     required: false
     default: 'c837460853570690ccd9367c059e41b851d6f816'
   lcov:
@@ -64,10 +62,7 @@ outputs:
   EIGEN3_ROOT:
     description: 'The path to the eigen installation, e.g. to be used in CMake'
     value: ${{ inputs.eigen_install_dir }}/eigen
-  # There used to be a WDM_ROOT output here built from a `wdm_install_dir` input
-  # that was commented out, so it always evaluated to the literal '/wdm'.
-  # Nothing consumed it -- wdm is installed to the system prefix below and found
-  # via find_package -- so it has been removed rather than fixed.
+  # No WDM_ROOT: wdm installs to the system prefix and is found via find_package.
 runs:
   using: 'composite'
   steps:
@@ -90,18 +85,6 @@ runs:
           boost_version: ${{inputs.boost_version}}
           boost_install_dir: ${{ inputs.boost_install_dir }}
 
-    # NOTE: left exactly as it was, deliberately. Eigen is cloned *and* built
-    # from git on every non-Windows leg, which is worth caching -- but the
-    # install prefix here is `eigen_install_dir` while the EIGEN3_ROOT output
-    # below is `eigen_install_dir/eigen`, so the EIGEN3_INCLUDE_DIR the workflow
-    # derives from it points at a directory that does not exist. Configuration
-    # succeeds anyway because cmake/findDependencies.cmake reads the bare CMake
-    # variable, not $ENV{EIGEN3_INCLUDE_DIR}, so that env var is inert here and
-    # find_package(Eigen3 CONFIG) locates Eigen on its own. Fixing the Eigen
-    # handling in findDependencies.cmake (deriving EIGEN3_INCLUDE_DIR from the
-    # Eigen3::Eigen target, as pyvinecopulib had to do downstream) is a
-    # prerequisite for caching this sensibly, so both are left to the CMake
-    # modernization rather than bolted on here.
     - name: Install Eigen ${{inputs.eigen_version}}
       if: inputs.eigen == 'true'
       run: |
@@ -117,9 +100,8 @@ runs:
     - name: Install wdm (pinned to ${{inputs.wdm_ref}})
       if: inputs.wdm == 'true'
       run: |
-          # Clone into a relative path, not ${{runner.temp}}: on Windows that
-          # expands to a backslash path (D:\a\_temp) and bash swallows the
-          # backslashes, so `cd` lands on a nonexistent `D:a_temp/wdm`.
+          # Relative path: ${{runner.temp}} is a backslash path on Windows,
+          # which bash mangles.
           git clone https://github.com/tnagler/wdm.git wdm
           cd wdm
           git checkout --detach ${{ inputs.wdm_ref }}
@@ -154,10 +136,8 @@ runs:
         # set here too so the action stays self-contained)
         GITHUB_PAT: ${{ github.token }}
       run: |
-        # GSL is a VineCopula build dependency when it compiles from source. The
-        # previous macOS branch tested for 'macos-latest', which this action is
-        # never called with (the matrix passes macos-15 and macos-15-intel), so
-        # brew install gsl never ran; match any macOS runner instead.
+        # GSL is needed when VineCopula compiles from source. Match any macOS
+        # runner, not the exact label.
         case "${{ inputs.os }}" in
           ubuntu-*) sudo apt-get install --no-install-recommends -y libgsl0-dev ;;
           macos-*)  brew install gsl ;;

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,15 @@
+version: 2
+
+# Only the GitHub Actions ecosystem is covered. Dependabot cannot see the
+# FetchContent pins in cmake/findDependencies.cmake (wdm, googletest,
+# google/benchmark) -- those still need reviewing by hand.
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: monthly
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: 'ci'
+    labels:
+      - dependencies

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,8 +1,6 @@
 name: CodeQL
 
-# Replaces Codacy, whose badge 404s and whose `.codacy.yml` uses an `engines:`
-# format the service abandoned years ago. CodeQL supports C++ natively, needs no
-# third-party account, and reports into the repository's Security tab.
+# Reports into the repository's Security tab.
 
 on:
   push:
@@ -45,19 +43,14 @@ jobs:
           R: false
           lcov: false
 
-      # BOOST_ROOT has to be exported rather than passed as -DBoost_INCLUDE_DIR:
-      # findDependencies.cmake guards on the *plural* Boost_INCLUDE_DIRS, so the
-      # singular command-line variable does not satisfy it and Boost::boost is
-      # never defined.
+      # BOOST_ROOT must be exported: find_package picks it up via CMP0074.
       - name: Set environment variables
         run: |
           echo "BOOST_ROOT=${{ steps.install-dependencies.outputs.BOOST_ROOT }}" >> $GITHUB_ENV
           echo "Boost_INCLUDE_DIR=${{ steps.install-dependencies.outputs.BOOST_ROOT }}/include" >> $GITHUB_ENV
           echo "EIGEN3_INCLUDE_DIR=${{ steps.install-dependencies.outputs.EIGEN3_ROOT }}/include/eigen3" >> $GITHUB_ENV
 
-      # A manual build rather than autobuild: the precompiled configuration is
-      # what turns the .ipp tree into real translation units, so it is the only
-      # mode in which CodeQL actually sees the implementation code.
+      # Precompiled, so the .ipp files become translation units CodeQL can see.
       - name: Build (precompiled, so the .ipp tree is compiled)
         run: |
           mkdir build-codeql && cd build-codeql

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,64 @@
+name: CodeQL
+
+# Replaces Codacy, whose badge 404s and whose `.codacy.yml` uses an `engines:`
+# format the service abandoned years ago. CodeQL supports C++ natively, needs no
+# third-party account, and reports into the repository's Security tab.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: '41 5 * * 1'  # Mondays, 05:41 UTC
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  analyze:
+    name: analyze C++
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: cpp
+          queries: security-and-quality
+
+      - name: Install dependencies
+        id: install-dependencies
+        uses: ./.github/actions/install-dependencies
+        with:
+          os: ubuntu-latest
+          boost_version: 1.84.0
+          eigen_version: 3.4.0
+          R: false
+          lcov: false
+
+      # A manual build rather than autobuild: the precompiled configuration is
+      # what turns the .ipp tree into real translation units, so it is the only
+      # mode in which CodeQL actually sees the implementation code.
+      - name: Build (precompiled, so the .ipp tree is compiled)
+        run: |
+          mkdir build-codeql && cd build-codeql
+          cmake .. -DCMAKE_BUILD_TYPE=Release \
+            -DVINECOPULIB_PRECOMPILED=ON \
+            -DBUILD_TESTING=OFF \
+            -DBoost_INCLUDE_DIR=${{ steps.install-dependencies.outputs.BOOST_ROOT }}/include \
+            -DEIGEN3_INCLUDE_DIR=${{ steps.install-dependencies.outputs.EIGEN3_ROOT }}/include/eigen3
+          make -j"$(nproc)"
+
+      - name: Perform CodeQL analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:cpp

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,6 +45,16 @@ jobs:
           R: false
           lcov: false
 
+      # BOOST_ROOT has to be exported rather than passed as -DBoost_INCLUDE_DIR:
+      # findDependencies.cmake guards on the *plural* Boost_INCLUDE_DIRS, so the
+      # singular command-line variable does not satisfy it and Boost::boost is
+      # never defined.
+      - name: Set environment variables
+        run: |
+          echo "BOOST_ROOT=${{ steps.install-dependencies.outputs.BOOST_ROOT }}" >> $GITHUB_ENV
+          echo "Boost_INCLUDE_DIR=${{ steps.install-dependencies.outputs.BOOST_ROOT }}/include" >> $GITHUB_ENV
+          echo "EIGEN3_INCLUDE_DIR=${{ steps.install-dependencies.outputs.EIGEN3_ROOT }}/include/eigen3" >> $GITHUB_ENV
+
       # A manual build rather than autobuild: the precompiled configuration is
       # what turns the .ipp tree into real translation units, so it is the only
       # mode in which CodeQL actually sees the implementation code.
@@ -53,9 +63,7 @@ jobs:
           mkdir build-codeql && cd build-codeql
           cmake .. -DCMAKE_BUILD_TYPE=Release \
             -DVINECOPULIB_PRECOMPILED=ON \
-            -DBUILD_TESTING=OFF \
-            -DBoost_INCLUDE_DIR=${{ steps.install-dependencies.outputs.BOOST_ROOT }}/include \
-            -DEIGEN3_INCLUDE_DIR=${{ steps.install-dependencies.outputs.EIGEN3_ROOT }}/include/eigen3
+            -DBUILD_TESTING=OFF
           make -j"$(nproc)"
 
       - name: Perform CodeQL analysis

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -7,13 +7,10 @@ on:
   pull_request:
     branches: [main]
   workflow_dispatch:
-  # Called by release.yml so a tag is re-verified against the full matrix
-  # before anything is published.
+  # release.yml re-runs the matrix against the tag before publishing.
   workflow_call:
 
-# One run per ref. Previously `on: [push, pull_request]` meant every same-repo
-# pull request triggered two identical matrix runs, and nothing cancelled a
-# superseded run when a branch was pushed twice.
+# One run per ref; supersede in-flight runs.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -34,19 +31,13 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      # Installed from PyPI rather than apt: `clang-format-14` is only in the
-      # ubuntu-latest image until the image rolls forward, at which point the
-      # package disappears and this job breaks with no code change. A pinned
-      # wheel also means contributors can install the exact same binary, so
-      # local formatting matches CI by construction.
+      # From PyPI, not apt: pins the exact binary so local runs match CI.
       - name: Install clang-format ${{ env.CLANG_FORMAT_VERSION }}
         run: pipx install "clang-format==${{ env.CLANG_FORMAT_VERSION }}"
 
       - name: Check formatting
         run: |
-          # nlohmann_json.hpp is vendored verbatim; tools_stats_sobol.hpp is a
-          # 3.4 MB generated table, and reformatting it on every run costs time
-          # for a file no human edits.
+          # Skip the vendored JSON header and the generated Sobol table.
           git ls-files -z '*.h' '*.hpp' '*.ipp' '*.cpp' '*.cc' \
             | grep -zv '^include/vinecopulib/misc/nlohmann_json\.hpp$' \
             | grep -zv '^include/vinecopulib/misc/tools_stats_sobol\.hpp$' \
@@ -133,28 +124,16 @@ jobs:
             cmake --build .
           fi
         shell: bash
-      # The Debug build enables -fsanitize=address,undefined (OPT_ASAN is ON by
-      # default), so not running it was leaving the entire point of that build
-      # unobserved on every leg except ubuntu/GNU, where the coverage target
-      # runs the tests as a side effect.
-      #
-      # This runs the single test_all binary rather than `ctest`. Measured on a
-      # 64-core machine: test_all runs all 645 tests in ~71 s, while `ctest -j64`
-      # had not finished after 13 minutes -- the R-parity fixtures shell out to
-      # Rscript and exchange data through hardcoded `temp`/`temp2`/`temp3` files
-      # in the working directory (test/src_test/vinecop_test.cpp:18-31 and
-      # cmake/templates/test_vinecop_parametric.R:42-45), so concurrent cases
-      # clobber and delete each other's files and wedge. Making those paths
-      # unique per test is a prerequisite for using ctest's parallelism.
+      # Debug enables -fsanitize=address,undefined, so these tests must run.
+      # Use test_all, not ctest: the R-parity fixtures share fixed temp file
+      # names, so they cannot run concurrently.
       - name: Run the debug tests
         if: matrix.cfg.os != 'ubuntu-latest' || matrix.cfg.name != 'GNU'
         run: |
           cd debug
           if [ "${{ matrix.cfg.os }}" != "windows-latest" ]; then bin/test_all; else bin/test_all.exe; fi
         shell: bash
-      # Cheap guard for the test-registration wiring that nothing exercised
-      # before: gtest_discover_tests writes a `<target>_NOT_BUILT` placeholder
-      # when discovery fails, so a healthy build must list far more than one.
+      # gtest_discover_tests registers a `_NOT_BUILT` placeholder on failure.
       - name: Check that ctest discovery works
         if: matrix.cfg.os != 'windows-latest'
         run: |
@@ -171,9 +150,6 @@ jobs:
         if: contains(matrix.cfg.os, 'ubuntu') && contains(matrix.cfg.name, 'GNU')
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          # `file:` was silently ignored -- the input has been `files:` since
-          # codecov-action v4, so the explicit path did nothing and the uploader
-          # only worked by falling back to auto-discovery.
           files: debug/coverage.info
           disable_search: true
           fail_ci_if_error: true
@@ -206,10 +182,8 @@ jobs:
           done
         shell: bash
 
-  # The default, header-only configuration had no CI coverage at all: both
-  # installs above set VINECOPULIB_PRECOMPILED=ON, so the .hpp + .ipp install
-  # tree that most users and both wrapper libraries consume was never built,
-  # installed, or linked against.
+  # The default configuration: .hpp + .ipp install, as consumed by the R and
+  # Python wrappers. The matrix above only covers VINECOPULIB_PRECOMPILED=ON.
   header-only-install:
     name: header-only install (ubuntu, GNU)
     runs-on: ubuntu-latest
@@ -248,10 +222,8 @@ jobs:
             ( cd "examples/$ex" && mkdir build && cd build && cmake .. && make && ../bin/main )
           done
 
-  # bench_all and parity_dump were built by no workflow, so the whole #688
-  # benchmark and numerical-parity infrastructure could rot against header
-  # changes without anyone noticing. The parity self-comparison is cheap and
-  # proves the dump populates every group and that the gates file parses.
+  # Keeps the benchmark and parity targets compiling. The self-comparison
+  # checks that every group is populated and that the gates file parses.
   benchmarks:
     name: benchmarks and parity harness
     runs-on: ubuntu-latest
@@ -295,9 +267,7 @@ jobs:
           path: bench_results/parity.json
           if-no-files-found: warn
 
-  # Doxygen was never even smoke-built, which is how ~10 uncompilable snippets
-  # and a stale Doxyfile went unnoticed. This job currently only proves the
-  # configuration still runs; the docs rewrite tightens it to WARN_AS_ERROR.
+  # Smoke-builds the docs. To be tightened to WARN_AS_ERROR with the docs rewrite.
   docs:
     name: doxygen
     runs-on: ubuntu-latest
@@ -317,11 +287,7 @@ jobs:
           eigen_version: ${{ env.EIGEN_VERSION }}
           R: false
           lcov: false
-      # Same shape as every other job: export BOOST_ROOT so find_package picks
-      # it up via CMP0074. Passing -DBoost_INCLUDE_DIR on the command line does
-      # not work -- findDependencies.cmake tests the *plural*
-      # Boost_INCLUDE_DIRS, so the guard does not fire and Boost::boost never
-      # gets defined.
+      # BOOST_ROOT must be exported: find_package picks it up via CMP0074.
       - name: Set environment variables
         run: |
           echo "BOOST_ROOT=${{ steps.install-dependencies.outputs.BOOST_ROOT }}" >> $GITHUB_ENV
@@ -346,9 +312,7 @@ jobs:
           path: build-docs/doxygen.log
           if-no-files-found: warn
 
-  # Replaces the block that sat commented out in this file. Runs only on the
-  # pull-request diff, so the curated check list is enforceable as an error
-  # instead of producing thousands of findings nobody reads.
+  # Diff-only, so the curated check list can be enforced as an error.
   clang-tidy:
     name: clang-tidy (diff)
     if: github.event_name == 'pull_request'
@@ -379,8 +343,7 @@ jobs:
         run: |
           mkdir build-tidy && cd build-tidy
           cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
-          # FetchContent puts googletest translation units in the database; they
-          # are not ours to lint.
+          # Drop FetchContent (googletest) translation units.
           jq '[.[] | select(.file | test("_deps/") | not)]' compile_commands.json > filtered.json
           mv filtered.json compile_commands.json
       - name: Run clang-tidy on the diff

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -1,52 +1,93 @@
-name: Build Status 
+name: Build Status
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [main]
+    tags: ['v*']
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+  # Called by release.yml so a tag is re-verified against the full matrix
+  # before anything is published.
+  workflow_call:
+
+# One run per ref. Previously `on: [push, pull_request]` meant every same-repo
+# pull request triggered two identical matrix runs, and nothing cancelled a
+# superseded run when a branch was pushed twice.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+env:
+  BOOST_VERSION: 1.84.0
+  EIGEN_VERSION: 3.4.0
+  CLANG_FORMAT_VERSION: 14.0.6
 
 jobs:
   style:
     name: clang-format
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      # Install the version specified in your .clang-format (here LLVM 14).
-      - name: Install clang-format
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y clang-format-14
+      # Installed from PyPI rather than apt: `clang-format-14` is only in the
+      # ubuntu-latest image until the image rolls forward, at which point the
+      # package disappears and this job breaks with no code change. A pinned
+      # wheel also means contributors can install the exact same binary, so
+      # local formatting matches CI by construction.
+      - name: Install clang-format ${{ env.CLANG_FORMAT_VERSION }}
+        run: pipx install "clang-format==${{ env.CLANG_FORMAT_VERSION }}"
 
       - name: Check formatting
         run: |
-          FILES=$(git ls-files | grep -E '\.(h|hpp|ipp|cpp|cc)$' | grep -v '^include/vinecopulib/misc/nlohmann_json.hpp$')
-          clang-format-14 --dry-run --Werror $FILES
+          # nlohmann_json.hpp is vendored verbatim; tools_stats_sobol.hpp is a
+          # 3.4 MB generated table, and reformatting it on every run costs time
+          # for a file no human edits.
+          git ls-files -z '*.h' '*.hpp' '*.ipp' '*.cpp' '*.cc' \
+            | grep -zv '^include/vinecopulib/misc/nlohmann_json\.hpp$' \
+            | grep -zv '^include/vinecopulib/misc/tools_stats_sobol\.hpp$' \
+            | xargs -0 clang-format --dry-run --Werror
+
+  version:
+    name: version consistency
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v5
+      - name: Check that the version agrees everywhere it is stated
+        run: python3 scripts/check_version.py
+
   build:
     strategy:
       fail-fast: false
-      max-parallel: 6 
+      max-parallel: 6
       matrix:
         cfg:
-          - { os: ubuntu-latest,   name: GNU,    cc: gcc,   cxx: g++,     platform: x64, root_install_dir: '/home/runner/work'}
-          - { os: ubuntu-latest,   name: Clang,  cc: clang, cxx: clang++, platform: x64, root_install_dir: '/home/runner/work'}
-          - { os: macos-15-intel,    name: Clang,  cc: clang, cxx: clang++, platform: x64, root_install_dir: '/Users/runner/work'} # intel runner
-          - { os: macos-15,    name: Clang,  cc: clang, cxx: clang++, platform: arm64, root_install_dir: '/Users/runner/work'} # apple silicon runner
-          - { os: windows-latest,  name: x32, cc: cl,    cxx: cl,      platform: x32, root_install_dir: 'D:\'}
-          - { os: windows-latest,  name: x64, cc: cl,    cxx: cl,      platform: x64, root_install_dir: 'D:\'}
+          - { os: ubuntu-latest,  name: GNU,   cc: gcc,   cxx: g++,     platform: x64,   root_install_dir: '/home/runner/work' }
+          - { os: ubuntu-latest,  name: Clang, cc: clang, cxx: clang++, platform: x64,   root_install_dir: '/home/runner/work' }
+          - { os: macos-15-intel, name: Clang, cc: clang, cxx: clang++, platform: x64,   root_install_dir: '/Users/runner/work' } # intel runner
+          - { os: macos-15,       name: Clang, cc: clang, cxx: clang++, platform: arm64, root_install_dir: '/Users/runner/work' } # apple silicon runner
+          - { os: windows-latest, name: x32,   cc: cl,    cxx: cl,      platform: x32,   root_install_dir: 'D:\' }
+          - { os: windows-latest, name: x64,   cc: cl,    cxx: cl,      platform: x64,   root_install_dir: 'D:\' }
     env:
-      BOOST_VERSION: 1.84.0
-      EIGEN_VERSION: 3.4.0
       # Authenticate remotes::install_github against the GitHub API using the
       # automatic Actions token instead of the rate-limited bundled PAT (the
-      # VineCopula >= 2.6.2 install below, and any test-time fallback, need it).
+      # VineCopula >= 2.6.2 install, and any test-time fallback, need it).
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
 
     runs-on: ${{ matrix.cfg.os }}
-    name:    ${{ matrix.cfg.os }} (${{ matrix.cfg.name }}, ${{ matrix.cfg.platform }})
+    name: ${{ matrix.cfg.os }} (${{ matrix.cfg.name }}, ${{ matrix.cfg.platform }})
+    timeout-minutes: 90
     steps:
-      - name: Checkout project 
-        uses: actions/checkout@v4
+      - name: Checkout project
+        uses: actions/checkout@v5
       - name: Set up MSVC environment
         if: matrix.cfg.os == 'windows-latest'
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
         with:
           arch: ${{ matrix.cfg.platform == 'x32' && 'x86' || matrix.cfg.platform }}
       - name: Install dependencies
@@ -57,87 +98,285 @@ jobs:
           platform: ${{ matrix.cfg.platform }}
           boost_install_dir: ${{ matrix.cfg.root_install_dir }}
           eigen_install_dir: ${{ matrix.cfg.root_install_dir }}
-          # wdm_install_dir: ${{ matrix.cfg.root_install_dir }}
           boost_version: ${{ env.BOOST_VERSION }}
           eigen_version: ${{ env.EIGEN_VERSION }}
           R: true
       - name: Set environment variables and path
-        run:   |
+        run: |
           echo "CC=${{ matrix.cfg.cc }}" >> $GITHUB_ENV
           echo "CXX=${{ matrix.cfg.cxx }}" >> $GITHUB_ENV
           echo "BOOST_ROOT=${{ steps.install-dependencies.outputs.BOOST_ROOT }}" >> $GITHUB_ENV
-          echo "Boost_INCLUDE_DIR =${{ steps.install-dependencies.outputs.BOOST_ROOT }}/include" >> $GITHUB_ENV
+          echo "Boost_INCLUDE_DIR=${{ steps.install-dependencies.outputs.BOOST_ROOT }}/include" >> $GITHUB_ENV
           echo "EIGEN3_INCLUDE_DIR=${{ steps.install-dependencies.outputs.EIGEN3_ROOT }}/include/eigen3" >> $GITHUB_ENV
           if [ "${{ matrix.cfg.os }}" == "windows-latest" ]; then
+            echo "D:\a\vinecopulib\vinecopulib\debug" >> $GITHUB_PATH
             echo "D:\a\vinecopulib\vinecopulib\release" >> $GITHUB_PATH
             echo "D:\a\vinecopulib\vinecopulib\release\Release" >> $GITHUB_PATH
           fi
-
         shell: bash
       - name: Compile the debug version
-        run:   |
+        run: |
           mkdir debug && cd debug
           if [ "${{ matrix.cfg.os }}" != "windows-latest" ]; then
             if [ "${{ matrix.cfg.os }}/${{ matrix.cfg.name }}" == "ubuntu-latest/GNU" ]; then
               cmake .. -DSTRICT_COMPILER=ON \
-              -DCODE_COVERAGE=ON \
-              -DCMAKE_BUILD_TYPE=Debug \
-              -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+                -DCODE_COVERAGE=ON \
+                -DCMAKE_BUILD_TYPE=Debug \
+                -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
               make vinecopulib_coverage
             else
               cmake .. -DCMAKE_BUILD_TYPE=Debug
               make
             fi
           else
-            cmake .. -G Ninja \
-            -DCMAKE_BUILD_TYPE=Debug
+            cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Debug
             cmake --build .
           fi
         shell: bash
-      # - name: Run clang-tidy static analysis
-      #   if: matrix.cfg.os == 'ubuntu-latest' && matrix.cfg.name == 'GNU'
-      #   run: |
-      #     sudo apt-get update
-      #     sudo apt-get install -y clang-tidy-14 jq
-      #     cp debug/compile_commands.json debug/compile_commands_bak.json
-      #     jq '[.[] | select(.file | test("_deps/") | not)]' debug/compile_commands_bak.json > debug/compile_commands.json
-      #     FILES=$(git ls-files | grep -E '^(include|test|examples)/.*\.(cpp|cc|cxx|h|hpp|ipp)$')
-      #     for file in $FILES; do
-      #       echo "Running clang-tidy on $file"
-      #       run-clang-tidy-14 -p debug -quiet -- "$file"
-      #     done
-      #     mv debug/compile_commands_bak.json debug/compile_commands.json
+      # The Debug build enables -fsanitize=address,undefined (OPT_ASAN is ON by
+      # default), so not running it was leaving the entire point of that build
+      # unobserved on every leg except ubuntu/GNU, where the coverage target
+      # runs the tests as a side effect.
+      #
+      # This runs the single test_all binary rather than `ctest`. Measured on a
+      # 64-core machine: test_all runs all 645 tests in ~71 s, while `ctest -j64`
+      # had not finished after 13 minutes -- the R-parity fixtures shell out to
+      # Rscript and exchange data through hardcoded `temp`/`temp2`/`temp3` files
+      # in the working directory (test/src_test/vinecop_test.cpp:18-31 and
+      # cmake/templates/test_vinecop_parametric.R:42-45), so concurrent cases
+      # clobber and delete each other's files and wedge. Making those paths
+      # unique per test is a prerequisite for using ctest's parallelism.
+      - name: Run the debug tests
+        if: matrix.cfg.os != 'ubuntu-latest' || matrix.cfg.name != 'GNU'
+        run: |
+          cd debug
+          if [ "${{ matrix.cfg.os }}" != "windows-latest" ]; then bin/test_all; else bin/test_all.exe; fi
+        shell: bash
+      # Cheap guard for the test-registration wiring that nothing exercised
+      # before: gtest_discover_tests writes a `<target>_NOT_BUILT` placeholder
+      # when discovery fails, so a healthy build must list far more than one.
+      - name: Check that ctest discovery works
+        if: matrix.cfg.os != 'windows-latest'
+        run: |
+          cd debug
+          n=$(ctest -N | sed -n 's/^Total Tests: //p')
+          echo "ctest discovered $n test(s)"
+          if [ "${n:-0}" -lt 100 ]; then
+            echo "::error::ctest discovered only ${n:-0} tests; gtest_discover_tests is broken"
+            exit 1
+          fi
+        shell: bash
       - name: Code coverage
         uses: codecov/codecov-action@v5
         if: contains(matrix.cfg.os, 'ubuntu') && contains(matrix.cfg.name, 'GNU')
         with:
-          token: ${{secrets.CODECOV_TOKEN}}
-          file: debug/coverage.info 
-      - name: Compile, test and install the release version
-        run:   |
+          token: ${{ secrets.CODECOV_TOKEN }}
+          # `file:` was silently ignored -- the input has been `files:` since
+          # codecov-action v4, so the explicit path did nothing and the uploader
+          # only worked by falling back to auto-discovery.
+          files: debug/coverage.info
+          disable_search: true
+          fail_ci_if_error: true
+      - name: Compile, test and install the precompiled release version
+        run: |
           mkdir release && cd release
           if [ "${{ matrix.cfg.os }}" != "windows-latest" ]; then
             cmake .. -DCMAKE_BUILD_TYPE=Release -DVINECOPULIB_PRECOMPILED=ON
-            make && sudo make install
+            make
             bin/test_all
+            sudo make install
           else
-            cmake .. -G Ninja \
-            -DCMAKE_BUILD_TYPE=Release -DVINECOPULIB_PRECOMPILED=ON
+            cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release -DVINECOPULIB_PRECOMPILED=ON
             cmake --build .
             bin/test_all.exe
             cmake --build . --target install
           fi
         shell: bash
-      - name: Test the install
-        run:   |
-          cd examples/bicop
-          mkdir build && cd build
-          if [ "${{ matrix.cfg.os }}" != "windows-latest" ]; then
-            cmake .. && make
-            ../bin/main
-          else
-            cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release
-            cmake --build .
-            ../bin/main.exe
-          fi
+      - name: Test the install (bicop and vinecop examples)
+        run: |
+          for ex in bicop vinecop; do
+            ( cd "examples/$ex" && mkdir build && cd build
+              if [ "${{ matrix.cfg.os }}" != "windows-latest" ]; then
+                cmake .. && make && ../bin/main
+              else
+                cmake .. -G Ninja -DCMAKE_BUILD_TYPE=Release
+                cmake --build .
+                ../bin/main.exe
+              fi )
+          done
         shell: bash
+
+  # The default, header-only configuration had no CI coverage at all: both
+  # installs above set VINECOPULIB_PRECOMPILED=ON, so the .hpp + .ipp install
+  # tree that most users and both wrapper libraries consume was never built,
+  # installed, or linked against.
+  header-only-install:
+    name: header-only install (ubuntu, GNU)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install dependencies
+        id: install-dependencies
+        uses: ./.github/actions/install-dependencies
+        with:
+          os: ubuntu-latest
+          boost_version: ${{ env.BOOST_VERSION }}
+          eigen_version: ${{ env.EIGEN_VERSION }}
+          R: true
+      - name: Set environment variables
+        run: |
+          echo "BOOST_ROOT=${{ steps.install-dependencies.outputs.BOOST_ROOT }}" >> $GITHUB_ENV
+          echo "Boost_INCLUDE_DIR=${{ steps.install-dependencies.outputs.BOOST_ROOT }}/include" >> $GITHUB_ENV
+          echo "EIGEN3_INCLUDE_DIR=${{ steps.install-dependencies.outputs.EIGEN3_ROOT }}/include/eigen3" >> $GITHUB_ENV
+      - name: Configure, build, test and install (header-only)
+        run: |
+          mkdir release && cd release
+          cmake .. -DCMAKE_BUILD_TYPE=Release
+          make
+          bin/test_all
+          sudo make install
+      - name: Verify the .ipp tree was installed
+        run: |
+          test -f /usr/local/include/vinecopulib/bicop/implementation/class.ipp \
+            || { echo "header-only install did not ship the .ipp tree"; exit 1; }
+      - name: Link the examples against the header-only install
+        run: |
+          for ex in bicop vinecop; do
+            ( cd "examples/$ex" && mkdir build && cd build && cmake .. && make && ../bin/main )
+          done
+
+  # bench_all and parity_dump were built by no workflow, so the whole #688
+  # benchmark and numerical-parity infrastructure could rot against header
+  # changes without anyone noticing. The parity self-comparison is cheap and
+  # proves the dump populates every group and that the gates file parses.
+  benchmarks:
+    name: benchmarks and parity harness
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install dependencies
+        id: install-dependencies
+        uses: ./.github/actions/install-dependencies
+        with:
+          os: ubuntu-latest
+          boost_version: ${{ env.BOOST_VERSION }}
+          eigen_version: ${{ env.EIGEN_VERSION }}
+          R: false
+      - name: Set environment variables
+        run: |
+          echo "BOOST_ROOT=${{ steps.install-dependencies.outputs.BOOST_ROOT }}" >> $GITHUB_ENV
+          echo "Boost_INCLUDE_DIR=${{ steps.install-dependencies.outputs.BOOST_ROOT }}/include" >> $GITHUB_ENV
+          echo "EIGEN3_INCLUDE_DIR=${{ steps.install-dependencies.outputs.EIGEN3_ROOT }}/include/eigen3" >> $GITHUB_ENV
+      - name: Build bench_all and parity_dump
+        run: |
+          mkdir build-bench && cd build-bench
+          cmake .. -DCMAKE_BUILD_TYPE=Release \
+            -DVINECOPULIB_BUILD_BENCHMARKS=ON -DBUILD_TESTING=OFF
+          make bench_all parity_dump
+      - name: Smoke-run the benchmark suite
+        run: build-bench/bin/bench_all --benchmark_min_time=1x --benchmark_filter='bicop/pdf'
+      - name: Parity dump and self-comparison
+        run: |
+          mkdir -p bench_results
+          build-bench/bin/parity_dump bench_results/parity.json
+          cp bench_results/parity.json bench_results/parity_ref.json
+          python3 scripts/compare_parity.py \
+            bench_results/parity_ref.json bench_results/parity.json \
+            --tol-config scripts/parity_gates.json
+      - name: Upload the parity dump
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: parity-dump
+          path: bench_results/parity.json
+          if-no-files-found: warn
+
+  # Doxygen was never even smoke-built, which is how ~10 uncompilable snippets
+  # and a stale Doxyfile went unnoticed. This job currently only proves the
+  # configuration still runs; the docs rewrite tightens it to WARN_AS_ERROR.
+  docs:
+    name: doxygen
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v5
+      - name: Install Doxygen
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -y doxygen graphviz
+      - name: Install dependencies
+        id: install-dependencies
+        uses: ./.github/actions/install-dependencies
+        with:
+          os: ubuntu-latest
+          boost_version: ${{ env.BOOST_VERSION }}
+          eigen_version: ${{ env.EIGEN_VERSION }}
+          R: false
+          lcov: false
+      - name: Build the documentation
+        run: |
+          mkdir build-docs && cd build-docs
+          cmake .. -DBUILD_DOC=ON -DBUILD_TESTING=OFF \
+            -DBoost_INCLUDE_DIR=${{ steps.install-dependencies.outputs.BOOST_ROOT }}/include \
+            -DEIGEN3_INCLUDE_DIR=${{ steps.install-dependencies.outputs.EIGEN3_ROOT }}/include/eigen3
+          make doc 2>&1 | tee doxygen.log
+      - name: Summarize Doxygen warnings
+        if: always()
+        run: |
+          count=$(grep -c -i 'warning' build-docs/doxygen.log || true)
+          echo "Doxygen emitted $count warning line(s)."
+          grep -i 'warning' build-docs/doxygen.log | head -50 || true
+      - name: Upload the Doxygen log
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: doxygen-log
+          path: build-docs/doxygen.log
+          if-no-files-found: warn
+
+  # Replaces the block that sat commented out in this file. Runs only on the
+  # pull-request diff, so the curated check list is enforceable as an error
+  # instead of producing thousands of findings nobody reads.
+  clang-tidy:
+    name: clang-tidy (diff)
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+      - name: Install clang-tidy
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -y clang-tidy-14 jq
+      - name: Install dependencies
+        id: install-dependencies
+        uses: ./.github/actions/install-dependencies
+        with:
+          os: ubuntu-latest
+          boost_version: ${{ env.BOOST_VERSION }}
+          eigen_version: ${{ env.EIGEN_VERSION }}
+          R: true
+      - name: Configure to generate compile_commands.json
+        run: |
+          mkdir build-tidy && cd build-tidy
+          cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+            -DBoost_INCLUDE_DIR=${{ steps.install-dependencies.outputs.BOOST_ROOT }}/include \
+            -DEIGEN3_INCLUDE_DIR=${{ steps.install-dependencies.outputs.EIGEN3_ROOT }}/include/eigen3
+          # FetchContent puts googletest translation units in the database; they
+          # are not ours to lint.
+          jq '[.[] | select(.file | test("_deps/") | not)]' compile_commands.json > filtered.json
+          mv filtered.json compile_commands.json
+      - name: Run clang-tidy on the diff
+        run: |
+          git diff -U0 "origin/${{ github.base_ref }}...HEAD" \
+            -- '*.hpp' '*.ipp' '*.cpp' '*.cc' '*.h' \
+            ':(exclude)include/vinecopulib/misc/nlohmann_json.hpp' \
+            ':(exclude)include/vinecopulib/misc/tools_stats_sobol.hpp' \
+            | /usr/lib/llvm-14/share/clang/clang-tidy-diff.py \
+                -p1 -path build-tidy -clang-tidy-binary clang-tidy-14 -use-color

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -317,12 +317,20 @@ jobs:
           eigen_version: ${{ env.EIGEN_VERSION }}
           R: false
           lcov: false
+      # Same shape as every other job: export BOOST_ROOT so find_package picks
+      # it up via CMP0074. Passing -DBoost_INCLUDE_DIR on the command line does
+      # not work -- findDependencies.cmake tests the *plural*
+      # Boost_INCLUDE_DIRS, so the guard does not fire and Boost::boost never
+      # gets defined.
+      - name: Set environment variables
+        run: |
+          echo "BOOST_ROOT=${{ steps.install-dependencies.outputs.BOOST_ROOT }}" >> $GITHUB_ENV
+          echo "Boost_INCLUDE_DIR=${{ steps.install-dependencies.outputs.BOOST_ROOT }}/include" >> $GITHUB_ENV
+          echo "EIGEN3_INCLUDE_DIR=${{ steps.install-dependencies.outputs.EIGEN3_ROOT }}/include/eigen3" >> $GITHUB_ENV
       - name: Build the documentation
         run: |
           mkdir build-docs && cd build-docs
-          cmake .. -DBUILD_DOC=ON -DBUILD_TESTING=OFF \
-            -DBoost_INCLUDE_DIR=${{ steps.install-dependencies.outputs.BOOST_ROOT }}/include \
-            -DEIGEN3_INCLUDE_DIR=${{ steps.install-dependencies.outputs.EIGEN3_ROOT }}/include/eigen3
+          cmake .. -DBUILD_DOC=ON -DBUILD_TESTING=OFF
           make doc 2>&1 | tee doxygen.log
       - name: Summarize Doxygen warnings
         if: always()
@@ -362,12 +370,15 @@ jobs:
           boost_version: ${{ env.BOOST_VERSION }}
           eigen_version: ${{ env.EIGEN_VERSION }}
           R: true
+      - name: Set environment variables
+        run: |
+          echo "BOOST_ROOT=${{ steps.install-dependencies.outputs.BOOST_ROOT }}" >> $GITHUB_ENV
+          echo "Boost_INCLUDE_DIR=${{ steps.install-dependencies.outputs.BOOST_ROOT }}/include" >> $GITHUB_ENV
+          echo "EIGEN3_INCLUDE_DIR=${{ steps.install-dependencies.outputs.EIGEN3_ROOT }}/include/eigen3" >> $GITHUB_ENV
       - name: Configure to generate compile_commands.json
         run: |
           mkdir build-tidy && cd build-tidy
-          cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
-            -DBoost_INCLUDE_DIR=${{ steps.install-dependencies.outputs.BOOST_ROOT }}/include \
-            -DEIGEN3_INCLUDE_DIR=${{ steps.install-dependencies.outputs.EIGEN3_ROOT }}/include/eigen3
+          cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
           # FetchContent puts googletest translation units in the database; they
           # are not ours to lint.
           jq '[.[] | select(.file | test("_deps/") | not)]' compile_commands.json > filtered.json

--- a/.github/workflows/release-drift.yml
+++ b/.github/workflows/release-drift.yml
@@ -1,0 +1,54 @@
+name: Release drift
+
+# The 0.8.0 failure mode, caught on a schedule: every version string in the tree
+# said 0.8.0 and the NEWS heading carried a real date, but no v0.8.0 tag was ever
+# pushed. Nothing was watching, so the repo sat half-released for months.
+#
+# This has to be scheduled rather than push-triggered: between the release PR
+# merging and the tag being pushed, the tree legitimately sits in the
+# dated-but-untagged state for a few minutes. A weekly check means a forgotten
+# tag surfaces within a week instead of never.
+
+on:
+  schedule:
+    - cron: '17 6 * * 1'  # Mondays, 06:17 UTC
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  drift:
+    name: declared version is tagged
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0  # need the tags
+
+      - name: Compare the declared version against the tags
+        run: |
+          version=$(sed -nE 's/^project\(vinecopulib VERSION ([0-9.]+)\).*/\1/p' CMakeLists.txt)
+          if [ -z "$version" ]; then
+            echo "::error::could not read the project version from CMakeLists.txt"
+            exit 1
+          fi
+          echo "Declared version: $version"
+
+          news_heading=$(grep -m1 '^## vinecopulib ' NEWS.md)
+          echo "Top NEWS heading: $news_heading"
+
+          if printf '%s' "$news_heading" | grep -qi '(unreleased)'; then
+            echo "Version $version is marked unreleased in NEWS.md; nothing to tag yet."
+            exit 0
+          fi
+
+          if git rev-parse -q --verify "refs/tags/v$version" >/dev/null; then
+            echo "Tag v$version exists. No drift."
+            exit 0
+          fi
+
+          echo "::error::NEWS.md declares $version as released but tag v$version does not exist."
+          echo "Either push the tag (see docs/releasing.md) or set the NEWS heading back to (unreleased)."
+          exit 1

--- a/.github/workflows/release-drift.yml
+++ b/.github/workflows/release-drift.yml
@@ -1,13 +1,8 @@
 name: Release drift
 
-# The 0.8.0 failure mode, caught on a schedule: every version string in the tree
-# said 0.8.0 and the NEWS heading carried a real date, but no v0.8.0 tag was ever
-# pushed. Nothing was watching, so the repo sat half-released for months.
-#
-# This has to be scheduled rather than push-triggered: between the release PR
-# merging and the tag being pushed, the tree legitimately sits in the
-# dated-but-untagged state for a few minutes. A weekly check means a forgotten
-# tag surfaces within a week instead of never.
+# Catches a version that NEWS.md declares released but that was never tagged.
+# Scheduled rather than push-triggered, because the tree legitimately sits
+# dated-but-untagged between the release PR merging and the tag being pushed.
 
 on:
   schedule:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,107 @@
+name: Release
+
+# Releases used to be a plain merge commit on main plus a hand-pushed tag, with
+# nothing verifying the two agreed. The 0.8.0 cycle bumped every version string
+# and dated the NEWS heading but never pushed a tag, and nobody noticed for
+# months. This workflow makes the tag the trigger and refuses to publish unless
+# the declared version, the tag, and the changelog all match.
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to publish (e.g. v1.0.0). Must already exist.'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  verify:
+    name: verify release metadata
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    outputs:
+      version: ${{ steps.declared.outputs.version }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+
+      - name: Check the version, the tag, and the changelog agree
+        run: |
+          python3 scripts/check_version.py \
+            --released --tag "${{ inputs.tag || github.ref_name }}"
+
+      - name: Read the declared version
+        id: declared
+        run: |
+          version=$(sed -nE 's/^project\(vinecopulib VERSION ([0-9.]+)\).*/\1/p' CMakeLists.txt)
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+          echo "Releasing version $version"
+
+      - name: Extract this version's NEWS.md section
+        run: |
+          # Everything between the first '## vinecopulib ...' heading and the
+          # next one becomes the release body.
+          awk '/^## vinecopulib /{n++; if (n>1) exit} n==1' NEWS.md \
+            | tail -n +2 > release-notes.md
+          if [ ! -s release-notes.md ]; then
+            echo "Refusing to publish: the NEWS.md section is empty." >&2
+            exit 1
+          fi
+          echo "--- release body ---"
+          cat release-notes.md
+
+      - name: Upload the release notes
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-notes
+          path: release-notes.md
+
+  # Re-run the full matrix against the exact tagged tree. A tag that cannot
+  # build is not a release.
+  build:
+    name: re-run CI on the tag
+    needs: verify
+    uses: ./.github/workflows/continuous_integration.yml
+    secrets: inherit
+
+  publish:
+    name: publish the GitHub release
+    needs: [verify, build]
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.tag || github.ref }}
+
+      - name: Download the release notes
+        uses: actions/download-artifact@v4
+        with:
+          name: release-notes
+
+      - name: Create a source archive and checksum
+        run: |
+          tag="${{ inputs.tag || github.ref_name }}"
+          version="${{ needs.verify.outputs.version }}"
+          git archive --format=tar.gz --prefix="vinecopulib-${version}/" \
+            -o "vinecopulib-${version}.tar.gz" "$tag"
+          sha256sum "vinecopulib-${version}.tar.gz" > "vinecopulib-${version}.tar.gz.sha256"
+
+      - name: Create the release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="${{ inputs.tag || github.ref_name }}"
+          version="${{ needs.verify.outputs.version }}"
+          gh release create "$tag" \
+            --title "vinecopulib $version" \
+            --notes-file release-notes.md \
+            --verify-tag \
+            "vinecopulib-${version}.tar.gz" \
+            "vinecopulib-${version}.tar.gz.sha256"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,10 +1,7 @@
 name: Release
 
-# Releases used to be a plain merge commit on main plus a hand-pushed tag, with
-# nothing verifying the two agreed. The 0.8.0 cycle bumped every version string
-# and dated the NEWS heading but never pushed a tag, and nobody noticed for
-# months. This workflow makes the tag the trigger and refuses to publish unless
-# the declared version, the tag, and the changelog all match.
+# The tag is the trigger. Refuses to publish unless the declared version, the
+# tag, and the NEWS.md heading all agree. See docs/releasing.md.
 
 on:
   push:
@@ -45,8 +42,7 @@ jobs:
 
       - name: Extract this version's NEWS.md section
         run: |
-          # Everything between the first '## vinecopulib ...' heading and the
-          # next one becomes the release body.
+          # The first NEWS.md section becomes the release body.
           awk '/^## vinecopulib /{n++; if (n>1) exit} n==1' NEWS.md \
             | tail -n +2 > release-notes.md
           if [ ! -s release-notes.md ]; then
@@ -62,8 +58,7 @@ jobs:
           name: release-notes
           path: release-notes.md
 
-  # Re-run the full matrix against the exact tagged tree. A tag that cannot
-  # build is not a release.
+  # A tag that cannot build is not a release.
   build:
     name: re-run CI on the tag
     needs: verify

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -326,11 +326,21 @@ For any behaviour change:
 - Run the validation sequence: `clang-format-14`, a Debug build +
   `bin/test_all`, and — for anything touching the install/precompiled
   path — a `VINECOPULIB_PRECOMPILED=ON` release build.
+- **Fix what you find.** A defect uncovered along the way is addressed, not
+  annotated, worked around, or left for later behind an explanatory comment.
+  When the real fix genuinely belongs in a separate change, say so in the PR
+  description and open an issue for it — a comment is not a substitute.
 
 ## Coding conventions
 
 - **Style: `BasedOnStyle: Mozilla`** (2-space indent, ~80-column),
   enforced by clang-format 14.
+- **Comments are documentation, not history.** Keep them short and aimed at
+  whoever reads the code next: the constraint, the invariant, or the reason a
+  non-obvious choice is required. Previous bugs, benchmark numbers, review
+  discussion, and the reasoning behind a change belong in the commit message
+  and the PR description. If a comment needs a paragraph, it probably belongs
+  there instead. This applies equally to CMake, CI workflows, and configs.
 - **Compiler warnings.** Do not suppress warnings with diagnostic pragmas.
   Fix the underlying code instead, including in vendored headers when the
   warning originates there. If a warning cannot reasonably be fixed, keep any

--- a/README.md
+++ b/README.md
@@ -1,8 +1,7 @@
 # vinecopulib
 
-[![Build Status](https://github.com/vinecopulib/vinecopulib/workflows/Build%20Status/badge.svg)](https://github.com/vinecopulib/vinecopulib/actions)
+[![Build Status](https://github.com/vinecopulib/vinecopulib/actions/workflows/continuous_integration.yml/badge.svg?branch=main)](https://github.com/vinecopulib/vinecopulib/actions/workflows/continuous_integration.yml)
 [![Coverage Status](https://img.shields.io/codecov/c/github/vinecopulib/vinecopulib/main.svg)](https://codecov.io/github/vinecopulib/vinecopulib?branch=main)
-[![Codacy Badge](https://app.codacy.com/project/badge/Grade/2c8d45ebcb954082b409b4a2bd31af2b)](https://www.codacy.com/gh/vinecopulib/vinecopulib/dashboard?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=vinecopulib/vinecopulib&amp;utm_campaign=Badge_Grade)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 [![Documentation](https://img.shields.io/website/http/vinecopulib.github.io/vinecopulib.svg)](https://vinecopulib.github.io/vinecopulib/)
 [![DOI](https://zenodo.org/badge/76354683.svg)](https://zenodo.org/badge/latestdoi/76354683)

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,6 @@
 codecov:
   notify:
-    require_ci_to_pass: yes
+    require_ci_to_pass: true
 
 coverage:
   precision: 2
@@ -18,19 +18,26 @@ coverage:
         threshold: 0.5%
         base: auto
         target: auto
+
 parsers:
   gcov:
     branch_detection:
-      conditional: yes
-      loop: yes
-      method: no
-      macro: no
+      conditional: true
+      loop: true
+      method: false
+      macro: false
 
 comment:
   layout: "reach, diff, flags, files, footer"
   behavior: default
-  require_changes: no
+  require_changes: false
 
 ignore:
   - "test/"
+  - "benchmarks/"
+  - "examples/"
   - "include/vinecopulib/misc/nlohmann_json.hpp"
+  # Generated tables, not hand-written code: the Sobol direction numbers alone
+  # are 3.4 MB, which distorts the line-coverage denominator.
+  - "include/vinecopulib/misc/tools_stats_sobol.hpp"
+  - "include/vinecopulib/misc/tools_stats_ghalton.hpp"

--- a/examples/vinecop/src/main.cpp
+++ b/examples/vinecop/src/main.cpp
@@ -33,15 +33,15 @@ main()
   Eigen::Matrix<size_t, Eigen::Dynamic, Eigen::Dynamic> mat(3, 3);
   mat << 1, 1, 1, 2, 2, 0, 3, 0, 0;
 
-  // instantiate a custom model using pair_copulas and
-  Vinecop custom_model(pair_copulas, mat);
+  // instantiate a custom model from the structure matrix and the pair copulas
+  Vinecop custom_model(mat, pair_copulas);
 
   // simulate data
   Eigen::MatrixXd data = custom_model.simulate(1e3);
 
-  // instantiate a D-vine and select the families
+  // instantiate a D-vine and fit the pair copulas on its fixed structure
   Vinecop fitted(d);
-  fitted.select_families(data);
+  fitted.fit(data);
 
   // alternatively, instantiate a new object by
   // selecting the structure along with the families

--- a/include/vinecopulib/version.hpp
+++ b/include/vinecopulib/version.hpp
@@ -15,8 +15,13 @@
 //  VINECOPULIB_VERSION % 100 is the patch level
 //  VINECOPULIB_VERSION / 100 % 1000 is the minor version
 //  VINECOPULIB_VERSION / 100000 is the major version
+//
+//  This must be a plain decimal literal with no leading zeros: a leading zero
+//  makes it octal, which either decodes to the wrong version or -- for any
+//  digit above 7 -- is not a valid literal at all, turning the arithmetic
+//  above into a compile error. `scripts/check_version.py` enforces this.
 
-#define VINECOPULIB_VERSION 000800
+#define VINECOPULIB_VERSION 800
 
 //
 //  VINECOPULIB_LIB_VERSION must be defined to be the same as

--- a/include/vinecopulib/version.hpp
+++ b/include/vinecopulib/version.hpp
@@ -16,10 +16,8 @@
 //  VINECOPULIB_VERSION / 100 % 1000 is the minor version
 //  VINECOPULIB_VERSION / 100000 is the major version
 //
-//  This must be a plain decimal literal with no leading zeros: a leading zero
-//  makes it octal, which either decodes to the wrong version or -- for any
-//  digit above 7 -- is not a valid literal at all, turning the arithmetic
-//  above into a compile error. `scripts/check_version.py` enforces this.
+//  Must be a plain decimal literal: a leading zero makes it octal and breaks
+//  the arithmetic above. Enforced by scripts/check_version.py.
 
 #define VINECOPULIB_VERSION 800
 

--- a/include/vinecopulib/vinecop/class.hpp
+++ b/include/vinecopulib/vinecop/class.hpp
@@ -47,10 +47,11 @@ public:
                    const std::vector<std::string>& var_types = {},
                    const FitControlsVinecop& controls = FitControlsVinecop());
 
+  // `matrix` must not be defaulted: that makes `Vinecop(data)` ambiguous with
+  // the overload above.
   explicit Vinecop(
     const Eigen::MatrixXd& data,
-    const Eigen::Matrix<size_t, Eigen::Dynamic, Eigen::Dynamic>& matrix =
-      Eigen::Matrix<size_t, Eigen::Dynamic, Eigen::Dynamic>(),
+    const Eigen::Matrix<size_t, Eigen::Dynamic, Eigen::Dynamic>& matrix,
     const std::vector<std::string>& var_types = {},
     const FitControlsVinecop& controls = FitControlsVinecop());
 

--- a/include/vinecopulib/vinecop/implementation/class.ipp
+++ b/include/vinecopulib/vinecop/implementation/class.ipp
@@ -108,9 +108,9 @@ inline Vinecop::Vinecop(const Eigen::MatrixXd& data,
 //! then selecting the model using `select()`.
 //!
 //! @param data An \f$ n \times d \f$ matrix of observations.
-//! @param matrix Either an empty matrix (default) or an R-vine structure
-//!     matrix, see `select()`. If empty, then it is selected as part of the
-//!     fit.
+//! @param matrix Either an R-vine structure matrix, see `select()`, or an
+//!     empty matrix, in which case the structure is selected as part of the
+//!     fit. To select the structure, prefer `Vinecop(data)`.
 //! @param var_types Strings specifying the types of the variables,
 //!   e.g., `("c", "d")` means first variable continuous, second discrete.
 //!   If empty, then all variables are set as continuous.

--- a/scripts/check_version.py
+++ b/scripts/check_version.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Check that the version is stated consistently everywhere it appears.
+
+The version of vinecopulib lives in several hand-maintained places. Nothing
+used to verify that they agree, and the 0.8.0 cycle showed what that costs:
+``CMakeLists.txt``, ``version.hpp``, both Doxyfiles and ``NEWS.md`` were all
+bumped to 0.8.0 and dated, but no ``v0.8.0`` tag was ever pushed, and the tree
+sat in that half-released state for months.
+
+Run with no arguments to check internal consistency (the ``version`` CI job on
+every pull request)::
+
+    python3 scripts/check_version.py
+
+Add ``--released`` to additionally require that the top ``NEWS.md`` heading
+carries a real date rather than ``(unreleased)``, and ``--tag vX.Y.Z`` to
+require that a git tag matches the declared version (the release workflow)::
+
+    python3 scripts/check_version.py --released --tag "$GITHUB_REF_NAME"
+
+Exits 0 if every check passes, 1 otherwise, printing one line per check.
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# vinecopulib encodes the version as major * 100000 + minor * 100 + patch; see
+# the comment block in include/vinecopulib/version.hpp.
+MAJOR_SCALE = 100000
+MINOR_SCALE = 100
+
+
+class Failures(list):
+    """Collected problems, so one run reports every mismatch at once."""
+
+    def check(self, condition: bool, message: str) -> bool:
+        status = "ok  " if condition else "FAIL"
+        print(f"  [{status}] {message}")
+        if not condition:
+            self.append(message)
+        return condition
+
+
+def read(relative_path: str) -> str | None:
+    path = REPO_ROOT / relative_path
+    if not path.is_file():
+        return None
+    return path.read_text(encoding="utf-8")
+
+
+def encode(major: int, minor: int, patch: int) -> int:
+    return major * MAJOR_SCALE + minor * MINOR_SCALE + patch
+
+
+def lib_version_string(major: int, minor: int, patch: int) -> str:
+    """"x_y" when the patch level is 0, "x_y_z" otherwise."""
+    if patch == 0:
+        return f"{major}_{minor}"
+    return f"{major}_{minor}_{patch}"
+
+
+def parse_project_version(failures: Failures) -> tuple[int, int, int] | None:
+    """The single source of truth: project(vinecopulib VERSION X.Y.Z)."""
+    text = read("CMakeLists.txt")
+    if text is None:
+        failures.check(False, "CMakeLists.txt is missing")
+        return None
+    match = re.search(
+        r"project\s*\(\s*vinecopulib\s+VERSION\s+(\d+)\.(\d+)\.(\d+)",
+        text,
+        re.IGNORECASE,
+    )
+    if match is None:
+        failures.check(False, "CMakeLists.txt: no project(vinecopulib VERSION X.Y.Z)")
+        return None
+    version = tuple(int(g) for g in match.groups())
+    print(f"  project version: {version[0]}.{version[1]}.{version[2]}")
+    return version  # type: ignore[return-value]
+
+
+def check_version_header(failures: Failures, major: int, minor: int, patch: int) -> None:
+    text = read("include/vinecopulib/version.hpp")
+    if text is None:
+        failures.check(False, "include/vinecopulib/version.hpp is missing")
+        return
+
+    match = re.search(r"#define\s+VINECOPULIB_VERSION\s+(\S+)", text)
+    if not failures.check(match is not None, "version.hpp defines VINECOPULIB_VERSION"):
+        return
+    literal = match.group(1)  # type: ignore[union-attr]
+
+    # A leading zero makes this an octal literal, so it either decodes to the
+    # wrong number (0.7.3 shipped as 000703, i.e. octal 451) or does not compile
+    # at all (0.8.0 shipped as 000800, and 8 is not a valid octal digit -- the
+    # documented `VINECOPULIB_VERSION / 100 % 1000` arithmetic in version.hpp is
+    # a hard compile error the moment anyone actually uses it). Require a plain
+    # decimal literal so the documented contract works.
+    is_decimal = re.fullmatch(r"0|[1-9]\d*", literal) is not None
+    failures.check(
+        is_decimal,
+        f"VINECOPULIB_VERSION is a plain decimal literal (found {literal!r}"
+        + ("" if is_decimal else "; a leading zero makes it octal")
+        + ")",
+    )
+
+    if is_decimal:
+        expected = encode(major, minor, patch)
+        failures.check(
+            int(literal) == expected,
+            f"VINECOPULIB_VERSION == {expected} (found {literal})",
+        )
+
+    match = re.search(r'#define\s+VINECOPULIB_LIB_VERSION\s+"([^"]*)"', text)
+    if failures.check(
+        match is not None, "version.hpp defines VINECOPULIB_LIB_VERSION"
+    ):
+        expected_lib = lib_version_string(major, minor, patch)
+        found_lib = match.group(1)  # type: ignore[union-attr]
+        failures.check(
+            found_lib == expected_lib,
+            f'VINECOPULIB_LIB_VERSION == "{expected_lib}" (found "{found_lib}")',
+        )
+
+
+def check_doxyfiles(failures: Failures, version: str) -> None:
+    for relative_path in ("docs/Doxyfile", "docs/Doxyfile.in"):
+        text = read(relative_path)
+        if text is None:
+            # docs/Doxyfile is deliberately removed once the two are collapsed
+            # into a single template; absence is not a failure.
+            continue
+        match = re.search(r"^\s*PROJECT_NUMBER\s*=\s*(.*)$", text, re.MULTILINE)
+        if match is None:
+            failures.check(False, f"{relative_path}: no PROJECT_NUMBER")
+            continue
+        found = match.group(1).strip()
+        if found.startswith("@") and found.endswith("@"):
+            # Substituted by CMake from PROJECT_VERSION; nothing to compare.
+            print(f"  [ok  ] {relative_path}: PROJECT_NUMBER templated ({found})")
+            continue
+        failures.check(
+            found == version,
+            f"{relative_path}: PROJECT_NUMBER == {version} (found {found or '<empty>'})",
+        )
+
+
+def parse_news_heading(failures: Failures) -> tuple[str, str] | None:
+    """Return (version, date-or-unreleased) from the top NEWS.md heading."""
+    text = read("NEWS.md")
+    if text is None:
+        failures.check(False, "NEWS.md is missing")
+        return None
+    for line in text.splitlines():
+        if not line.startswith("## "):
+            continue
+        match = re.match(r"##\s+vinecopulib\s+(\S+)\s+\((.+)\)\s*$", line)
+        if match is None:
+            failures.check(
+                False,
+                "NEWS.md: first heading is not '## vinecopulib X.Y.Z (date)'"
+                f" (found {line.strip()!r})",
+            )
+            return None
+        return match.group(1), match.group(2).strip()
+    failures.check(False, "NEWS.md: no '## vinecopulib ...' heading found")
+    return None
+
+
+def check_citation(failures: Failures, version: str) -> None:
+    text = read("CITATION.cff")
+    if text is None:
+        # Added later in the release; absence is not a failure.
+        return
+    match = re.search(r"^version:\s*['\"]?([^'\"\s]+)", text, re.MULTILINE)
+    if match is None:
+        failures.check(False, "CITATION.cff: no version field")
+        return
+    failures.check(
+        match.group(1) == version,
+        f"CITATION.cff: version == {version} (found {match.group(1)})",
+    )
+
+
+def check_zenodo(failures: Failures, version: str) -> None:
+    text = read(".zenodo.json")
+    if text is None:
+        return
+    match = re.search(r'"version"\s*:\s*"([^"]+)"', text)
+    if match is None:
+        # .zenodo.json has no version field today; Zenodo falls back to the
+        # release tag, so this is optional rather than wrong.
+        return
+    failures.check(
+        match.group(1) == version,
+        f".zenodo.json: version == {version} (found {match.group(1)})",
+    )
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--released",
+        action="store_true",
+        help="also require the top NEWS.md heading to carry a real date",
+    )
+    parser.add_argument(
+        "--tag",
+        default=None,
+        metavar="vX.Y.Z",
+        help="also require this git tag to match the declared version",
+    )
+    args = parser.parse_args()
+
+    failures = Failures()
+    print("Checking version consistency:")
+
+    parsed = parse_project_version(failures)
+    if parsed is None:
+        print("\nFAILED: cannot determine the project version.")
+        return 1
+    major, minor, patch = parsed
+    version = f"{major}.{minor}.{patch}"
+
+    check_version_header(failures, major, minor, patch)
+    check_doxyfiles(failures, version)
+    check_citation(failures, version)
+    check_zenodo(failures, version)
+
+    news = parse_news_heading(failures)
+    if news is not None:
+        news_version, news_date = news
+        failures.check(
+            news_version == version,
+            f"NEWS.md: top heading version == {version} (found {news_version})",
+        )
+        if args.released:
+            failures.check(
+                news_date.lower() != "unreleased",
+                f"NEWS.md: top heading is dated, not '(unreleased)' (found"
+                f" '({news_date})')",
+            )
+        else:
+            print(f"  news date: ({news_date})")
+
+    if args.tag is not None:
+        expected_tag = f"v{version}"
+        failures.check(
+            args.tag == expected_tag,
+            f"git tag == {expected_tag} (found {args.tag})",
+        )
+
+    if failures:
+        print(f"\nFAILED: {len(failures)} check(s) did not pass.")
+        return 1
+    print(f"\nOK: version {version} is stated consistently.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/check_version.py
+++ b/scripts/check_version.py
@@ -1,11 +1,9 @@
 #!/usr/bin/env python3
 """Check that the version is stated consistently everywhere it appears.
 
-The version of vinecopulib lives in several hand-maintained places. Nothing
-used to verify that they agree, and the 0.8.0 cycle showed what that costs:
-``CMakeLists.txt``, ``version.hpp``, both Doxyfiles and ``NEWS.md`` were all
-bumped to 0.8.0 and dated, but no ``v0.8.0`` tag was ever pushed, and the tree
-sat in that half-released state for months.
+The version lives in several hand-maintained places: ``CMakeLists.txt``,
+``version.hpp``, the Doxyfiles, ``NEWS.md``, ``CITATION.cff`` and
+``.zenodo.json``. This checks that they agree.
 
 Run with no arguments to check internal consistency (the ``version`` CI job on
 every pull request)::
@@ -95,12 +93,8 @@ def check_version_header(failures: Failures, major: int, minor: int, patch: int)
         return
     literal = match.group(1)  # type: ignore[union-attr]
 
-    # A leading zero makes this an octal literal, so it either decodes to the
-    # wrong number (0.7.3 shipped as 000703, i.e. octal 451) or does not compile
-    # at all (0.8.0 shipped as 000800, and 8 is not a valid octal digit -- the
-    # documented `VINECOPULIB_VERSION / 100 % 1000` arithmetic in version.hpp is
-    # a hard compile error the moment anyone actually uses it). Require a plain
-    # decimal literal so the documented contract works.
+    # A leading zero would make this octal, breaking the arithmetic that
+    # version.hpp documents.
     is_decimal = re.fullmatch(r"0|[1-9]\d*", literal) is not None
     failures.check(
         is_decimal,
@@ -132,8 +126,6 @@ def check_doxyfiles(failures: Failures, version: str) -> None:
     for relative_path in ("docs/Doxyfile", "docs/Doxyfile.in"):
         text = read(relative_path)
         if text is None:
-            # docs/Doxyfile is deliberately removed once the two are collapsed
-            # into a single template; absence is not a failure.
             continue
         match = re.search(r"^\s*PROJECT_NUMBER\s*=\s*(.*)$", text, re.MULTILINE)
         if match is None:
@@ -141,7 +133,7 @@ def check_doxyfiles(failures: Failures, version: str) -> None:
             continue
         found = match.group(1).strip()
         if found.startswith("@") and found.endswith("@"):
-            # Substituted by CMake from PROJECT_VERSION; nothing to compare.
+            # Substituted by CMake from PROJECT_VERSION.
             print(f"  [ok  ] {relative_path}: PROJECT_NUMBER templated ({found})")
             continue
         failures.check(
@@ -175,7 +167,6 @@ def parse_news_heading(failures: Failures) -> tuple[str, str] | None:
 def check_citation(failures: Failures, version: str) -> None:
     text = read("CITATION.cff")
     if text is None:
-        # Added later in the release; absence is not a failure.
         return
     match = re.search(r"^version:\s*['\"]?([^'\"\s]+)", text, re.MULTILINE)
     if match is None:
@@ -193,8 +184,7 @@ def check_zenodo(failures: Failures, version: str) -> None:
         return
     match = re.search(r'"version"\s*:\s*"([^"]+)"', text)
     if match is None:
-        # .zenodo.json has no version field today; Zenodo falls back to the
-        # release tag, so this is optional rather than wrong.
+        # Optional: Zenodo falls back to the release tag.
         return
     failures.check(
         match.group(1) == version,


### PR DESCRIPTION
First of the 1.0.0 release-prep PRs. CI is the safety net for everything that
follows, so it goes first.

## Why

`on: [push, pull_request]` fired on every branch *and* every pull request, so
each same-repo PR got **two identical six-leg matrix runs**, and nothing
cancelled a superseded run. More importantly, several things were never tested
at all — which is how this cycle's bugs survived.

## Coverage gaps closed

| Gap | Consequence |
|---|---|
| Both installs set `VINECOPULIB_PRECOMPILED=ON` | The **default header-only install** — what most users and both wrappers consume — was never built, installed or linked against |
| Debug legs only compiled | The Debug build enables `-fsanitize=address,undefined`; on macOS/Windows it was never *run*, so the point of the build was unobserved |
| `bench_all` / `parity_dump` built by no workflow | The entire #688 benchmark + numerical-parity infrastructure could rot silently against header changes |
| Doxygen never built | ~10 uncompilable `.dox` snippets and a 2014-era Doxyfile went unnoticed |
| `examples/vinecop` never built | Only `examples/bicop` was linked against the install |

Plus a `ctest -N` guard: `gtest_discover_tests` writes a `<target>_NOT_BUILT`
placeholder when discovery fails, so a healthy build must list far more than one.

## Release automation (previously none)

- **`scripts/check_version.py`** cross-checks `CMakeLists.txt`, both
  `version.hpp` macros, both Doxyfiles, `CITATION.cff`, `.zenodo.json` and the
  top `NEWS.md` heading. Runs on every PR.
- **`release.yml`** on `v*` tags: verify metadata → re-run the full matrix
  against the tagged tree → publish with the NEWS section as the body, plus a
  source archive and SHA256.
- **`release-drift.yml`**, weekly: fails if the declared version has no matching
  tag. **This is the check that catches the 0.8.0 failure** — every version
  string was bumped and the NEWS heading dated, but no tag was ever pushed and
  nothing noticed for months. It has to be scheduled, because between the
  release PR merging and the tag being pushed the tree legitimately sits
  dated-but-untagged for a few minutes.

### The version check's first catch

`VINECOPULIB_VERSION` was `000800`. That is not merely octal — `8` is not a
valid octal digit, so it is an **invalid octal constant**, and the
`/ 100 % 1000` arithmetic that `version.hpp` itself documents is a hard compile
error for any consumer who actually uses it:

```
error: invalid digit "8" in octal constant
    1 | #define VINECOPULIB_VERSION 000800
    2 | #if VINECOPULIB_VERSION >= 700
```

It survived only because nothing in the library ever uses the macro. Now `800`,
with a comment explaining why leading zeros are forbidden. (For the record,
`000703` in 0.7.3 *did* compile — and decoded to 0.4.51.)

## Static analysis

Codacy is dropped: its badge 404s, its `.codacy.yml` used an `engines:` format
the service abandoned years ago, and its README link used a retired domain.
Shipping a dead analyzer wired into a 1.0.0 is worse than shipping none.

In its place, the clang-tidy block that sat commented out becomes a real gate on
the PR diff. `.clang-tidy` goes from eight wildcard groups with
`WarningsAsErrors: ''` to a curated list with `WarningsAsErrors: '*'` (so the
two can't drift), and `HeaderFilterRegex` is fixed — `^(/)?(include|test|examples)/`
is matched against *absolute* paths, so it matched nothing and every header
diagnostic was silently discarded. Plus CodeQL for C++.

## Toolchain

- clang-format from a **pinned PyPI wheel** rather than apt: `clang-format-14`
  disappears when the runner image rolls forward, and a pinned wheel means
  contributors get the identical binary, so local == CI by construction.
- The CI wdm clone is **pinned to the same commit as the FetchContent
  `GIT_TAG`**. It cloned the default branch, so a wdm master commit could break
  an unrelated PR, and CI silently tested a different wdm than a FetchContent
  build would use.
- `actions/checkout@v5`; SHA-pin `ilammy/msvc-dev-cmd`; delete the dead
  `macos-latest` branch (the matrix passes `macos-15`/`macos-15-intel`, so
  `brew install gsl` never ran); remove the `WDM_ROOT` output that resolved to
  the literal `/wdm` from a commented-out input.
- codecov: `file:` has been **`files:`** since codecov-action v4, so the
  explicit path was ignored and only auto-discovery made it work. Adds
  `fail_ci_if_error` and ignores the generated tables.
- dependabot for `github-actions`.

## Why CI still runs `bin/test_all` and not `ctest`

Measured on 64 cores:

| | wall time |
|---|---|
| `bin/test_all` (645 tests, one process) | **71 s**, all pass |
| `ctest -j64` | **not finished after 13 min**, wedged with ~40 live processes |

The R-parity fixtures shell out to `Rscript` and exchange data through
**hardcoded `temp` / `temp2` / `temp3` files in the working directory**
(`test/src_test/vinecop_test.cpp:18-31`,
`cmake/templates/test_vinecop_parametric.R:42-45`), so concurrent cases
overwrite and `rm` each other's files. Parallel ctest is *racy*, not merely
slow. Making those paths unique per test is a genuine fix, and a prerequisite
for using ctest's parallelism — it belongs in the test-consolidation PR.

## Verified locally

- `check_version.py` fails on `000800`, passes on `800`, and both `--released`
  and `--tag` modes behave.
- All 125 files pass clang-format with the de-BOM'd config; both exclusions apply.
- `-DVINECOPULIB_BUILD_BENCHMARKS=ON -DBUILD_TESTING=OFF` configures without R,
  and `bench_all` + `parity_dump` build.
- `parity_dump` writes a 1.08 MB dump with all six groups; `compare_parity.py
  --tol-config scripts/parity_gates.json` passes.
- `bench_all --benchmark_min_time=1x --benchmark_filter='bicop/pdf'` runs.
- `gtest_discover_tests` discovers 645 entries, so the `ctest -N` guard is
  meaningful.
- Every YAML file parses.

## Follow-up deliberately not done here

Eigen is cloned *and* built from git on every non-Windows leg and is worth
caching, but the install prefix is `eigen_install_dir` while the `EIGEN3_ROOT`
output is `eigen_install_dir/eigen`, so the derived `EIGEN3_INCLUDE_DIR` points
at a directory that does not exist — and configuration succeeds anyway, because
`cmake/findDependencies.cmake` reads the bare CMake variable rather than
`$ENV{EIGEN3_INCLUDE_DIR}`, leaving that env var inert. The underlying bug is
that `findDependencies.cmake:14-21` never sets `EIGEN3_INCLUDE_DIR` from the
`Eigen3::Eigen` target, so `external_includes` silently drops Eigen (verified: a
local configure leaves it out of `CMakeCache.txt` entirely). Fixing that — the
same change pyvinecopulib needed downstream in `3cd6cde` — is a prerequisite for
caching, so both go in the CMake PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)