### PR TITLE
refactor: clear the clang-tidy backlog, widen the checks, and fix what that surfaced

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,11 +2,15 @@
 #
 # performance-* and portability-* are enabled wholesale: the tree is clean
 # against both, so they cost nothing and guard against regressions.
-# The remaining groups are curated, because enabling them wholesale is not
-# currently actionable (measured over the whole library: bugprone-* 435,
-# misc-* 83, modernize-* 1233, readability-* ~344k, the last dominated by
-# numeric literals in test fixtures). Widening them means fixing the
-# findings, not just flipping the switch.
+# bugprone-* and misc-* are enabled wholesale too, minus four checks that are
+# not actionable here: narrowing-conversions (389 findings, inherent to
+# size_t/Eigen::Index/double arithmetic), easily-swappable-parameters (43),
+# non-private-member-variables-in-classes (61; the edge and graph structs are
+# deliberately plain data) and no-recursion (21).
+#
+# modernize-* and readability-* stay curated: measured over the whole library
+# they report 1233 and ~344k findings, the latter dominated by numeric literals
+# in test fixtures. Widening those means fixing the findings first.
 #
 # WarningsAsErrors is '*', so there is no reported-but-tolerated tier. The
 # diff job gives fast feedback; a second job runs the whole library.
@@ -17,43 +21,14 @@
 
 Checks: >
   -*,
-  bugprone-argument-comment,
-  bugprone-assert-side-effect,
-  bugprone-bool-pointer-implicit-conversion,
-  bugprone-copy-constructor-init,
-  bugprone-dangling-handle,
-  bugprone-fold-init-type,
-  bugprone-forward-declaration-namespace,
-  bugprone-inaccurate-erase,
-  bugprone-incorrect-roundings,
-  bugprone-integer-division,
-  bugprone-macro-repeated-side-effects,
-  bugprone-misplaced-widening-cast,
-  bugprone-move-forwarding-reference,
-  bugprone-multiple-statement-macro,
-  bugprone-parent-virtual-call,
-  bugprone-redundant-branch-condition,
-  bugprone-string-constructor,
-  bugprone-string-integer-assignment,
-  bugprone-suspicious-memset-usage,
-  bugprone-suspicious-semicolon,
-  bugprone-suspicious-string-compare,
-  bugprone-swapped-arguments,
-  bugprone-terminating-continue,
-  bugprone-undefined-memory-manipulation,
-  bugprone-undelegated-constructor,
-  bugprone-unused-raii,
-  bugprone-unused-return-value,
-  bugprone-use-after-move,
-  bugprone-virtual-near-miss,
+  bugprone-*,
+  -bugprone-narrowing-conversions,
+  -bugprone-easily-swappable-parameters,
+  misc-*,
+  -misc-non-private-member-variables-in-classes,
+  -misc-no-recursion,
   performance-*,
   portability-*,
-  misc-misplaced-const,
-  misc-redundant-expression,
-  misc-static-assert,
-  misc-uniqueptr-reset-release,
-  misc-unused-alias-decls,
-  misc-unused-using-decls,
   modernize-deprecated-headers,
   modernize-loop-convert,
   modernize-make-shared,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -5,6 +5,9 @@
 # reported-but-tolerated tier. The CI job runs on the pull-request diff, so a new
 # check does not require fixing the whole tree at once.
 #
+# modernize-loop-convert is deliberately absent: on this codebase it rewrote a
+# loop over `hess(t, e)` into a loop over `hess`, which is a different container.
+#
 # To propose a check: add it, run
 #   run-clang-tidy-14 -p <build-dir> -checks='-*,<the-new-check>' include/
 # and either fix the findings in the same pull request or leave it out.
@@ -47,7 +50,6 @@ Checks: >
   misc-unused-alias-decls,
   misc-unused-using-decls,
   modernize-deprecated-headers,
-  modernize-loop-convert,
   modernize-make-shared,
   modernize-make-unique,
   modernize-redundant-void-arg,

--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,12 +1,15 @@
 # clang-tidy 14, matching the clang-format version pinned in CI.
 #
-# A curated list, not wildcard groups: every check here is one we are willing to
-# fail a pull request over, and WarningsAsErrors is '*' so there is no
-# reported-but-tolerated tier. The CI job runs on the pull-request diff, so a new
-# check does not require fixing the whole tree at once.
+# performance-* and portability-* are enabled wholesale: the tree is clean
+# against both, so they cost nothing and guard against regressions.
+# The remaining groups are curated, because enabling them wholesale is not
+# currently actionable (measured over the whole library: bugprone-* 435,
+# misc-* 83, modernize-* 1233, readability-* ~344k, the last dominated by
+# numeric literals in test fixtures). Widening them means fixing the
+# findings, not just flipping the switch.
 #
-# modernize-loop-convert is deliberately absent: on this codebase it rewrote a
-# loop over `hess(t, e)` into a loop over `hess`, which is a different container.
+# WarningsAsErrors is '*', so there is no reported-but-tolerated tier. The
+# diff job gives fast feedback; a second job runs the whole library.
 #
 # To propose a check: add it, run
 #   run-clang-tidy-14 -p <build-dir> -checks='-*,<the-new-check>' include/
@@ -43,6 +46,8 @@ Checks: >
   bugprone-unused-return-value,
   bugprone-use-after-move,
   bugprone-virtual-near-miss,
+  performance-*,
+  portability-*,
   misc-misplaced-const,
   misc-redundant-expression,
   misc-static-assert,
@@ -50,6 +55,7 @@ Checks: >
   misc-unused-alias-decls,
   misc-unused-using-decls,
   modernize-deprecated-headers,
+  modernize-loop-convert,
   modernize-make-shared,
   modernize-make-unique,
   modernize-redundant-void-arg,
@@ -60,19 +66,6 @@ Checks: >
   modernize-use-nullptr,
   modernize-use-override,
   modernize-use-using,
-  performance-faster-string-find,
-  performance-for-range-copy,
-  performance-implicit-conversion-in-loop,
-  performance-inefficient-algorithm,
-  performance-inefficient-string-concatenation,
-  performance-inefficient-vector-operation,
-  performance-move-const-arg,
-  performance-move-constructor-init,
-  performance-no-automatic-move,
-  performance-noexcept-move-constructor,
-  performance-trivially-destructible,
-  performance-unnecessary-copy-initialization,
-  performance-unnecessary-value-param,
   readability-const-return-type,
   readability-container-size-empty,
   readability-delete-null-pointer,

--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -88,12 +88,27 @@ runs:
     - name: Install Eigen ${{inputs.eigen_version}}
       if: inputs.eigen == 'true'
       run: |
+          # Both sources are flaky enough to have failed CI on a 503, so retry.
+          retry() {
+            for attempt in 1 2 3; do
+              "$@" && return 0
+              echo "attempt $attempt failed; retrying in $((attempt * 15))s"
+              sleep $((attempt * 15))
+            done
+            return 1
+          }
+          clone_eigen() {
+            # git clone refuses a non-empty destination, so start clean.
+            rm -rf "${{runner.temp}}/eigen"
+            git clone --depth 1 --branch ${{inputs.eigen_version}} \
+              https://gitlab.com/libeigen/eigen.git/ "${{runner.temp}}/eigen"
+          }
           if [ "${{ inputs.os }}" != "windows-latest" ]; then
-            git clone --depth 1 --branch ${{inputs.eigen_version}} https://gitlab.com/libeigen/eigen.git/ ${{runner.temp}}/eigen
+            retry clone_eigen
             cmake ${{runner.temp}}/eigen -B ${{runner.temp}}/eigen/build -DCMAKE_INSTALL_PREFIX=${{ inputs.eigen_install_dir }}
             make install -C ${{runner.temp}}/eigen/build
           else
-            choco install eigen --version="${{inputs.eigen_version}}"
+            retry choco install eigen --version="${{inputs.eigen_version}}"
           fi
       shell: bash
 

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,10 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 90
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
+        uses: github/codeql-action/init@v4
         with:
           languages: cpp
           queries: security-and-quality
@@ -60,6 +60,6 @@ jobs:
           make -j"$(nproc)"
 
       - name: Perform CodeQL analysis
-        uses: github/codeql-action/analyze@v3
+        uses: github/codeql-action/analyze@v4
         with:
           category: /language:cpp

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -354,3 +354,9 @@ jobs:
             ':(exclude)include/vinecopulib/misc/tools_stats_sobol.hpp' \
             | /usr/lib/llvm-14/share/clang/clang-tidy-diff.py \
                 -p1 -path build-tidy -clang-tidy-binary clang-tidy-14 -use-color
+
+      # test_all.cpp includes every test header, and so transitively the whole
+      # library: one translation unit covers the tree. Keeps the backlog at zero
+      # rather than only gating new code.
+      - name: Run clang-tidy over the whole library
+        run: clang-tidy-14 -p build-tidy --quiet test/test_all.cpp

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
 
       # From PyPI, not apt: pins the exact binary so local runs match CI.
       - name: Install clang-format ${{ env.CLANG_FORMAT_VERSION }}
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - name: Check that the version agrees everywhere it is stated
         run: python3 scripts/check_version.py
 
@@ -69,13 +69,16 @@ jobs:
       # automatic Actions token instead of the rate-limited bundled PAT (the
       # VineCopula >= 2.6.2 install, and any test-time fallback, need it).
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      # Lifted to the job so the coverage step can test for it: Dependabot and
+      # fork pull requests do not receive repository secrets.
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
     runs-on: ${{ matrix.cfg.os }}
     name: ${{ matrix.cfg.os }} (${{ matrix.cfg.name }}, ${{ matrix.cfg.platform }})
     timeout-minutes: 90
     steps:
       - name: Checkout project
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
       - name: Set up MSVC environment
         if: matrix.cfg.os == 'windows-latest'
         uses: ilammy/msvc-dev-cmd@0b201ec74fa43914dc39ae48a89fd1d8cb592756 # v1.13.0
@@ -145,11 +148,16 @@ jobs:
             exit 1
           fi
         shell: bash
+      # Skipped without a token rather than failing: Codecov rejects tokenless
+      # uploads to a protected branch, and Dependabot and fork pull requests get
+      # no secrets. When the token is present the upload must succeed.
       - name: Code coverage
-        uses: codecov/codecov-action@v5
-        if: contains(matrix.cfg.os, 'ubuntu') && contains(matrix.cfg.name, 'GNU')
+        uses: codecov/codecov-action@v7
+        if: >
+          contains(matrix.cfg.os, 'ubuntu') && contains(matrix.cfg.name, 'GNU')
+          && env.CODECOV_TOKEN != ''
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
+          token: ${{ env.CODECOV_TOKEN }}
           files: debug/coverage.info
           disable_search: true
           fail_ci_if_error: true
@@ -191,7 +199,7 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - name: Install dependencies
         id: install-dependencies
         uses: ./.github/actions/install-dependencies
@@ -229,7 +237,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - name: Install dependencies
         id: install-dependencies
         uses: ./.github/actions/install-dependencies
@@ -261,7 +269,7 @@ jobs:
             --tol-config scripts/parity_gates.json
       - name: Upload the parity dump
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: parity-dump
           path: bench_results/parity.json
@@ -273,7 +281,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
       - name: Install Doxygen
         run: |
           sudo apt-get update
@@ -306,7 +314,7 @@ jobs:
           grep -i 'warning' build-docs/doxygen.log | head -50 || true
       - name: Upload the Doxygen log
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: doxygen-log
           path: build-docs/doxygen.log
@@ -319,7 +327,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 45
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
       - name: Install clang-tidy

--- a/.github/workflows/release-drift.yml
+++ b/.github/workflows/release-drift.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0  # need the tags
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
     outputs:
       version: ${{ steps.declared.outputs.version }}
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.tag || github.ref }}
 
@@ -53,7 +53,7 @@ jobs:
           cat release-notes.md
 
       - name: Upload the release notes
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: release-notes
           path: release-notes.md
@@ -71,12 +71,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v5
+      - uses: actions/checkout@v7
         with:
           ref: ${{ inputs.tag || github.ref }}
 
       - name: Download the release notes
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: release-notes
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -330,6 +330,12 @@ For any behaviour change:
   annotated, worked around, or left for later behind an explanatory comment.
   When the real fix genuinely belongs in a separate change, say so in the PR
   description and open an issue for it — a comment is not a substitute.
+- **Never merge to `main` without express consent.** Open the pull request, get
+  it green, and stop. A green matrix and an approved plan are not authorization
+  to merge — the maintainers merge, after review. Where changes build on one
+  another, **stack the pull requests** (each branching off the previous one)
+  rather than merging to unblock yourself. This applies equally to pushing tags
+  and to changing repository settings.
 
 ## Coding conventions
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -336,6 +336,13 @@ For any behaviour change:
   another, **stack the pull requests** (each branching off the previous one)
   rather than merging to unblock yourself. This applies equally to pushing tags
   and to changing repository settings.
+- **Squash on merge: one pull request, one commit on `main`.** The iterations
+  taken to reach a working state are review history, not project history, so the
+  squashed message — not the intermediate commits — is what has to explain the
+  change. Write it as the summary of the whole pull request: what changed, why,
+  and anything a future reader needs (behaviour changes, follow-ups). The
+  `(#NNN)` suffix keeps the pull request discoverable from `git log`, which is
+  where [NEWS.md](NEWS.md) entries are sourced.
 
 ## Coding conventions
 
@@ -374,6 +381,14 @@ For any behaviour change:
   see the per-family docs on the `BicopFamily` enum in
   [bicop/family.hpp](include/vinecopulib/bicop/family.hpp) for the house
   style.
+- **Parameter passing.** Read-only parameters come in by `const&`. A parameter
+  the body needs as a mutable working buffer — `Vinecop::pdf`, `pdf_full`,
+  `rosenblatt`, `scores*`, `gradient`, `hessian*`, which pass `u` to
+  `collapse_data_inplace()` or move it onward — is taken **by value and moved**,
+  never `const&`: a reference would force an extra n × d copy inside. Value
+  parameters that are stored (the `FitControls` setters) are likewise by value
+  and `std::move`d into the member. Converting either kind to `const&` is a
+  performance regression, not a cleanup, even though clang-tidy may suggest it.
 - **C++14 + Eigen.** `Eigen::MatrixXd` / `VectorXd` are the workhorse
   types; prefer `.array()`, `.unaryExpr`, and the helpers in
   [misc/tools_eigen.hpp](include/vinecopulib/misc/tools_eigen.hpp)

--- a/include/vinecopulib/bicop/abstract.hpp
+++ b/include/vinecopulib/bicop/abstract.hpp
@@ -223,7 +223,7 @@ protected:
                           const Eigen::MatrixXd& parameters);
 
   double loglik(const Eigen::MatrixXd& u,
-                const Eigen::VectorXd weights = Eigen::VectorXd());
+                const Eigen::VectorXd& weights = Eigen::VectorXd());
 
   // Data members
   BicopFamily family_;

--- a/include/vinecopulib/bicop/abstract.hpp
+++ b/include/vinecopulib/bicop/abstract.hpp
@@ -232,7 +232,7 @@ protected:
 };
 
 //! A shared pointer to an object of class AbstracBicop.
-typedef std::shared_ptr<AbstractBicop> BicopPtr;
+using BicopPtr = std::shared_ptr<AbstractBicop>;
 }
 
 #include <vinecopulib/bicop/implementation/abstract.ipp>

--- a/include/vinecopulib/bicop/archimedean.hpp
+++ b/include/vinecopulib/bicop/archimedean.hpp
@@ -23,29 +23,29 @@ private:
   // cdf, hfunctions and inverses (`parameters` is m x p, m in {1, n}; a single
   // row is broadcast to all observations)
   Eigen::VectorXd cdf(const Eigen::MatrixXd& u,
-                      const Eigen::MatrixXd& parameters);
+                      const Eigen::MatrixXd& parameters) override;
 
   Eigen::VectorXd hfunc1_raw(const Eigen::MatrixXd& u,
-                             const Eigen::MatrixXd& parameters);
+                             const Eigen::MatrixXd& parameters) override;
 
   Eigen::VectorXd hfunc2_raw(const Eigen::MatrixXd& u,
-                             const Eigen::MatrixXd& parameters);
+                             const Eigen::MatrixXd& parameters) override;
 
   Eigen::VectorXd hinv1_raw(const Eigen::MatrixXd& u,
-                            const Eigen::MatrixXd& parameters);
+                            const Eigen::MatrixXd& parameters) override;
 
   Eigen::VectorXd hinv2_raw(const Eigen::MatrixXd& u,
-                            const Eigen::MatrixXd& parameters);
+                            const Eigen::MatrixXd& parameters) override;
 
   // Archimedean copulas are exchangeable: the second h-function derivatives
   // are the first ones at swapped arguments/selectors
   Eigen::VectorXd hfunc2_deriv_raw(const Eigen::MatrixXd& u,
                                    const Eigen::MatrixXd& parameters,
-                                   const std::string& deriv);
+                                   const std::string& deriv) override;
 
   Eigen::VectorXd hfunc2_deriv2_raw(const Eigen::MatrixXd& u,
                                     const Eigen::MatrixXd& parameters,
-                                    const std::string& deriv);
+                                    const std::string& deriv) override;
 
   // generator, its inverse and derivative; `parameters` is a single parameter
   // set (a p x 1 column)
@@ -63,7 +63,7 @@ private:
 
   // virtual double generator_derivative2(const double &u) = 0;
 
-  Eigen::VectorXd get_start_parameters(const double tau);
+  Eigen::VectorXd get_start_parameters(const double tau) override;
 };
 }
 

--- a/include/vinecopulib/bicop/bb1.hpp
+++ b/include/vinecopulib/bicop/bb1.hpp
@@ -26,51 +26,53 @@ public:
 
 private:
   // generator, its inverse and derivatives for the archimedean copula
-  double generator(const double& u,
-                   const Eigen::Ref<const Eigen::VectorXd>& parameters);
+  double generator(
+    const double& u,
+    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
 
-  double generator_inv(const double& u,
-                       const Eigen::Ref<const Eigen::VectorXd>& parameters);
+  double generator_inv(
+    const double& u,
+    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
 
   double generator_derivative(
     const double& u,
-    const Eigen::Ref<const Eigen::VectorXd>& parameters);
+    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
 
   // pdf
   Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u,
-                          const Eigen::MatrixXd& parameters);
+                          const Eigen::MatrixXd& parameters) override;
 
   // analytic derivatives (per-selector closed forms; see bb1.ipp)
   Eigen::VectorXd pdf_deriv_raw(const Eigen::MatrixXd& u,
                                 const Eigen::MatrixXd& parameters,
-                                const std::string& deriv);
+                                const std::string& deriv) override;
 
   Eigen::VectorXd pdf_deriv2_raw(const Eigen::MatrixXd& u,
                                  const Eigen::MatrixXd& parameters,
-                                 const std::string& deriv);
+                                 const std::string& deriv) override;
 
   Eigen::VectorXd hfunc1_deriv_raw(const Eigen::MatrixXd& u,
                                    const Eigen::MatrixXd& parameters,
-                                   const std::string& deriv);
+                                   const std::string& deriv) override;
 
   Eigen::VectorXd hfunc1_deriv2_raw(const Eigen::MatrixXd& u,
                                     const Eigen::MatrixXd& parameters,
-                                    const std::string& deriv);
+                                    const std::string& deriv) override;
 
   Eigen::VectorXd logpdf_deriv_raw(const Eigen::MatrixXd& u,
                                    const Eigen::MatrixXd& parameters,
-                                   const std::string& deriv);
+                                   const std::string& deriv) override;
 
   Eigen::VectorXd logpdf_deriv2_raw(const Eigen::MatrixXd& u,
                                     const Eigen::MatrixXd& parameters,
-                                    const std::string& deriv);
+                                    const std::string& deriv) override;
 
   // link between Kendall's tau and the par_bicop parameter
-  double parameters_to_tau(const Eigen::MatrixXd& par);
+  double parameters_to_tau(const Eigen::MatrixXd& par) override;
 
-  Eigen::MatrixXd parameters_to_taildep(const Eigen::MatrixXd& par);
+  Eigen::MatrixXd parameters_to_taildep(const Eigen::MatrixXd& par) override;
 
-  Eigen::MatrixXd tau_to_parameters(const double& tau);
+  Eigen::MatrixXd tau_to_parameters(const double& tau) override;
 };
 }
 

--- a/include/vinecopulib/bicop/bb6.hpp
+++ b/include/vinecopulib/bicop/bb6.hpp
@@ -25,51 +25,53 @@ public:
 
 private:
   // generator, its inverse and derivatives for the archimedean copula
-  double generator(const double& u,
-                   const Eigen::Ref<const Eigen::VectorXd>& parameters);
+  double generator(
+    const double& u,
+    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
 
-  double generator_inv(const double& u,
-                       const Eigen::Ref<const Eigen::VectorXd>& parameters);
+  double generator_inv(
+    const double& u,
+    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
 
   double generator_derivative(
     const double& u,
-    const Eigen::Ref<const Eigen::VectorXd>& parameters);
+    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
 
   // pdf
   Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u,
-                          const Eigen::MatrixXd& parameters);
+                          const Eigen::MatrixXd& parameters) override;
 
   // analytic derivatives (per-selector closed forms; see bb6.ipp)
   Eigen::VectorXd pdf_deriv_raw(const Eigen::MatrixXd& u,
                                 const Eigen::MatrixXd& parameters,
-                                const std::string& deriv);
+                                const std::string& deriv) override;
 
   Eigen::VectorXd pdf_deriv2_raw(const Eigen::MatrixXd& u,
                                  const Eigen::MatrixXd& parameters,
-                                 const std::string& deriv);
+                                 const std::string& deriv) override;
 
   Eigen::VectorXd hfunc1_deriv_raw(const Eigen::MatrixXd& u,
                                    const Eigen::MatrixXd& parameters,
-                                   const std::string& deriv);
+                                   const std::string& deriv) override;
 
   Eigen::VectorXd hfunc1_deriv2_raw(const Eigen::MatrixXd& u,
                                     const Eigen::MatrixXd& parameters,
-                                    const std::string& deriv);
+                                    const std::string& deriv) override;
 
   Eigen::VectorXd logpdf_deriv_raw(const Eigen::MatrixXd& u,
                                    const Eigen::MatrixXd& parameters,
-                                   const std::string& deriv);
+                                   const std::string& deriv) override;
 
   Eigen::VectorXd logpdf_deriv2_raw(const Eigen::MatrixXd& u,
                                     const Eigen::MatrixXd& parameters,
-                                    const std::string& deriv);
+                                    const std::string& deriv) override;
 
   // link between Kendall's tau and the par_bicop parameter
-  double parameters_to_tau(const Eigen::MatrixXd& par);
+  double parameters_to_tau(const Eigen::MatrixXd& par) override;
 
-  Eigen::MatrixXd parameters_to_taildep(const Eigen::MatrixXd& par);
+  Eigen::MatrixXd parameters_to_taildep(const Eigen::MatrixXd& par) override;
 
-  Eigen::MatrixXd tau_to_parameters(const double& tau);
+  Eigen::MatrixXd tau_to_parameters(const double& tau) override;
 };
 }
 

--- a/include/vinecopulib/bicop/bb7.hpp
+++ b/include/vinecopulib/bicop/bb7.hpp
@@ -25,51 +25,53 @@ public:
 
 private:
   // generator, its inverse and derivatives for the archimedean copula
-  double generator(const double& u,
-                   const Eigen::Ref<const Eigen::VectorXd>& parameters);
+  double generator(
+    const double& u,
+    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
 
-  double generator_inv(const double& u,
-                       const Eigen::Ref<const Eigen::VectorXd>& parameters);
+  double generator_inv(
+    const double& u,
+    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
 
   double generator_derivative(
     const double& u,
-    const Eigen::Ref<const Eigen::VectorXd>& parameters);
+    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
 
   // pdf
   Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u,
-                          const Eigen::MatrixXd& parameters);
+                          const Eigen::MatrixXd& parameters) override;
 
   // analytic derivatives (per-selector closed forms; see bb7.ipp)
   Eigen::VectorXd pdf_deriv_raw(const Eigen::MatrixXd& u,
                                 const Eigen::MatrixXd& parameters,
-                                const std::string& deriv);
+                                const std::string& deriv) override;
 
   Eigen::VectorXd pdf_deriv2_raw(const Eigen::MatrixXd& u,
                                  const Eigen::MatrixXd& parameters,
-                                 const std::string& deriv);
+                                 const std::string& deriv) override;
 
   Eigen::VectorXd hfunc1_deriv_raw(const Eigen::MatrixXd& u,
                                    const Eigen::MatrixXd& parameters,
-                                   const std::string& deriv);
+                                   const std::string& deriv) override;
 
   Eigen::VectorXd hfunc1_deriv2_raw(const Eigen::MatrixXd& u,
                                     const Eigen::MatrixXd& parameters,
-                                    const std::string& deriv);
+                                    const std::string& deriv) override;
 
   Eigen::VectorXd logpdf_deriv_raw(const Eigen::MatrixXd& u,
                                    const Eigen::MatrixXd& parameters,
-                                   const std::string& deriv);
+                                   const std::string& deriv) override;
 
   Eigen::VectorXd logpdf_deriv2_raw(const Eigen::MatrixXd& u,
                                     const Eigen::MatrixXd& parameters,
-                                    const std::string& deriv);
+                                    const std::string& deriv) override;
 
   // link between Kendall's tau and the par_bicop parameter
-  double parameters_to_tau(const Eigen::MatrixXd& par);
+  double parameters_to_tau(const Eigen::MatrixXd& par) override;
 
-  Eigen::MatrixXd parameters_to_taildep(const Eigen::MatrixXd& par);
+  Eigen::MatrixXd parameters_to_taildep(const Eigen::MatrixXd& par) override;
 
-  Eigen::MatrixXd tau_to_parameters(const double& tau);
+  Eigen::MatrixXd tau_to_parameters(const double& tau) override;
 };
 }
 

--- a/include/vinecopulib/bicop/bb8.hpp
+++ b/include/vinecopulib/bicop/bb8.hpp
@@ -25,51 +25,53 @@ public:
 
 private:
   // generator, its inverse and derivatives for the archimedean copula
-  double generator(const double& u,
-                   const Eigen::Ref<const Eigen::VectorXd>& parameters);
+  double generator(
+    const double& u,
+    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
 
-  double generator_inv(const double& u,
-                       const Eigen::Ref<const Eigen::VectorXd>& parameters);
+  double generator_inv(
+    const double& u,
+    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
 
   double generator_derivative(
     const double& u,
-    const Eigen::Ref<const Eigen::VectorXd>& parameters);
+    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
 
   // pdf
   Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u,
-                          const Eigen::MatrixXd& parameters);
+                          const Eigen::MatrixXd& parameters) override;
 
   // analytic derivatives (per-selector closed forms; see bb8.ipp)
   Eigen::VectorXd pdf_deriv_raw(const Eigen::MatrixXd& u,
                                 const Eigen::MatrixXd& parameters,
-                                const std::string& deriv);
+                                const std::string& deriv) override;
 
   Eigen::VectorXd pdf_deriv2_raw(const Eigen::MatrixXd& u,
                                  const Eigen::MatrixXd& parameters,
-                                 const std::string& deriv);
+                                 const std::string& deriv) override;
 
   Eigen::VectorXd hfunc1_deriv_raw(const Eigen::MatrixXd& u,
                                    const Eigen::MatrixXd& parameters,
-                                   const std::string& deriv);
+                                   const std::string& deriv) override;
 
   Eigen::VectorXd hfunc1_deriv2_raw(const Eigen::MatrixXd& u,
                                     const Eigen::MatrixXd& parameters,
-                                    const std::string& deriv);
+                                    const std::string& deriv) override;
 
   Eigen::VectorXd logpdf_deriv_raw(const Eigen::MatrixXd& u,
                                    const Eigen::MatrixXd& parameters,
-                                   const std::string& deriv);
+                                   const std::string& deriv) override;
 
   Eigen::VectorXd logpdf_deriv2_raw(const Eigen::MatrixXd& u,
                                     const Eigen::MatrixXd& parameters,
-                                    const std::string& deriv);
+                                    const std::string& deriv) override;
 
   // link between Kendall's tau and the par_bicop parameter
-  double parameters_to_tau(const Eigen::MatrixXd& par);
+  double parameters_to_tau(const Eigen::MatrixXd& par) override;
 
-  Eigen::MatrixXd parameters_to_taildep(const Eigen::MatrixXd& par);
+  Eigen::MatrixXd parameters_to_taildep(const Eigen::MatrixXd& par) override;
 
-  Eigen::MatrixXd tau_to_parameters(const double& tau);
+  Eigen::MatrixXd tau_to_parameters(const double& tau) override;
 };
 }
 

--- a/include/vinecopulib/bicop/class.hpp
+++ b/include/vinecopulib/bicop/class.hpp
@@ -58,6 +58,10 @@ public:
 
   Bicop(const Bicop& other);
 
+  // Required, not redundant: the copy constructor above suppresses the implicit
+  // move, and copying deep-clones the family object.
+  Bicop(Bicop&& other) = default;
+
   explicit Bicop(const std::string& filename);
 
   explicit Bicop(const nlohmann::json& input);

--- a/include/vinecopulib/bicop/clayton.hpp
+++ b/include/vinecopulib/bicop/clayton.hpp
@@ -25,57 +25,60 @@ public:
 
 private:
   // generator, its inverse and derivatives for the archimedean copula
-  double generator(const double& u,
-                   const Eigen::Ref<const Eigen::VectorXd>& parameters);
+  double generator(
+    const double& u,
+    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
 
-  double generator_inv(const double& u,
-                       const Eigen::Ref<const Eigen::VectorXd>& parameters);
+  double generator_inv(
+    const double& u,
+    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
 
   double generator_derivative(
     const double& u,
-    const Eigen::Ref<const Eigen::VectorXd>& parameters);
+    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
 
   // pdf
   Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u,
-                          const Eigen::MatrixXd& parameters);
+                          const Eigen::MatrixXd& parameters) override;
 
   // analytic derivatives (ported from the VineCopula R package)
   Eigen::VectorXd pdf_deriv_raw(const Eigen::MatrixXd& u,
                                 const Eigen::MatrixXd& parameters,
-                                const std::string& deriv);
+                                const std::string& deriv) override;
 
   Eigen::VectorXd pdf_deriv2_raw(const Eigen::MatrixXd& u,
                                  const Eigen::MatrixXd& parameters,
-                                 const std::string& deriv);
+                                 const std::string& deriv) override;
 
   Eigen::VectorXd hfunc1_deriv_raw(const Eigen::MatrixXd& u,
                                    const Eigen::MatrixXd& parameters,
-                                   const std::string& deriv);
+                                   const std::string& deriv) override;
 
   Eigen::VectorXd hfunc1_deriv2_raw(const Eigen::MatrixXd& u,
                                     const Eigen::MatrixXd& parameters,
-                                    const std::string& deriv);
+                                    const std::string& deriv) override;
 
   Eigen::VectorXd logpdf_deriv_raw(const Eigen::MatrixXd& u,
                                    const Eigen::MatrixXd& parameters,
-                                   const std::string& deriv);
+                                   const std::string& deriv) override;
 
   Eigen::VectorXd logpdf_deriv2_raw(const Eigen::MatrixXd& u,
                                     const Eigen::MatrixXd& parameters,
-                                    const std::string& deriv);
+                                    const std::string& deriv) override;
 
   // inverse hfunction
   Eigen::VectorXd hinv1_raw(const Eigen::MatrixXd& u,
-                            const Eigen::MatrixXd& parameters);
+                            const Eigen::MatrixXd& parameters) override;
 
   // link between Kendall's tau and the par_bicop parameter
-  Eigen::MatrixXd tau_to_parameters(const double& tau);
+  Eigen::MatrixXd tau_to_parameters(const double& tau) override;
 
-  double parameters_to_tau(const Eigen::MatrixXd& parameters);
+  double parameters_to_tau(const Eigen::MatrixXd& parameters) override;
 
-  Eigen::MatrixXd parameters_to_taildep(const Eigen::MatrixXd& parameters);
+  Eigen::MatrixXd parameters_to_taildep(
+    const Eigen::MatrixXd& parameters) override;
 
-  Eigen::VectorXd get_start_parameters(const double tau);
+  Eigen::VectorXd get_start_parameters(const double tau) override;
 };
 }
 

--- a/include/vinecopulib/bicop/elliptical.hpp
+++ b/include/vinecopulib/bicop/elliptical.hpp
@@ -24,23 +24,23 @@ class EllipticalBicop : public ParBicop
 private:
   // hfunction and its inverse (thread `parameters` through the column swap)
   Eigen::VectorXd hfunc2_raw(const Eigen::MatrixXd& u,
-                             const Eigen::MatrixXd& parameters);
+                             const Eigen::MatrixXd& parameters) override;
 
   Eigen::VectorXd hinv2_raw(const Eigen::MatrixXd& u,
-                            const Eigen::MatrixXd& parameters);
+                            const Eigen::MatrixXd& parameters) override;
 
   // elliptical copulas are exchangeable: the second h-function derivatives
   // are the first ones at swapped arguments/selectors
   Eigen::VectorXd hfunc2_deriv_raw(const Eigen::MatrixXd& u,
                                    const Eigen::MatrixXd& parameters,
-                                   const std::string& deriv);
+                                   const std::string& deriv) override;
 
   Eigen::VectorXd hfunc2_deriv2_raw(const Eigen::MatrixXd& u,
                                     const Eigen::MatrixXd& parameters,
-                                    const std::string& deriv);
+                                    const std::string& deriv) override;
 
   // link between Kendall's tau and the par_bicop parameter
-  double parameters_to_tau(const Eigen::MatrixXd& parameters);
+  double parameters_to_tau(const Eigen::MatrixXd& parameters) override;
 };
 }
 

--- a/include/vinecopulib/bicop/extreme_value.hpp
+++ b/include/vinecopulib/bicop/extreme_value.hpp
@@ -23,22 +23,22 @@ private:
   // pdf, cdf, hfunctions and inverses (`parameters` is m x p, m in {1, n}; a
   // single row is broadcast to all observations)
   Eigen::VectorXd cdf(const Eigen::MatrixXd& u,
-                      const Eigen::MatrixXd& parameters);
+                      const Eigen::MatrixXd& parameters) override;
 
   Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u,
-                          const Eigen::MatrixXd& parameters);
+                          const Eigen::MatrixXd& parameters) override;
 
   Eigen::VectorXd hfunc1_raw(const Eigen::MatrixXd& u,
-                             const Eigen::MatrixXd& parameters);
+                             const Eigen::MatrixXd& parameters) override;
 
   Eigen::VectorXd hfunc2_raw(const Eigen::MatrixXd& u,
-                             const Eigen::MatrixXd& parameters);
+                             const Eigen::MatrixXd& parameters) override;
 
   Eigen::VectorXd hinv1_raw(const Eigen::MatrixXd& u,
-                            const Eigen::MatrixXd& parameters);
+                            const Eigen::MatrixXd& parameters) override;
 
   Eigen::VectorXd hinv2_raw(const Eigen::MatrixXd& u,
-                            const Eigen::MatrixXd& parameters);
+                            const Eigen::MatrixXd& parameters) override;
 
   // pickands dependence functions and its derivatives; `parameters` is a single
   // parameter set (a p x 1 column)
@@ -55,9 +55,9 @@ private:
     const Eigen::Ref<const Eigen::VectorXd>& parameters) = 0;
 
   // link between Kendall's tau and the par_bicop parameter
-  double parameters_to_tau(const Eigen::MatrixXd& par);
+  double parameters_to_tau(const Eigen::MatrixXd& par) override;
 
-  Eigen::MatrixXd parameters_to_taildep(const Eigen::MatrixXd& par);
+  Eigen::MatrixXd parameters_to_taildep(const Eigen::MatrixXd& par) override;
 };
 }
 

--- a/include/vinecopulib/bicop/family.hpp
+++ b/include/vinecopulib/bicop/family.hpp
@@ -75,7 +75,7 @@ std::string
 get_family_name(BicopFamily family);
 
 BicopFamily
-get_family_enum(std::string family);
+get_family_enum(const std::string& family);
 
 //! Convenience definitions of sets of bivariate copula families
 namespace bicop_families {

--- a/include/vinecopulib/bicop/frank.hpp
+++ b/include/vinecopulib/bicop/frank.hpp
@@ -25,54 +25,57 @@ public:
 
 private:
   // generator, its inverse and derivatives for the archimedean copula
-  double generator(const double& u,
-                   const Eigen::Ref<const Eigen::VectorXd>& parameters);
+  double generator(
+    const double& u,
+    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
 
-  double generator_inv(const double& u,
-                       const Eigen::Ref<const Eigen::VectorXd>& parameters);
+  double generator_inv(
+    const double& u,
+    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
 
   double generator_derivative(
     const double& u,
-    const Eigen::Ref<const Eigen::VectorXd>& parameters);
+    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
 
   // pdf
   Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u,
-                          const Eigen::MatrixXd& parameters);
+                          const Eigen::MatrixXd& parameters) override;
 
   // analytic derivatives of pdf, hfunc1, and log-pdf
   Eigen::VectorXd pdf_deriv_raw(const Eigen::MatrixXd& u,
                                 const Eigen::MatrixXd& parameters,
-                                const std::string& deriv);
+                                const std::string& deriv) override;
 
   Eigen::VectorXd pdf_deriv2_raw(const Eigen::MatrixXd& u,
                                  const Eigen::MatrixXd& parameters,
-                                 const std::string& deriv);
+                                 const std::string& deriv) override;
 
   Eigen::VectorXd hfunc1_deriv_raw(const Eigen::MatrixXd& u,
                                    const Eigen::MatrixXd& parameters,
-                                   const std::string& deriv);
+                                   const std::string& deriv) override;
 
   Eigen::VectorXd hfunc1_deriv2_raw(const Eigen::MatrixXd& u,
                                     const Eigen::MatrixXd& parameters,
-                                    const std::string& deriv);
+                                    const std::string& deriv) override;
 
   Eigen::VectorXd logpdf_deriv_raw(const Eigen::MatrixXd& u,
                                    const Eigen::MatrixXd& parameters,
-                                   const std::string& deriv);
+                                   const std::string& deriv) override;
 
   Eigen::VectorXd logpdf_deriv2_raw(const Eigen::MatrixXd& u,
                                     const Eigen::MatrixXd& parameters,
-                                    const std::string& deriv);
+                                    const std::string& deriv) override;
 
   // link between Kendall's tau and the par_bicop parameter
-  Eigen::MatrixXd tau_to_parameters(const double& tau);
+  Eigen::MatrixXd tau_to_parameters(const double& tau) override;
 
-  double parameters_to_tau(const Eigen::MatrixXd& par);
+  double parameters_to_tau(const Eigen::MatrixXd& par) override;
 
   // the Frank copula has no tail dependence in any corner
-  Eigen::MatrixXd parameters_to_taildep(const Eigen::MatrixXd& parameters);
+  Eigen::MatrixXd parameters_to_taildep(
+    const Eigen::MatrixXd& parameters) override;
 
-  Eigen::VectorXd get_start_parameters(const double tau);
+  Eigen::VectorXd get_start_parameters(const double tau) override;
 };
 
 double

--- a/include/vinecopulib/bicop/gaussian.hpp
+++ b/include/vinecopulib/bicop/gaussian.hpp
@@ -26,48 +26,49 @@ public:
 private:
   // evaluation leaves (`parameters` is m x 1, m in {1, n})
   Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u,
-                          const Eigen::MatrixXd& parameters);
+                          const Eigen::MatrixXd& parameters) override;
 
   Eigen::VectorXd cdf(const Eigen::MatrixXd& u,
-                      const Eigen::MatrixXd& parameters);
+                      const Eigen::MatrixXd& parameters) override;
 
   Eigen::VectorXd hfunc1_raw(const Eigen::MatrixXd& u,
-                             const Eigen::MatrixXd& parameters);
+                             const Eigen::MatrixXd& parameters) override;
 
   Eigen::VectorXd hinv1_raw(const Eigen::MatrixXd& u,
-                            const Eigen::MatrixXd& parameters);
+                            const Eigen::MatrixXd& parameters) override;
 
   // analytic derivative leaves (see tools_deriv for the selector encoding)
   Eigen::VectorXd pdf_deriv_raw(const Eigen::MatrixXd& u,
                                 const Eigen::MatrixXd& parameters,
-                                const std::string& deriv);
+                                const std::string& deriv) override;
 
   Eigen::VectorXd pdf_deriv2_raw(const Eigen::MatrixXd& u,
                                  const Eigen::MatrixXd& parameters,
-                                 const std::string& deriv);
+                                 const std::string& deriv) override;
 
   Eigen::VectorXd hfunc1_deriv_raw(const Eigen::MatrixXd& u,
                                    const Eigen::MatrixXd& parameters,
-                                   const std::string& deriv);
+                                   const std::string& deriv) override;
 
   Eigen::VectorXd hfunc1_deriv2_raw(const Eigen::MatrixXd& u,
                                     const Eigen::MatrixXd& parameters,
-                                    const std::string& deriv);
+                                    const std::string& deriv) override;
 
   Eigen::VectorXd logpdf_deriv_raw(const Eigen::MatrixXd& u,
                                    const Eigen::MatrixXd& parameters,
-                                   const std::string& deriv);
+                                   const std::string& deriv) override;
 
   Eigen::VectorXd logpdf_deriv2_raw(const Eigen::MatrixXd& u,
                                     const Eigen::MatrixXd& parameters,
-                                    const std::string& deriv);
+                                    const std::string& deriv) override;
 
-  Eigen::MatrixXd tau_to_parameters(const double& tau);
+  Eigen::MatrixXd tau_to_parameters(const double& tau) override;
 
   // the Gaussian copula has no tail dependence in any corner
-  Eigen::MatrixXd parameters_to_taildep(const Eigen::MatrixXd& parameters);
+  Eigen::MatrixXd parameters_to_taildep(
+    const Eigen::MatrixXd& parameters) override;
 
-  Eigen::VectorXd get_start_parameters(const double tau);
+  Eigen::VectorXd get_start_parameters(const double tau) override;
 };
 }
 

--- a/include/vinecopulib/bicop/gumbel.hpp
+++ b/include/vinecopulib/bicop/gumbel.hpp
@@ -25,57 +25,60 @@ public:
 
 private:
   // generator, its inverse and derivatives for the archimedean copula
-  double generator(const double& u,
-                   const Eigen::Ref<const Eigen::VectorXd>& parameters);
+  double generator(
+    const double& u,
+    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
 
-  double generator_inv(const double& u,
-                       const Eigen::Ref<const Eigen::VectorXd>& parameters);
+  double generator_inv(
+    const double& u,
+    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
 
   double generator_derivative(
     const double& u,
-    const Eigen::Ref<const Eigen::VectorXd>& parameters);
+    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
 
   // pdf
   Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u,
-                          const Eigen::MatrixXd& parameters);
+                          const Eigen::MatrixXd& parameters) override;
 
   // inverse hfunction
   Eigen::VectorXd hinv1_raw(const Eigen::MatrixXd& u,
-                            const Eigen::MatrixXd& parameters);
+                            const Eigen::MatrixXd& parameters) override;
 
   // analytic derivatives
   Eigen::VectorXd pdf_deriv_raw(const Eigen::MatrixXd& u,
                                 const Eigen::MatrixXd& parameters,
-                                const std::string& deriv);
+                                const std::string& deriv) override;
 
   Eigen::VectorXd pdf_deriv2_raw(const Eigen::MatrixXd& u,
                                  const Eigen::MatrixXd& parameters,
-                                 const std::string& deriv);
+                                 const std::string& deriv) override;
 
   Eigen::VectorXd hfunc1_deriv_raw(const Eigen::MatrixXd& u,
                                    const Eigen::MatrixXd& parameters,
-                                   const std::string& deriv);
+                                   const std::string& deriv) override;
 
   Eigen::VectorXd hfunc1_deriv2_raw(const Eigen::MatrixXd& u,
                                     const Eigen::MatrixXd& parameters,
-                                    const std::string& deriv);
+                                    const std::string& deriv) override;
 
   Eigen::VectorXd logpdf_deriv_raw(const Eigen::MatrixXd& u,
                                    const Eigen::MatrixXd& parameters,
-                                   const std::string& deriv);
+                                   const std::string& deriv) override;
 
   Eigen::VectorXd logpdf_deriv2_raw(const Eigen::MatrixXd& u,
                                     const Eigen::MatrixXd& parameters,
-                                    const std::string& deriv);
+                                    const std::string& deriv) override;
 
   // link between Kendall's tau and the par_bicop parameter
-  Eigen::MatrixXd tau_to_parameters(const double& tau);
+  Eigen::MatrixXd tau_to_parameters(const double& tau) override;
 
-  double parameters_to_tau(const Eigen::MatrixXd& parameters);
+  double parameters_to_tau(const Eigen::MatrixXd& parameters) override;
 
-  Eigen::MatrixXd parameters_to_taildep(const Eigen::MatrixXd& parameters);
+  Eigen::MatrixXd parameters_to_taildep(
+    const Eigen::MatrixXd& parameters) override;
 
-  Eigen::VectorXd get_start_parameters(const double tau);
+  Eigen::VectorXd get_start_parameters(const double tau) override;
 };
 }
 

--- a/include/vinecopulib/bicop/implementation/abstract.ipp
+++ b/include/vinecopulib/bicop/implementation/abstract.ipp
@@ -215,7 +215,7 @@ AbstractBicop::hinv2(const Eigen::MatrixXd& u)
 //! @param u Data matrix.
 //! @param weights Optional weights for each observation.
 inline double
-AbstractBicop::loglik(const Eigen::MatrixXd& u, const Eigen::VectorXd weights)
+AbstractBicop::loglik(const Eigen::MatrixXd& u, const Eigen::VectorXd& weights)
 {
   Eigen::MatrixXd log_pdf = this->pdf(u).array().log();
   if (weights.size() > 0) {

--- a/include/vinecopulib/bicop/implementation/abstract.ipp
+++ b/include/vinecopulib/bicop/implementation/abstract.ipp
@@ -25,7 +25,7 @@
 namespace vinecopulib {
 
 //! virtual destructor
-inline AbstractBicop::~AbstractBicop() {}
+inline AbstractBicop::~AbstractBicop() = default;
 
 //! Instantiates a bivariate copula using the default contructor
 //!

--- a/include/vinecopulib/bicop/implementation/class.ipp
+++ b/include/vinecopulib/bicop/implementation/class.ipp
@@ -1595,6 +1595,7 @@ Bicop::mbic(const Eigen::MatrixXd& u, const double psi0) const
                      static_cast<double>(is_indep) * std::log(1.0 - psi0);
   double n = static_cast<double>(nobs_);
   if (u.rows() > 0) {
+    tools_eigen::remove_nans(u_no_nan);
     n = static_cast<double>(u_no_nan.rows());
   }
   return -2 * this->loglik(u_no_nan) + std::log(n) * npars - 2 * log_prior;
@@ -2257,7 +2258,7 @@ Bicop::check_var_types(const std::vector<std::string>& var_types) const
   if (var_types.size() != 2) {
     throw std::runtime_error("var_types must have size two.");
   }
-  for (auto t : var_types) {
+  for (const auto& t : var_types) {
     if (!tools_stl::is_member(t, { "c", "d" })) {
       throw std::runtime_error("var type must be either 'c' or 'd'.");
     }
@@ -2269,7 +2270,7 @@ inline unsigned short
 Bicop::get_n_discrete() const
 {
   int n_discrete = 0;
-  for (auto t : var_types_) {
+  for (const auto& t : var_types_) {
     n_discrete += (t == "d");
   }
   return static_cast<unsigned short>(n_discrete);

--- a/include/vinecopulib/bicop/implementation/class.ipp
+++ b/include/vinecopulib/bicop/implementation/class.ipp
@@ -1947,7 +1947,7 @@ Bicop::str() const
   } else if (get_family() != BicopFamily::indep) {
     bicop_str << "  parameters = " << get_parameters() << "\n";
   }
-  return bicop_str.str().c_str();
+  return bicop_str.str();
 }
 
 //! @brief Gets lower bounds for copula parameters.

--- a/include/vinecopulib/bicop/implementation/family.ipp
+++ b/include/vinecopulib/bicop/implementation/family.ipp
@@ -34,7 +34,7 @@ get_family_name(BicopFamily family)
 //! @brief Converts a string name into a BicopFamily.
 //! @param family The family name.
 inline BicopFamily
-get_family_enum(std::string family)
+get_family_enum(const std::string& family)
 {
   return family_names.right.at(family);
 }

--- a/include/vinecopulib/bicop/implementation/family.ipp
+++ b/include/vinecopulib/bicop/implementation/family.ipp
@@ -9,7 +9,7 @@
 
 namespace vinecopulib {
 
-typedef boost::bimap<BicopFamily, std::string> family_bimap;
+using family_bimap = boost::bimap<BicopFamily, std::string>;
 const family_bimap family_names =
   boost::assign::list_of<family_bimap::relation>(
     BicopFamily::indep,

--- a/include/vinecopulib/bicop/implementation/fit_controls.ipp
+++ b/include/vinecopulib/bicop/implementation/fit_controls.ipp
@@ -6,6 +6,7 @@
 
 #include <stdexcept>
 #include <thread>
+#include <utility>
 #include <vinecopulib/misc/tools_stl.hpp>
 
 //! Tools for bivariate and vine copula modeling
@@ -47,12 +48,12 @@ inline FitControlsBicop::FitControlsBicop(std::vector<BicopFamily> family_set,
                                           bool allow_rotations,
                                           size_t num_threads)
 {
-  set_family_set(family_set);
-  set_parametric_method(parametric_method);
-  set_nonparametric_method(nonparametric_method);
+  set_family_set(std::move(family_set));
+  set_parametric_method(std::move(parametric_method));
+  set_nonparametric_method(std::move(nonparametric_method));
   set_nonparametric_mult(nonparametric_mult);
   set_nonparametric_grid_size(nonparametric_grid_size);
-  set_selection_criterion(selection_criterion);
+  set_selection_criterion(std::move(selection_criterion));
   set_weights(weights);
   set_preselect_families(preselect_families);
   set_allow_rotations(allow_rotations);
@@ -66,7 +67,7 @@ inline FitControlsBicop::FitControlsBicop(std::vector<BicopFamily> family_set,
 inline FitControlsBicop::FitControlsBicop(std::string parametric_method)
   : FitControlsBicop()
 {
-  set_parametric_method(parametric_method);
+  set_parametric_method(std::move(parametric_method));
 }
 
 //! @brief Instantiates default controls except for the nonparametric method.
@@ -82,7 +83,7 @@ inline FitControlsBicop::FitControlsBicop(std::string nonparametric_method,
                                           size_t nonparametric_grid_size)
   : FitControlsBicop()
 {
-  set_nonparametric_method(nonparametric_method);
+  set_nonparametric_method(std::move(nonparametric_method));
   set_nonparametric_mult(nonparametric_mult);
   set_nonparametric_grid_size(nonparametric_grid_size);
 }
@@ -133,7 +134,7 @@ inline FitControlsBicop::FitControlsBicop(const FitControlsConfig& config)
 inline void
 FitControlsBicop::check_parametric_method(std::string parametric_method)
 {
-  if (!tools_stl::is_member(parametric_method, { "itau", "mle" })) {
+  if (!tools_stl::is_member(std::move(parametric_method), { "itau", "mle" })) {
     throw std::runtime_error("parametric_method should be mle or itau");
   }
 }
@@ -141,7 +142,7 @@ FitControlsBicop::check_parametric_method(std::string parametric_method)
 inline void
 FitControlsBicop::check_nonparametric_method(std::string nonparametric_method)
 {
-  if (!tools_stl::is_member(nonparametric_method,
+  if (!tools_stl::is_member(std::move(nonparametric_method),
                             { "constant", "linear", "quadratic" })) {
     throw std::runtime_error(
       "parametric_method should be constant, linear or quadratic");
@@ -170,7 +171,7 @@ FitControlsBicop::check_selection_criterion(std::string selection_criterion)
   std::vector<std::string> allowed_crits = {
     "loglik", "aic", "bic", "mbic", "mbicv"
   };
-  if (!tools_stl::is_member(selection_criterion, allowed_crits)) {
+  if (!tools_stl::is_member(std::move(selection_criterion), allowed_crits)) {
     throw std::runtime_error("selection_criterion should be 'loglik', 'aic', "
                              "'bic', 'mbic', or 'mbicv'");
   }
@@ -268,7 +269,7 @@ FitControlsBicop::get_allow_rotations() const
 inline void
 FitControlsBicop::set_family_set(std::vector<BicopFamily> family_set)
 {
-  family_set_ = family_set;
+  family_set_ = std::move(family_set);
 }
 
 //! @brief Sets the parametric method.
@@ -276,7 +277,7 @@ inline void
 FitControlsBicop::set_parametric_method(std::string parametric_method)
 {
   check_parametric_method(parametric_method);
-  parametric_method_ = parametric_method;
+  parametric_method_ = std::move(parametric_method);
 }
 
 //! @brief Sets the nonparmetric method.
@@ -284,7 +285,7 @@ inline void
 FitControlsBicop::set_nonparametric_method(std::string nonparametric_method)
 {
   check_nonparametric_method(nonparametric_method);
-  nonparametric_method_ = nonparametric_method;
+  nonparametric_method_ = std::move(nonparametric_method);
 }
 
 //! @brief Sets the nonparametric multiplier.
@@ -308,7 +309,7 @@ inline void
 FitControlsBicop::set_selection_criterion(std::string selection_criterion)
 {
   check_selection_criterion(selection_criterion);
-  selection_criterion_ = selection_criterion;
+  selection_criterion_ = std::move(selection_criterion);
 }
 
 //! @brief Sets the observation weights.

--- a/include/vinecopulib/bicop/implementation/fit_controls.ipp
+++ b/include/vinecopulib/bicop/implementation/fit_controls.ipp
@@ -408,7 +408,7 @@ FitControlsBicop::str_internal(bool print_threads) const
                  << (get_num_threads() == 0 ? 1 : get_num_threads())
                  << std::endl;
   }
-  return controls_str.str().c_str();
+  return controls_str.str();
 }
 
 }

--- a/include/vinecopulib/bicop/implementation/tll.ipp
+++ b/include/vinecopulib/bicop/implementation/tll.ipp
@@ -25,7 +25,7 @@ TllBicop::gaussian_kernel_2d(const Eigen::MatrixXd& x)
 //! times appropriate factor).
 inline Eigen::Matrix2d
 TllBicop::select_bandwidth(const Eigen::MatrixXd& x,
-                           std::string method,
+                           const std::string& method,
                            const Eigen::VectorXd& weights)
 {
   size_t n = x.rows();
@@ -82,7 +82,7 @@ inline Eigen::MatrixXd
 TllBicop::fit_local_likelihood(const Eigen::MatrixXd& x,
                                const Eigen::MatrixXd& x_data,
                                const Eigen::Matrix2d& B,
-                               std::string method,
+                               const std::string& method,
                                const Eigen::VectorXd& weights)
 {
   size_t m = x.rows();      // number of evaluation points

--- a/include/vinecopulib/bicop/implementation/tools_select.ipp
+++ b/include/vinecopulib/bicop/implementation/tools_select.ipp
@@ -35,13 +35,13 @@ create_candidate_bicops(const Eigen::MatrixXd& data,
   std::vector<Bicop> new_bicops;
   for (auto& fam : families) {
     if (tools_stl::is_member(fam, bicop_families::rotationless)) {
-      new_bicops.push_back(Bicop(fam, 0));
+      new_bicops.emplace_back(fam, 0);
     } else {
       if (controls.get_allow_rotations()) {
-        new_bicops.push_back(Bicop(fam, which_rotations[0]));
-        new_bicops.push_back(Bicop(fam, which_rotations[1]));
+        new_bicops.emplace_back(fam, which_rotations[0]);
+        new_bicops.emplace_back(fam, which_rotations[1]);
       } else if (tau > 0) {
-        new_bicops.push_back(Bicop(fam, 0));
+        new_bicops.emplace_back(fam, 0);
       }
     }
   }

--- a/include/vinecopulib/bicop/indep.hpp
+++ b/include/vinecopulib/bicop/indep.hpp
@@ -27,33 +27,34 @@ private:
   // evaluation leaves; the independence copula has no parameters, so they
   // ignore `parameters`
   Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u,
-                          const Eigen::MatrixXd& parameters);
+                          const Eigen::MatrixXd& parameters) override;
 
   Eigen::VectorXd cdf(const Eigen::MatrixXd& u,
-                      const Eigen::MatrixXd& parameters);
+                      const Eigen::MatrixXd& parameters) override;
 
   Eigen::VectorXd hfunc1_raw(const Eigen::MatrixXd& u,
-                             const Eigen::MatrixXd& parameters);
+                             const Eigen::MatrixXd& parameters) override;
 
   Eigen::VectorXd hfunc2_raw(const Eigen::MatrixXd& u,
-                             const Eigen::MatrixXd& parameters);
+                             const Eigen::MatrixXd& parameters) override;
 
   Eigen::VectorXd hinv1_raw(const Eigen::MatrixXd& u,
-                            const Eigen::MatrixXd& parameters);
+                            const Eigen::MatrixXd& parameters) override;
 
   Eigen::VectorXd hinv2_raw(const Eigen::MatrixXd& u,
-                            const Eigen::MatrixXd& parameters);
+                            const Eigen::MatrixXd& parameters) override;
 
-  Eigen::MatrixXd tau_to_parameters(const double&);
+  Eigen::MatrixXd tau_to_parameters(const double&) override;
 
-  double parameters_to_tau(const Eigen::MatrixXd&);
+  double parameters_to_tau(const Eigen::MatrixXd&) override;
 
   // the independence copula has no tail dependence in any corner
-  Eigen::MatrixXd parameters_to_taildep(const Eigen::MatrixXd& parameters);
+  Eigen::MatrixXd parameters_to_taildep(
+    const Eigen::MatrixXd& parameters) override;
 
-  void flip();
+  void flip() override;
 
-  Eigen::VectorXd get_start_parameters(const double tau);
+  Eigen::VectorXd get_start_parameters(const double tau) override;
 };
 }
 

--- a/include/vinecopulib/bicop/joe.hpp
+++ b/include/vinecopulib/bicop/joe.hpp
@@ -25,57 +25,59 @@ public:
 
 private:
   // generator, its inverse and derivatives for the archimedean copula
-  double generator(const double& u,
-                   const Eigen::Ref<const Eigen::VectorXd>& parameters);
+  double generator(
+    const double& u,
+    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
 
-  double generator_inv(const double& u,
-                       const Eigen::Ref<const Eigen::VectorXd>& parameters);
+  double generator_inv(
+    const double& u,
+    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
 
   double generator_derivative(
     const double& u,
-    const Eigen::Ref<const Eigen::VectorXd>& parameters);
+    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
 
   // pdf
   Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u,
-                          const Eigen::MatrixXd& parameters);
+                          const Eigen::MatrixXd& parameters) override;
 
   // inverse hfunction
   Eigen::VectorXd hinv1_raw(const Eigen::MatrixXd& u,
-                            const Eigen::MatrixXd& parameters);
+                            const Eigen::MatrixXd& parameters) override;
 
   // analytic derivatives
   Eigen::VectorXd pdf_deriv_raw(const Eigen::MatrixXd& u,
                                 const Eigen::MatrixXd& parameters,
-                                const std::string& deriv);
+                                const std::string& deriv) override;
 
   Eigen::VectorXd pdf_deriv2_raw(const Eigen::MatrixXd& u,
                                  const Eigen::MatrixXd& parameters,
-                                 const std::string& deriv);
+                                 const std::string& deriv) override;
 
   Eigen::VectorXd hfunc1_deriv_raw(const Eigen::MatrixXd& u,
                                    const Eigen::MatrixXd& parameters,
-                                   const std::string& deriv);
+                                   const std::string& deriv) override;
 
   Eigen::VectorXd hfunc1_deriv2_raw(const Eigen::MatrixXd& u,
                                     const Eigen::MatrixXd& parameters,
-                                    const std::string& deriv);
+                                    const std::string& deriv) override;
 
   Eigen::VectorXd logpdf_deriv_raw(const Eigen::MatrixXd& u,
                                    const Eigen::MatrixXd& parameters,
-                                   const std::string& deriv);
+                                   const std::string& deriv) override;
 
   Eigen::VectorXd logpdf_deriv2_raw(const Eigen::MatrixXd& u,
                                     const Eigen::MatrixXd& parameters,
-                                    const std::string& deriv);
+                                    const std::string& deriv) override;
 
   // link between Kendall's tau and the par_bicop parameter
-  Eigen::MatrixXd tau_to_parameters(const double& tau);
+  Eigen::MatrixXd tau_to_parameters(const double& tau) override;
 
-  double parameters_to_tau(const Eigen::MatrixXd& par);
+  double parameters_to_tau(const Eigen::MatrixXd& par) override;
 
-  Eigen::MatrixXd parameters_to_taildep(const Eigen::MatrixXd& par);
+  Eigen::MatrixXd parameters_to_taildep(const Eigen::MatrixXd& par) override;
 
-  Eigen::VectorXd get_start_parameters(const double tau);
+  Eigen::VectorXd get_start_parameters(const double tau) override;
 };
 }
 

--- a/include/vinecopulib/bicop/parametric.hpp
+++ b/include/vinecopulib/bicop/parametric.hpp
@@ -20,15 +20,15 @@ class ParBicop : public AbstractBicop
 {
 protected:
   // Getters and setters
-  Eigen::MatrixXd get_parameters() const;
+  Eigen::MatrixXd get_parameters() const override;
 
-  Eigen::MatrixXd get_parameters_lower_bounds() const;
+  Eigen::MatrixXd get_parameters_lower_bounds() const override;
 
-  Eigen::MatrixXd get_parameters_upper_bounds() const;
+  Eigen::MatrixXd get_parameters_upper_bounds() const override;
 
-  void set_parameters(const Eigen::MatrixXd& parameters);
+  void set_parameters(const Eigen::MatrixXd& parameters) override;
 
-  void flip();
+  void flip() override;
 
   // Data members
   Eigen::MatrixXd parameters_;
@@ -39,11 +39,11 @@ protected:
            std::string method,
            double,
            size_t,
-           const Eigen::VectorXd& weights);
+           const Eigen::VectorXd& weights) override;
 
-  double get_npars() const;
+  double get_npars() const override;
 
-  void set_npars(const double& npars);
+  void set_npars(const double& npars) override;
 
   virtual Eigen::VectorXd get_start_parameters(const double tau) = 0;
 
@@ -52,27 +52,27 @@ protected:
   // interface; families with closed forms override these.
   Eigen::VectorXd pdf_deriv_raw(const Eigen::MatrixXd& u,
                                 const Eigen::MatrixXd& parameters,
-                                const std::string& deriv);
+                                const std::string& deriv) override;
 
   Eigen::VectorXd pdf_deriv2_raw(const Eigen::MatrixXd& u,
                                  const Eigen::MatrixXd& parameters,
-                                 const std::string& deriv);
+                                 const std::string& deriv) override;
 
   Eigen::VectorXd hfunc1_deriv_raw(const Eigen::MatrixXd& u,
                                    const Eigen::MatrixXd& parameters,
-                                   const std::string& deriv);
+                                   const std::string& deriv) override;
 
   Eigen::VectorXd hfunc1_deriv2_raw(const Eigen::MatrixXd& u,
                                     const Eigen::MatrixXd& parameters,
-                                    const std::string& deriv);
+                                    const std::string& deriv) override;
 
   Eigen::VectorXd hfunc2_deriv_raw(const Eigen::MatrixXd& u,
                                    const Eigen::MatrixXd& parameters,
-                                   const std::string& deriv);
+                                   const std::string& deriv) override;
 
   Eigen::VectorXd hfunc2_deriv2_raw(const Eigen::MatrixXd& u,
                                     const Eigen::MatrixXd& parameters,
-                                    const std::string& deriv);
+                                    const std::string& deriv) override;
 
 private:
   Eigen::VectorXd fd_deriv(

--- a/include/vinecopulib/bicop/student.hpp
+++ b/include/vinecopulib/bicop/student.hpp
@@ -27,43 +27,43 @@ private:
   // evaluation leaves (`parameters` is m x 2, m in {1, n}); these loop per row
   // because the t-distribution helpers take scalar parameters
   Eigen::VectorXd pdf_raw(const Eigen::MatrixXd& u,
-                          const Eigen::MatrixXd& parameters);
+                          const Eigen::MatrixXd& parameters) override;
 
   Eigen::VectorXd cdf(const Eigen::MatrixXd& u,
-                      const Eigen::MatrixXd& parameters);
+                      const Eigen::MatrixXd& parameters) override;
 
   Eigen::VectorXd hfunc1_raw(const Eigen::MatrixXd& u,
-                             const Eigen::MatrixXd& parameters);
+                             const Eigen::MatrixXd& parameters) override;
 
   Eigen::VectorXd hinv1_raw(const Eigen::MatrixXd& u,
-                            const Eigen::MatrixXd& parameters);
+                            const Eigen::MatrixXd& parameters) override;
 
   // analytic derivative leaves (canonical selectors; see tools_deriv),
   // ported from the VineCopula C sources (tcopuladeriv.c,
   // tcopuladeriv_new.c, logderiv.c)
   Eigen::VectorXd pdf_deriv_raw(const Eigen::MatrixXd& u,
                                 const Eigen::MatrixXd& parameters,
-                                const std::string& deriv);
+                                const std::string& deriv) override;
 
   Eigen::VectorXd pdf_deriv2_raw(const Eigen::MatrixXd& u,
                                  const Eigen::MatrixXd& parameters,
-                                 const std::string& deriv);
+                                 const std::string& deriv) override;
 
   Eigen::VectorXd hfunc1_deriv_raw(const Eigen::MatrixXd& u,
                                    const Eigen::MatrixXd& parameters,
-                                   const std::string& deriv);
+                                   const std::string& deriv) override;
 
   Eigen::VectorXd hfunc1_deriv2_raw(const Eigen::MatrixXd& u,
                                     const Eigen::MatrixXd& parameters,
-                                    const std::string& deriv);
+                                    const std::string& deriv) override;
 
   Eigen::VectorXd logpdf_deriv_raw(const Eigen::MatrixXd& u,
                                    const Eigen::MatrixXd& parameters,
-                                   const std::string& deriv);
+                                   const std::string& deriv) override;
 
   Eigen::VectorXd logpdf_deriv2_raw(const Eigen::MatrixXd& u,
                                     const Eigen::MatrixXd& parameters,
-                                    const std::string& deriv);
+                                    const std::string& deriv) override;
 
   // applies a scalar kernel to each row of `u` with per-row parameters
   static Eigen::VectorXd apply_kernel(
@@ -121,11 +121,12 @@ private:
                                     double rho,
                                     double nu);
 
-  Eigen::MatrixXd tau_to_parameters(const double& tau);
+  Eigen::MatrixXd tau_to_parameters(const double& tau) override;
 
-  Eigen::MatrixXd parameters_to_taildep(const Eigen::MatrixXd& parameters);
+  Eigen::MatrixXd parameters_to_taildep(
+    const Eigen::MatrixXd& parameters) override;
 
-  Eigen::VectorXd get_start_parameters(const double tau);
+  Eigen::VectorXd get_start_parameters(const double tau) override;
 };
 }
 

--- a/include/vinecopulib/bicop/tawn.hpp
+++ b/include/vinecopulib/bicop/tawn.hpp
@@ -38,35 +38,35 @@ private:
   // analytic derivatives (per-selector closed forms; see tawn.ipp)
   Eigen::VectorXd pdf_deriv_raw(const Eigen::MatrixXd& u,
                                 const Eigen::MatrixXd& parameters,
-                                const std::string& deriv);
+                                const std::string& deriv) override;
 
   Eigen::VectorXd pdf_deriv2_raw(const Eigen::MatrixXd& u,
                                  const Eigen::MatrixXd& parameters,
-                                 const std::string& deriv);
+                                 const std::string& deriv) override;
 
   Eigen::VectorXd hfunc1_deriv_raw(const Eigen::MatrixXd& u,
                                    const Eigen::MatrixXd& parameters,
-                                   const std::string& deriv);
+                                   const std::string& deriv) override;
 
   Eigen::VectorXd hfunc1_deriv2_raw(const Eigen::MatrixXd& u,
                                     const Eigen::MatrixXd& parameters,
-                                    const std::string& deriv);
+                                    const std::string& deriv) override;
 
   Eigen::VectorXd hfunc2_deriv_raw(const Eigen::MatrixXd& u,
                                    const Eigen::MatrixXd& parameters,
-                                   const std::string& deriv);
+                                   const std::string& deriv) override;
 
   Eigen::VectorXd hfunc2_deriv2_raw(const Eigen::MatrixXd& u,
                                     const Eigen::MatrixXd& parameters,
-                                    const std::string& deriv);
+                                    const std::string& deriv) override;
 
   Eigen::VectorXd logpdf_deriv_raw(const Eigen::MatrixXd& u,
                                    const Eigen::MatrixXd& parameters,
-                                   const std::string& deriv);
+                                   const std::string& deriv) override;
 
   Eigen::VectorXd logpdf_deriv2_raw(const Eigen::MatrixXd& u,
                                     const Eigen::MatrixXd& parameters,
-                                    const std::string& deriv);
+                                    const std::string& deriv) override;
 
   Eigen::MatrixXd tau_to_parameters(const double& tau) override;
 

--- a/include/vinecopulib/bicop/tll.hpp
+++ b/include/vinecopulib/bicop/tll.hpp
@@ -49,7 +49,7 @@ private:
            std::string method,
            double mult,
            size_t grid_size,
-           const Eigen::VectorXd& weights);
+           const Eigen::VectorXd& weights) override;
 };
 }
 

--- a/include/vinecopulib/bicop/tll.hpp
+++ b/include/vinecopulib/bicop/tll.hpp
@@ -27,13 +27,13 @@ private:
   static Eigen::VectorXd gaussian_kernel_2d(const Eigen::MatrixXd& x);
 
   Eigen::Matrix2d select_bandwidth(const Eigen::MatrixXd& x,
-                                   std::string method,
+                                   const std::string& method,
                                    const Eigen::VectorXd& weights);
 
   Eigen::MatrixXd fit_local_likelihood(const Eigen::MatrixXd& x,
                                        const Eigen::MatrixXd& x_data,
                                        const Eigen::Matrix2d& B,
-                                       std::string method,
+                                       const std::string& method,
                                        const Eigen::VectorXd& weights);
 
   double calculate_infl(const size_t& n,

--- a/include/vinecopulib/misc/tools_eigen.hpp
+++ b/include/vinecopulib/misc/tools_eigen.hpp
@@ -15,11 +15,11 @@ namespace vinecopulib {
 //! Tools for working with Eigen types
 namespace tools_eigen {
 //! An `Eigen::Matrix` containing `bool`s (similar to `Eigen::MatrixXd`).
-typedef Eigen::Matrix<bool, Eigen::Dynamic, Eigen::Dynamic> MatrixXb;
+using MatrixXb = Eigen::Matrix<bool, Eigen::Dynamic, Eigen::Dynamic>;
 
 //! A reference to a constant `Eigen::MatrixXd`; binds blocks (e.g.
 //! `u.leftCols(2)`) and full matrices without copying.
-typedef Eigen::Ref<const Eigen::MatrixXd> ConstMatRef;
+using ConstMatRef = Eigen::Ref<const Eigen::MatrixXd>;
 
 template<typename T>
 Eigen::MatrixXd

--- a/include/vinecopulib/misc/tools_interpolation.hpp
+++ b/include/vinecopulib/misc/tools_interpolation.hpp
@@ -20,7 +20,7 @@ namespace tools_interpolation {
 class InterpolationGrid
 {
 public:
-  InterpolationGrid() {}
+  InterpolationGrid() = default;
 
   InterpolationGrid(const Eigen::VectorXd& grid_points,
                     const Eigen::MatrixXd& values,

--- a/include/vinecopulib/misc/tools_thread.hpp
+++ b/include/vinecopulib/misc/tools_thread.hpp
@@ -102,7 +102,7 @@ template<class F, class... Args>
 void
 ThreadPool::push(F&& f, Args&&... args)
 {
-  if (workers_.size() == 0) {
+  if (workers_.empty()) {
     f(args...); // if there are no workers, do the job in the main thread
     return;
   } else {
@@ -250,7 +250,7 @@ ThreadPool::announce_stop()
 inline void
 ThreadPool::join_workers()
 {
-  if (workers_.size() > 0) {
+  if (!workers_.empty()) {
     for (auto& worker : workers_) {
       if (worker.joinable())
         worker.join();

--- a/include/vinecopulib/vinecop/class.hpp
+++ b/include/vinecopulib/vinecop/class.hpp
@@ -196,7 +196,7 @@ public:
   Eigen::VectorXd cdf(const Eigen::MatrixXd& u,
                       const size_t N = 1e4,
                       const size_t num_threads = 1,
-                      std::vector<int> seeds = std::vector<int>()) const;
+                      const std::vector<int>& seeds = std::vector<int>()) const;
 
   Eigen::MatrixXd simulate(
     const size_t n,

--- a/include/vinecopulib/vinecop/class.hpp
+++ b/include/vinecopulib/vinecop/class.hpp
@@ -27,7 +27,7 @@ class Vinecop
 {
 public:
   // default constructors
-  Vinecop() {}
+  Vinecop() = default;
 
   explicit Vinecop(size_t d);
 

--- a/include/vinecopulib/vinecop/fit_controls.hpp
+++ b/include/vinecopulib/vinecop/fit_controls.hpp
@@ -145,7 +145,7 @@ public:
 
   void set_select_families(bool select_families);
 
-  void set_fit_controls_bicop(FitControlsBicop controls);
+  void set_fit_controls_bicop(const FitControlsBicop& controls);
 
   void set_tree_algorithm(std::string tree_algorithm);
 

--- a/include/vinecopulib/vinecop/implementation/class.ipp
+++ b/include/vinecopulib/vinecop/implementation/class.ipp
@@ -3170,7 +3170,8 @@ Vinecop::inverse_rosenblatt(const Eigen::MatrixXd& u,
 
   Eigen::MatrixXd U_vine = u.leftCols(d); // output matrix
   //                   (hfunc1 + hfunc2)      (U_vine)       (info matrices)
-  size_t bytes_required = (8 * 2 * n * d * d) + (8 * n * d) + (4 * 4 * d * d);
+  size_t bytes_required =
+    (size_t{ 16 } * n * d * d) + (size_t{ 8 } * n * d) + (size_t{ 16 } * d * d);
   // if the problem is too large (requires more than 1 GB memory), split
   // the data into two halves and call simulate on the reduced data.
   if ((n > 1) & (bytes_required > static_cast<size_t>(1e9))) {

--- a/include/vinecopulib/vinecop/implementation/class.ipp
+++ b/include/vinecopulib/vinecop/implementation/class.ipp
@@ -1005,7 +1005,7 @@ Vinecop::check_var_types(const std::vector<std::string>& var_types) const
         << "than variables (" << d_ << ")" << std::endl;
     throw std::runtime_error(msg.str());
   }
-  for (auto t : var_types) {
+  for (const auto& t : var_types) {
     if (!tools_stl::is_member(t, { "c", "d" })) {
       msg << "variable type must be 'c' or 'd' (not '" << t << "')."
           << std::endl;

--- a/include/vinecopulib/vinecop/implementation/class.ipp
+++ b/include/vinecopulib/vinecop/implementation/class.ipp
@@ -37,11 +37,11 @@ inline Vinecop::Vinecop(const RVineStructure& structure,
   , rvine_structure_(structure)
 {
 
-  if (pair_copulas.size() > 0) {
+  if (!pair_copulas.empty()) {
     set_all_pair_copulas(pair_copulas);
   }
 
-  if (var_types.size() > 0) {
+  if (!var_types.empty()) {
     set_var_types(var_types);
   } else {
     set_continuous_var_types();
@@ -86,14 +86,14 @@ inline Vinecop::Vinecop(const Eigen::MatrixXd& data,
     d_ = structure.get_dim();
     rvine_structure_ = structure;
   } else {
-    if (var_types.size() > 0) {
+    if (!var_types.empty()) {
       d_ = var_types.size();
     } else {
       d_ = data.cols();
     }
     rvine_structure_ = RVineStructure(d_, static_cast<size_t>(0));
   }
-  if (var_types.size() == 0) {
+  if (var_types.empty()) {
     set_continuous_var_types();
   } else {
     set_var_types(var_types);
@@ -1025,7 +1025,7 @@ Vinecop::set_var_types_internal(const std::vector<std::string>& var_types) const
   for (const auto& t : var_types_) {
     n_discrete_ += (t == "d");
   }
-  if (pair_copulas_.size() == 0) {
+  if (pair_copulas_.empty()) {
     return;
   }
 
@@ -3443,7 +3443,7 @@ Vinecop::str(const std::vector<size_t>& trees) const
   std::vector<size_t> trees_to_summarize;
   std::vector<size_t> all_trees(rvine_structure_.get_trunc_lvl());
   std::iota(all_trees.begin(), all_trees.end(), 0);
-  if (trees.size() == 0) {
+  if (trees.empty()) {
     trees_to_summarize = all_trees;
   } else {
     trees_to_summarize = tools_stl::intersect(all_trees, trees);
@@ -3465,16 +3465,16 @@ Vinecop::str(const std::vector<size_t>& trees) const
   std::vector<std::string> parameters;
   std::vector<std::string> dfs;
   std::vector<std::string> taus;
-  trees_s.push_back("tree");
-  edges.push_back("edge");
-  conditioned_variables.push_back("conditioned variables");
-  conditioning_variables.push_back("conditioning variables");
-  var_types.push_back("var_types");
-  families.push_back("family");
-  rotations.push_back("rotation");
-  parameters.push_back("parameters");
-  dfs.push_back("df");
-  taus.push_back("tau");
+  trees_s.emplace_back("tree");
+  edges.emplace_back("edge");
+  conditioned_variables.emplace_back("conditioned variables");
+  conditioning_variables.emplace_back("conditioning variables");
+  var_types.emplace_back("var_types");
+  families.emplace_back("family");
+  rotations.emplace_back("rotation");
+  parameters.emplace_back("parameters");
+  dfs.emplace_back("df");
+  taus.emplace_back("tau");
 
   std::stringstream params_ss;   // 2 decimal places
   std::stringstream dfs_ss;      // 1 decimal place
@@ -3491,14 +3491,14 @@ Vinecop::str(const std::vector<size_t>& trees) const
       conditioned_variables.push_back(std::to_string(order[e]) + ", " +
                                       std::to_string(arr(t, e)));
       if (t > 0) {
-        std::string cv = "";
+        std::string cv;
         for (size_t cv_ = t - 1; cv_ > 0; --cv_) {
           cv += std::to_string(arr(cv_, e)) + ", ";
         }
         cv += std::to_string(arr(0, e));
         conditioning_variables.push_back(cv);
       } else {
-        conditioning_variables.push_back("");
+        conditioning_variables.emplace_back("");
       }
       var_types.push_back(var_types_[order[e] - 1] + ", " +
                           var_types_[arr(t, e) - 1]);
@@ -3538,10 +3538,10 @@ Vinecop::str(const std::vector<size_t>& trees) const
 
       } else {
         families.push_back(get_family_name(BicopFamily::indep));
-        rotations.push_back("");
-        parameters.push_back("");
-        taus.push_back("0.0");
-        dfs.push_back("");
+        rotations.emplace_back("");
+        parameters.emplace_back("");
+        taus.emplace_back("0.0");
+        dfs.emplace_back("");
       }
     }
   }

--- a/include/vinecopulib/vinecop/implementation/class.ipp
+++ b/include/vinecopulib/vinecop/implementation/class.ipp
@@ -2560,8 +2560,8 @@ Vinecop::hessian(Eigen::MatrixXd u,
     size_t ipar = 0;
     for (size_t t = 0; t < trunc_lvl; t++) {
       for (size_t e = 0; e < d_ - 1 - t; e++) {
-        for (size_t p = 0; p < hess(t, e).size(); p++) {
-          H.row(ipar++) += hess(t, e)[p].colwise().sum();
+        for (const auto& block : hess(t, e)) {
+          H.row(ipar++) += block.colwise().sum();
         }
       }
     }

--- a/include/vinecopulib/vinecop/implementation/class.ipp
+++ b/include/vinecopulib/vinecop/implementation/class.ipp
@@ -4,6 +4,7 @@
 // the MIT license. For a copy, see the LICENSE file in the root directory of
 // vinecopulib or https://vinecopulib.github.io/vinecopulib/.
 
+#include <utility>
 #include <vinecopulib/bicop/class.hpp>
 #include <vinecopulib/misc/tools_interface.hpp>
 #include <vinecopulib/misc/tools_serialization.hpp>
@@ -2586,7 +2587,7 @@ Vinecop::hessian(Eigen::MatrixXd u,
 inline Eigen::MatrixXd
 Vinecop::scores_cov(Eigen::MatrixXd u, bool step_wise, const size_t num_threads)
 {
-  auto s = this->scores(u, step_wise, num_threads);
+  auto s = this->scores(std::move(u), step_wise, num_threads);
   // materialize the centered scores; a lazy expression would be evaluated
   // twice by the product below
   Eigen::MatrixXd sc = s.rowwise() - s.colwise().mean();
@@ -2604,7 +2605,7 @@ Vinecop::scores_cov(Eigen::MatrixXd u,
                     bool step_wise,
                     const size_t num_threads)
 {
-  auto s = this->scores(u, parameters, step_wise, num_threads);
+  auto s = this->scores(std::move(u), parameters, step_wise, num_threads);
   Eigen::MatrixXd sc = s.rowwise() - s.colwise().mean();
   return (sc.adjoint() * sc) / static_cast<double>(s.rows());
 }
@@ -2640,7 +2641,7 @@ inline Eigen::VectorXd
 Vinecop::cdf(const Eigen::MatrixXd& u,
              const size_t N,
              const size_t num_threads,
-             std::vector<int> seeds) const
+             const std::vector<int>& seeds) const
 {
   if (d_ > 21201) {
     std::stringstream message;
@@ -3111,7 +3112,8 @@ Vinecop::rosenblatt(Eigen::MatrixXd u,
                                           : hfunc2.col(inverse_order[j]);
     }
     // randomize by weighting left and right limits with independent uniforms
-    auto R = tools_stats::simulate_uniform(u.rows(), d, false, seeds);
+    auto R =
+      tools_stats::simulate_uniform(u.rows(), d, false, std::move(seeds));
     U.leftCols(d) = U.leftCols(d).array() * R.array() +
                     U.rightCols(d).array() * (1 - R.array());
   }

--- a/include/vinecopulib/vinecop/implementation/fit_controls.ipp
+++ b/include/vinecopulib/vinecop/implementation/fit_controls.ipp
@@ -465,7 +465,7 @@ FitControlsVinecop::set_tree_algorithm(std::string tree_algorithm)
 inline void
 FitControlsVinecop::set_seeds(std::vector<int> seeds)
 {
-  if (seeds.size() == 0) {
+  if (seeds.empty()) {
     // no seeds provided, seed randomly
     std::random_device rd{};
     seeds = std::vector<int>(20);
@@ -518,7 +518,7 @@ FitControlsVinecop::str() const
       controls_str << v << " ";
   }
   controls_str << std::endl;
-  return controls_str.str().c_str();
+  return controls_str.str();
 }
 
 }

--- a/include/vinecopulib/vinecop/implementation/fit_controls.ipp
+++ b/include/vinecopulib/vinecop/implementation/fit_controls.ipp
@@ -7,6 +7,7 @@
 #include <boost/random/seed_seq.hpp>
 #include <random>
 #include <stdexcept>
+#include <utility>
 #include <vinecopulib/misc/tools_stl.hpp>
 
 //! @file vinecop/implementation/fit_controls.ipp
@@ -98,12 +99,12 @@ inline FitControlsVinecop::FitControlsVinecop(
   std::string tree_algorithm,
   bool allow_rotations,
   std::vector<int> seeds)
-  : FitControlsBicop(family_set,
-                     parametric_method,
-                     nonparametric_method,
+  : FitControlsBicop(std::move(family_set),
+                     std::move(parametric_method),
+                     std::move(nonparametric_method),
                      nonparametric_mult,
                      nonparametric_grid_size,
-                     selection_criterion,
+                     std::move(selection_criterion),
                      weights,
                      psi0,
                      preselect_families,
@@ -111,14 +112,14 @@ inline FitControlsVinecop::FitControlsVinecop(
                      num_threads)
 {
   set_trunc_lvl(trunc_lvl);
-  set_tree_criterion(tree_criterion);
+  set_tree_criterion(std::move(tree_criterion));
   set_threshold(threshold);
   set_select_trunc_lvl(select_trunc_lvl);
   set_select_threshold(select_threshold);
   set_select_families(select_families);
   set_show_trace(show_trace);
-  set_tree_algorithm(tree_algorithm);
-  set_seeds(seeds);
+  set_tree_algorithm(std::move(tree_algorithm));
+  set_seeds(std::move(seeds));
 }
 
 //! @brief Instantiates custom controls for fitting vine copula models.
@@ -163,14 +164,14 @@ inline FitControlsVinecop::FitControlsVinecop(const FitControlsBicop& controls,
   : FitControlsBicop(controls)
 {
   set_trunc_lvl(trunc_lvl);
-  set_tree_criterion(tree_criterion);
+  set_tree_criterion(std::move(tree_criterion));
   set_threshold(threshold);
   set_select_trunc_lvl(select_trunc_lvl);
   set_select_threshold(select_threshold);
   set_select_families(select_families);
   set_show_trace(show_trace);
-  set_tree_algorithm(tree_algorithm);
-  set_seeds(seeds);
+  set_tree_algorithm(std::move(tree_algorithm));
+  set_seeds(std::move(seeds));
 }
 
 //! @brief Instantiates the controls from a configuration object.
@@ -220,7 +221,8 @@ inline void
 FitControlsVinecop::check_tree_criterion(std::string tree_criterion)
 {
   if (!tools_stl::is_member(
-        tree_criterion, { "tau", "rho", "joe", "hoeffd", "mcor", "custom" })) {
+        std::move(tree_criterion),
+        { "tau", "rho", "joe", "hoeffd", "mcor", "custom" })) {
     throw std::runtime_error("tree_criterion must be one of "
                              "'tau', 'rho', 'hoeffd', 'mcor', 'joe', or "
                              "'custom'");
@@ -313,7 +315,7 @@ inline void
 FitControlsVinecop::set_tree_criterion(std::string tree_criterion)
 {
   check_tree_criterion(tree_criterion);
-  tree_criterion_ = tree_criterion;
+  tree_criterion_ = std::move(tree_criterion);
 }
 
 //! @brief Gets the custom criterion function for tree selection.
@@ -328,7 +330,7 @@ inline void
 FitControlsVinecop::set_tree_criterion_function(
   TreeCriterionFunction tree_criterion_function)
 {
-  tree_criterion_function_ = tree_criterion_function;
+  tree_criterion_function_ = std::move(tree_criterion_function);
 }
 
 //! @brief Gets the threshold parameter.
@@ -393,7 +395,7 @@ inline void
 FitControlsVinecop::set_conditioning_set(std::vector<size_t> conditioning_set)
 {
   check_conditioning_set(conditioning_set);
-  conditioning_set_ = conditioning_set;
+  conditioning_set_ = std::move(conditioning_set);
 }
 
 //! @brief Gets the random number generator.
@@ -434,7 +436,7 @@ FitControlsVinecop::get_fit_controls_bicop() const
 
 //! @brief Sets the fit controls for bivariate fitting.
 inline void
-FitControlsVinecop::set_fit_controls_bicop(FitControlsBicop controls)
+FitControlsVinecop::set_fit_controls_bicop(const FitControlsBicop& controls)
 {
   set_family_set(controls.get_family_set());
   set_parametric_method(controls.get_parametric_method());
@@ -458,7 +460,7 @@ FitControlsVinecop::set_tree_algorithm(std::string tree_algorithm)
       "tree_algorithm must be one of 'mst_prim', 'mst_kruskal', "
       "'random_weighted', or 'random_unweighted'");
   }
-  tree_algorithm_ = tree_algorithm;
+  tree_algorithm_ = std::move(tree_algorithm);
 }
 
 //! @brief Sets the random seeds for the random number generator.

--- a/include/vinecopulib/vinecop/implementation/rvine_structure.ipp
+++ b/include/vinecopulib/vinecop/implementation/rvine_structure.ipp
@@ -684,7 +684,7 @@ RVineStructure::check_upper_tri() const
 inline void
 RVineStructure::check_columns() const
 {
-  std::string problem = "";
+  std::string problem;
   for (size_t j = 0; j < d_ - 1; j++) {
     // read column into vector so we can use stl methods
     std::vector<size_t> col(std::min(trunc_lvl_, d_ - 1 - j));
@@ -702,7 +702,7 @@ RVineStructure::check_columns() const
     if (unique_in_col != col.size()) {
       problem = "a column must not contain duplicate entries.";
     }
-    if (problem != "") {
+    if (!problem.empty()) {
       throw std::runtime_error("not a valid R-vine array: " + problem);
     }
   }

--- a/include/vinecopulib/vinecop/implementation/rvine_structure.ipp
+++ b/include/vinecopulib/vinecop/implementation/rvine_structure.ipp
@@ -4,6 +4,7 @@
 // the MIT license. For a copy, see the LICENSE file in the root directory of
 // vinecopulib or https://vinecopulib.github.io/vinecopulib/.
 
+#include <utility>
 #include <vinecopulib/misc/tools_serialization.hpp>
 #include <vinecopulib/misc/tools_stats.hpp>
 #include <vinecopulib/misc/tools_stl.hpp>
@@ -387,7 +388,7 @@ RVineStructure::str() const
 inline RVineStructure
 RVineStructure::simulate(size_t d, bool natural_order, std::vector<int> seeds)
 {
-  auto U = tools_stats::simulate_uniform(d, d, false, seeds);
+  auto U = tools_stats::simulate_uniform(d, d, false, std::move(seeds));
 
   // A is the R-vine matrix we want to create (upper right-triag format).
   // B is a random binary representation that we need to convert.

--- a/include/vinecopulib/vinecop/implementation/tools_select.ipp
+++ b/include/vinecopulib/vinecop/implementation/tools_select.ipp
@@ -403,7 +403,7 @@ VinecopSelector::get_nobs() const
 inline double
 VinecopSelector::get_next_threshold(std::vector<double>& thresholded_crits)
 {
-  if (thresholded_crits.size() == 0) {
+  if (thresholded_crits.empty()) {
     return 1.0;
   }
   // sort in descending order
@@ -1077,7 +1077,7 @@ VinecopSelector::find_common_neighbor(size_t v0,
   auto ei1 = tree[v1].prev_edge_indices;
   auto ei_common = intersect(ei0, ei1);
 
-  if (ei_common.size() == 0) {
+  if (ei_common.empty()) {
     return -1;
   } else {
     return ei_common[0];
@@ -1241,7 +1241,7 @@ VinecopSelector::get_pc_index(const EdgeIterator& e, const VineTree& tree)
   // add 1 everywhere for user-facing representation (boost::graph
   // starts at 0)
   index << tree[e].conditioned[0] + 1 << "," << tree[e].conditioned[1] + 1;
-  if (tree[e].conditioning.size() > 0) {
+  if (!tree[e].conditioning.empty()) {
     index << " | ";
     for (unsigned int i = 0; i < tree[e].conditioning.size(); ++i) {
       index << tree[e].conditioning[i] + 1;
@@ -1250,7 +1250,7 @@ VinecopSelector::get_pc_index(const EdgeIterator& e, const VineTree& tree)
     }
   }
 
-  return index.str().c_str();
+  return index.str();
 }
 }
 }

--- a/include/vinecopulib/vinecop/implementation/tools_select.ipp
+++ b/include/vinecopulib/vinecop/implementation/tools_select.ipp
@@ -4,6 +4,7 @@
 // the MIT license. For a copy, see the LICENSE file in the root directory of
 // vinecopulib or https://vinecopulib.github.io/vinecopulib/.
 
+#include <utility>
 #include <vinecopulib/misc/tools_stats.hpp>
 #include <vinecopulib/misc/tools_stl.hpp>
 
@@ -108,8 +109,9 @@ inline VinecopSelector::VinecopSelector(const Eigen::MatrixXd& data,
                                         const FitControlsVinecop& controls,
                                         std::vector<std::string> var_types)
   : n_(data.rows())
+  // d_ is declared before var_types_, so it is initialized before the move.
   , d_(var_types.size())
-  , var_types_(var_types)
+  , var_types_(std::move(var_types))
   , controls_(controls)
   , pool_(controls_.get_num_threads())
   , trees_(std::vector<VineTree>(1))
@@ -133,7 +135,7 @@ inline VinecopSelector::VinecopSelector(const Eigen::MatrixXd& data,
                                         const RVineStructure& vine_struct,
                                         const FitControlsVinecop& controls,
                                         std::vector<std::string> var_types)
-  : VinecopSelector(data, controls, var_types)
+  : VinecopSelector(data, controls, std::move(var_types))
 {
   vine_struct_ = vine_struct;
   structure_unknown_ = false;

--- a/include/vinecopulib/vinecop/rvine_trees.hpp
+++ b/include/vinecopulib/vinecop/rvine_trees.hpp
@@ -54,6 +54,9 @@ public:
       : a(a_arg)
       , b(b_arg)
       , C(std::move(c_arg))
+      // Bicop's user-declared copy constructor suppresses its implicit move
+      // constructor, so this move is a copy today; keep the intent.
+      // NOLINTNEXTLINE(performance-move-const-arg)
       , pair_copula(std::move(pc))
     {
       finalize();

--- a/include/vinecopulib/vinecop/rvine_trees.hpp
+++ b/include/vinecopulib/vinecop/rvine_trees.hpp
@@ -50,14 +50,11 @@ public:
     {
       finalize();
     }
-    Edge(size_t a_arg, size_t b_arg, std::vector<size_t> c_arg, const Bicop& pc)
+    Edge(size_t a_arg, size_t b_arg, std::vector<size_t> c_arg, Bicop pc)
       : a(a_arg)
       , b(b_arg)
       , C(std::move(c_arg))
-      // By const reference rather than by value + move: Bicop's user-declared
-      // copy constructor suppresses its implicit move, so by-value would copy
-      // twice.
-      , pair_copula(pc)
+      , pair_copula(std::move(pc))
     {
       finalize();
     }

--- a/include/vinecopulib/vinecop/rvine_trees.hpp
+++ b/include/vinecopulib/vinecop/rvine_trees.hpp
@@ -50,14 +50,14 @@ public:
     {
       finalize();
     }
-    Edge(size_t a_arg, size_t b_arg, std::vector<size_t> c_arg, Bicop pc)
+    Edge(size_t a_arg, size_t b_arg, std::vector<size_t> c_arg, const Bicop& pc)
       : a(a_arg)
       , b(b_arg)
       , C(std::move(c_arg))
-      // Bicop's user-declared copy constructor suppresses its implicit move
-      // constructor, so this move is a copy today; keep the intent.
-      // NOLINTNEXTLINE(performance-move-const-arg)
-      , pair_copula(std::move(pc))
+      // By const reference rather than by value + move: Bicop's user-declared
+      // copy constructor suppresses its implicit move, so by-value would copy
+      // twice.
+      , pair_copula(pc)
     {
       finalize();
     }

--- a/include/vinecopulib/vinecop/tools_select.hpp
+++ b/include/vinecopulib/vinecop/tools_select.hpp
@@ -70,17 +70,16 @@ struct EdgeProperties
   vinecopulib::Bicop pair_copula;
   double fit_id;
 };
-typedef boost::adjacency_list<
+using VineTree = boost::adjacency_list<
   boost::vecS,
   boost::vecS,
   boost::undirectedS,
   VertexProperties,
-  boost::property<boost::edge_weight_t, double, EdgeProperties>>
-  VineTree;
+  boost::property<boost::edge_weight_t, double, EdgeProperties>>;
 
-typedef boost::graph_traits<VineTree>::edge_descriptor EdgeIterator;
-typedef std::pair<EdgeIterator, bool> FoundEdge;
-typedef boost::property_map<VineTree, boost::edge_weight_t>::type WeightMap;
+using EdgeIterator = boost::graph_traits<VineTree>::edge_descriptor;
+using FoundEdge = std::pair<EdgeIterator, bool>;
+using WeightMap = boost::property_map<VineTree, boost::edge_weight_t>::type;
 
 class VinecopSelector
 {

--- a/test/src_test/include/parbicop_test.hpp
+++ b/test/src_test/include/parbicop_test.hpp
@@ -39,7 +39,7 @@ protected:
   Bicop bicop_;
   bool needs_check_;
 
-  virtual void SetUp()
+  void SetUp() override
   {
     n_ = static_cast<int>(5e3);
     auto family = ::testing::get<0>(GetParam());

--- a/test/src_test/include/test_bicop_parametric.hpp
+++ b/test/src_test/include/test_bicop_parametric.hpp
@@ -454,8 +454,8 @@ TEST_P(ParBicopTest, derivatives_match_finite_differences)
   for (Eigen::Index k = 0; k < p; ++k) {
     comps.push_back("par" + std::to_string(k + 1));
   }
-  comps.push_back("u1");
-  comps.push_back("u2");
+  comps.emplace_back("u1");
+  comps.emplace_back("u2");
 
   auto fd_first = [&](const std::string& method, const std::string& comp) {
     auto eval = [&method](const Bicop& b,

--- a/test/src_test/include/test_bicop_parametric.hpp
+++ b/test/src_test/include/test_bicop_parametric.hpp
@@ -15,7 +15,7 @@
 namespace test_bicop_parametric {
 using namespace vinecopulib;
 using namespace tools_stl;
-std::vector<int> rotations = { 0, 90, 180, 270 };
+const std::vector<int> rotations = { 0, 90, 180, 270 };
 using test_utils::all_close;
 
 // Test that the serialization works

--- a/test/src_test/include/test_bicop_select.hpp
+++ b/test/src_test/include/test_bicop_select.hpp
@@ -7,6 +7,7 @@
 #pragma once
 
 #include "gtest/gtest.h"
+#include <limits>
 #include <vinecopulib.hpp>
 
 namespace test_bicop_select {
@@ -69,5 +70,21 @@ TEST(bicop_select, fit_stats_are_correct)
   EXPECT_NEAR(cop.get_bic(), cop.bic(), 1e-10);
   EXPECT_NEAR(cop.get_mbic(), cop.mbic(u), 1e-10);
   EXPECT_NEAR(cop.get_mbic(), cop.mbic(), 1e-10);
+}
+
+TEST(bicop_select, mbic_and_bic_agree_on_sample_size_with_nans)
+{
+  Bicop cop(BicopFamily::gaussian, 0, Eigen::VectorXd::Constant(1, -0.5));
+  auto u = cop.simulate(30, false, { 1 });
+  cop.select(u);
+
+  // Append rows containing NaN; both criteria must count complete cases only,
+  // so appending incomplete observations must not change either penalty.
+  Eigen::MatrixXd u_nan(u.rows() + 3, 2);
+  u_nan << u,
+    Eigen::MatrixXd::Constant(3, 2, std::numeric_limits<double>::quiet_NaN());
+
+  EXPECT_NEAR(cop.bic(u_nan), cop.bic(u), 1e-10);
+  EXPECT_NEAR(cop.mbic(u_nan), cop.mbic(u), 1e-10);
 }
 }

--- a/test/src_test/include/test_discrete.hpp
+++ b/test/src_test/include/test_discrete.hpp
@@ -185,7 +185,7 @@ TEST(discrete, vinecop)
   // check output
   auto pcs = vc2.get_all_pair_copulas();
   for (size_t t = 0; t < 4; t++) {
-    for (auto pc : pcs[t]) {
+    for (const auto& pc : pcs[t]) {
       EXPECT_EQ(pc.get_rotation(), 90);
       EXPECT_NEAR(
         pc.get_parameters()(0), 2.0 / (static_cast<double>(t) + 1.0), 0.5);
@@ -213,7 +213,7 @@ TEST(discrete, vinecop)
   vc2.pdf(u);
   pcs = vc2.get_all_pair_copulas();
   for (size_t t = 0; t < 4; t++) {
-    for (auto pc : pcs[t]) {
+    for (const auto& pc : pcs[t]) {
       EXPECT_EQ(pc.get_rotation(), 90);
       EXPECT_NEAR(
         pc.get_parameters()(0), 2.0 / (static_cast<double>(t) + 1.0), 0.5);
@@ -278,7 +278,7 @@ TEST(zero_inflated, vinecop)
   // check output
   auto pcs = vc.get_all_pair_copulas();
   for (size_t t = 0; t < 4; t++) {
-    for (auto pc : pcs[t]) {
+    for (const auto& pc : pcs[t]) {
       EXPECT_EQ(pc.get_rotation(), 90);
       EXPECT_NEAR(
         pc.get_parameters()(0), 2.0 / (static_cast<double>(t) + 1.0), 0.5);

--- a/test/src_test/include/test_tools_stats.hpp
+++ b/test/src_test/include/test_tools_stats.hpp
@@ -124,19 +124,19 @@ TEST(test_tools_stats, seed_works)
 
 TEST(test_tools_stats, dpqnorm_work)
 {
-  auto dnorm_boost = [](Eigen::MatrixXd x) {
+  auto dnorm_boost = [](const Eigen::MatrixXd& x) {
     boost::math::normal dist;
     auto f = [&dist](double y) { return boost::math::pdf(dist, y); };
     return tools_eigen::unaryExpr_or_nan(x, f);
   };
 
-  auto pnorm_boost = [](Eigen::MatrixXd x) {
+  auto pnorm_boost = [](const Eigen::MatrixXd& x) {
     boost::math::normal dist;
     auto f = [&dist](double y) { return boost::math::cdf(dist, y); };
     return tools_eigen::unaryExpr_or_nan(x, f);
   };
 
-  auto qnorm_boost = [](Eigen::MatrixXd x) {
+  auto qnorm_boost = [](const Eigen::MatrixXd& x) {
     boost::math::normal dist;
     auto f = [&dist](double y) { return boost::math::quantile(dist, y); };
     return tools_eigen::unaryExpr_or_nan(x, f);

--- a/test/src_test/include/test_vinecop_class.hpp
+++ b/test/src_test/include/test_vinecop_class.hpp
@@ -650,7 +650,7 @@ TEST_F(VinecopTest, conditional_select_places_conditioning_set_at_tail)
                                        BicopFamily::gumbel,
                                        BicopFamily::frank };
   std::vector<std::vector<size_t>> sets{ { 3 }, { 2, 5 }, { 1, 4, 6 } };
-  for (auto B : sets) {
+  for (const auto& B : sets) {
     FitControlsVinecop c;
     c.set_family_set(fam);
     c.set_conditioning_set(B);
@@ -743,7 +743,7 @@ TEST_F(VinecopTest, reorient_preserves_model)
     { 1 },    { 2 },    { 3 },    { 4 },       { 5 },      { 6 },
     { 1, 2 }, { 2, 5 }, { 3, 6 }, { 1, 4, 6 }, { 2, 3, 5 }
   };
-  for (auto B : candidates) {
+  for (const auto& B : candidates) {
     Vinecop vr = vc;
     try {
       vr.reorient(B);
@@ -1739,9 +1739,9 @@ get_pairs_unequal(
       vcl_sets[tree][edge][0] = matrix2(tree, edge);
       vcl_sets[tree][edge][1] = matrix2(trunc_lvl - edge, edge);
     }
-    for (auto s1 : vc_sets[tree]) {
+    for (const auto& s1 : vc_sets[tree]) {
       bool is_in_both = false;
-      for (auto s2 : vcl_sets[tree]) {
+      for (const auto& s2 : vcl_sets[tree]) {
         if (tools_stl::is_same_set(s1, s2)) {
           is_in_both = true;
         }


### PR DESCRIPTION
**Please review and merge yourself — I will not merge this.** Stacked on `main`.

Supersedes Dependabot's **#705, #706, #707, #708** (their bumps are applied here) and closes **#709**.

## Why this exists

The clang-tidy gate added in #704 ran on the pull-request diff only, so the existing tree had never been linted: **301 findings**. Left alone, the first later PR to touch an unlinted file would fail for reasons unrelated to its own change.

## The bugs this surfaced

**1. `Bicop::mbic` used the wrong sample size.** clang-tidy flagged a never-modified copy — which turned out to be the fossil of a *missing call*. `bic` strips incomplete observations before taking `n`; `mbic` made the same copy and never stripped it:

```cpp
// bic
Eigen::MatrixXd u_no_nan = u;
if (u.rows() > 0) {
  tools_eigen::remove_nans(u_no_nan);   // present
  n = u_no_nan.rows();
}

// mbic, before
Eigen::MatrixXd u_no_nan = u;
if (u.rows() > 0) {
                                        // missing
  n = u_no_nan.rows();
}
```

On data containing NaNs, mBIC's `log(n) · npars` penalty was computed from more observations than were fitted, so `mbic` and `bic` disagreed on the same input. `aic` has no `log(n)` term; `Vinecop::bic`/`mbicv` both use `u.rows()` and stay consistent with each other. Regression test verified to **fail before, pass after**.

**2. An ODR hazard.** `rotations` was a non-inline namespace-scope definition in `test_bicop_parametric.hpp`, which two translation units include. Read-only, so `const` gives it internal linkage.

**3. A throwing move constructor.** Moving an `RVineTrees::Edge` invoked `Bicop`'s *copy* constructor, because a user-declared copy constructor suppresses the implicit move — and `Bicop`'s copy is a **deep clone** that reconstructs the family object from family/rotation/parameters. `Bicop` now declares `Bicop(Bicop&&) = default`.

**4. Two implicit widenings** in `Vinecop::simulate`'s memory estimate (`8 * 2 * n` computed in `int`, then widened). The estimate guards a 1 GB split, so it should not depend on the values being small.

## On the move constructor: measured, not assumed

I expected a speed-up and did not get one. Benchmarked with and without it:

| benchmark | baseline | w/ move | change |
|---|---|---|---|
| `select/itau/d=10/threads=1` | 694.6 ms | 694.2 ms | −0.1% |
| `select/itau/d=5/threads=4` | 102.7 ms | 101.6 ms | −1.1% |
| `select/tll/d=5/threads=4` | 104.3 ms | 103.2 ms | −1.1% |
| `pdf/d=25/threads=1` | 42.59 ms | 42.48 ms | −0.3% |

All within noise, because **#681 and #701 already removed the per-edge `Bicop` deep copies** from these paths (non-owning pointers, in-place fits). It is kept because it makes `std::move` on a `Bicop` honest and resolves finding 3 — not because it is faster.

## Widening the checks

Each group measured over the whole library, then enabled where the tree can pass:

| group | findings | decision |
|---|---|---|
| `performance-*` | 0 | **wholesale** |
| `portability-*` | 0 | **wholesale** |
| `misc-*` | 83 | **wholesale** minus 2 |
| `bugprone-*` | 435 | **wholesale** minus 2 |
| `modernize-*` | 1,233 | stays curated |
| `readability-*` | ~344,000 | stays curated |

The four exclusions are unactionable, not merely inconvenient: `narrowing-conversions` (389) is inherent to `size_t`/`Eigen::Index`/`double` arithmetic; `non-private-member-variables-in-classes` (61) objects to the edge and graph structs, which are deliberately plain data; `easily-swappable-parameters` (43) and `no-recursion` (21) are noise. `modernize-*` and `readability-*` stay curated because widening them means fixing the findings first — a separate piece of work, happy to do it as a follow-up.

## What was cleared (301 → 0)

`modernize-use-override` 193 · `performance-unnecessary-value-param` 44 · `modernize-use-emplace` 21 · `readability-container-size-empty` 13 · `performance-for-range-copy` 10 · `modernize-use-using` 8 · 12 others.

The `use-override` pass is what closes **#709**: all eight `TawnBicop` `*_deriv*_raw` declarations now carry `override`, and clang with `-Werror=inconsistent-missing-override` is clean, so the rvinecopulib macOS job should pass. The compiler now also verifies every one of the 193 is a genuine override.

`performance-unnecessary-value-param` needed splitting rather than a uniform fix: read-only parameters take `const&`; **stored** parameters (every `FitControls` setter, `VinecopSelector`'s primary constructor) keep their by-value signature and are move-assigned. Converting those to `const&` would be *worse* — the constructors already forward with `std::move`, and you cannot move from a const reference. An intermediate commit did convert them and silently created 10 new `performance-move-const-arg` findings; the two checks chase each other on a sink.

## `modernize-loop-convert`: fixed, not suppressed

Initially I disabled it, since on `Vinecop::hessian` it rewrote a loop over `hess(t, e)` into one over `hess` — a *different container*, which would have silently corrupted the Hessian had it compiled. That was the wrong call: the check was pointing at real code. The loop is now a hand-written range-for over `hess(t, e)` and **the check is re-enabled**.

## `Eigen::MatrixXd u` by value vs `const&`

Reviewed as asked. The by-value ones are **load-bearing, not an oversight**: `rosenblatt` passes `u` to `collapse_data_inplace(u)`, and `pdf`/`scores`/… do `return pdf_full(std::move(u), …)`. Taking them by `const&` would force an extra full n × d copy inside; for an lvalue caller the two are equal, and for an rvalue by-value is strictly better. clang-tidy does not flag them, which corroborates it. The real defect was that this was undocumented — `AGENTS.md` now records the convention so it is not "cleaned up" into a regression.

## CI fixes the Dependabot PRs exposed

- **Coverage failed on all four of them**: `Token length: 0` → `"Token required because branch is protected"`. Dependabot and fork PRs get no repository secrets, and the `fail_ci_if_error` added in #704 turned that silent no-op into a hard failure of a required check. The step is now skipped without a token and still enforced with one.
- **#706's Windows leg** hit an unrelated chocolatey 503 fetching Eigen. Both Eigen sources are now retried three times with a growing delay.

## Also

`AGENTS.md` gains the squash-on-merge rule (one PR = one commit on `main`), the parameter-passing convention, and the never-merge-without-consent rule. A new CI job runs clang-tidy over the whole library so the backlog cannot regrow behind the diff-only gate.

**Note for reviewers:** verify `.ipp` changes in a header-only build, or reconfigure first. An existing `VINECOPULIB_PRECOMPILED=ON` tree compiled a stale generated `.cpp` and reported success for code that does not compile at all — `findHeaders.cmake` has no dependency edge from a generated `.cpp` to its `.ipp`. The CMake PR fixes that.

## Verification

- clang-tidy: **zero findings** over the whole library against the widened list.
- **646 tests pass** in both the header-only and precompiled configurations.
- **`parity_dump` byte-identical** to the pre-refactor baseline throughout.
- clang-format clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
