### PR TITLE
fix(vinecop): make inverse Rosenblatt thread-safe

### DIFF
--- a/include/vinecopulib/bicop/class.hpp
+++ b/include/vinecopulib/bicop/class.hpp
@@ -44,6 +44,7 @@ using BicopPtr = std::shared_ptr<AbstractBicop>;
 //!
 class Bicop
 {
+  friend class Vinecop;
 
 public:
   // Constructors
@@ -333,11 +334,22 @@ public:
   Bicop as_continuous() const;
 
 private:
+  // Evaluate the continuous copula represented by this object without
+  // consulting or changing its stored variable types. These are used by the
+  // inverse Rosenblatt transform, whose input and output always have
+  // continuous uniform margins even when the fitted model has discrete
+  // variables.
+  Eigen::VectorXd hfunc1_continuous(const Eigen::MatrixXd& u) const;
+
+  Eigen::VectorXd hinv2_continuous(const Eigen::MatrixXd& u) const;
+
   Eigen::MatrixXd format_data(const Eigen::MatrixXd& u) const;
 
   void rotate_data(Eigen::MatrixXd& u) const;
 
   Eigen::MatrixXd prep_for_abstract(const Eigen::MatrixXd& u) const;
+
+  Eigen::MatrixXd prep_for_abstract_continuous(const Eigen::MatrixXd& u) const;
 
   Eigen::MatrixXd format_parameters(const Eigen::MatrixXd& u,
                                     const Eigen::MatrixXd& parameters) const;

--- a/include/vinecopulib/bicop/implementation/class.ipp
+++ b/include/vinecopulib/bicop/implementation/class.ipp
@@ -399,6 +399,60 @@ Bicop::hinv2(const Eigen::MatrixXd& u) const
   tools_eigen::trim(hi, 0.0, 1.0);
   return hi;
 }
+
+inline Eigen::VectorXd
+Bicop::hfunc1_continuous(const Eigen::MatrixXd& u) const
+{
+  auto u_new = prep_for_abstract_continuous(u);
+  // TLL leaves read their interpolation grid directly and ignore the parameter
+  // argument; do not materialize the full grid merely to pass it unused.
+  Eigen::MatrixXd parameters = get_family() == BicopFamily::tll
+                                 ? Eigen::MatrixXd()
+                                 : bicop_->get_parameters().transpose();
+  Eigen::VectorXd h(u.rows());
+  switch (rotation_) {
+    default:
+      h = bicop_->hfunc1_raw(u_new, parameters);
+      break;
+    case 90:
+      h = bicop_->hfunc2_raw(u_new, parameters);
+      break;
+    case 180:
+      h = 1.0 - bicop_->hfunc1_raw(u_new, parameters).array();
+      break;
+    case 270:
+      h = 1.0 - bicop_->hfunc2_raw(u_new, parameters).array();
+      break;
+  }
+  tools_eigen::trim(h, 0.0, 1.0);
+  return h;
+}
+
+inline Eigen::VectorXd
+Bicop::hinv2_continuous(const Eigen::MatrixXd& u) const
+{
+  auto u_new = prep_for_abstract_continuous(u);
+  Eigen::MatrixXd parameters = get_family() == BicopFamily::tll
+                                 ? Eigen::MatrixXd()
+                                 : bicop_->get_parameters().transpose();
+  Eigen::VectorXd hi(u.rows());
+  switch (rotation_) {
+    default:
+      hi = bicop_->hinv2_raw(u_new, parameters);
+      break;
+    case 90:
+      hi = 1.0 - bicop_->hinv1_raw(u_new, parameters).array();
+      break;
+    case 180:
+      hi = 1.0 - bicop_->hinv2_raw(u_new, parameters).array();
+      break;
+    case 270:
+      hi = bicop_->hinv1_raw(u_new, parameters);
+      break;
+  }
+  tools_eigen::trim(hi, 0.0, 1.0);
+  return hi;
+}
 //! @}
 
 //! @name Stats methods with per-row parameters
@@ -2207,6 +2261,15 @@ inline Eigen::MatrixXd
 Bicop::prep_for_abstract(const Eigen::MatrixXd& u) const
 {
   auto u_new = format_data(u);
+  tools_eigen::trim(u_new);
+  rotate_data(u_new);
+  return u_new;
+}
+
+inline Eigen::MatrixXd
+Bicop::prep_for_abstract_continuous(const Eigen::MatrixXd& u) const
+{
+  Eigen::MatrixXd u_new = u.leftCols(2);
   tools_eigen::trim(u_new);
   rotate_data(u_new);
   return u_new;

--- a/include/vinecopulib/vinecop/class.hpp
+++ b/include/vinecopulib/vinecop/class.hpp
@@ -409,8 +409,8 @@ protected:
   double threshold_{ 0.0 };
   double loglik_{ NAN };
   size_t nobs_{ 0 };
-  mutable std::vector<std::string> var_types_;
-  mutable int n_discrete_{ 0 };
+  std::vector<std::string> var_types_;
+  int n_discrete_{ 0 };
 
   void check_data_dim(const Eigen::MatrixXd& data) const;
   void check_data(const Eigen::MatrixXd& data) const;
@@ -426,8 +426,8 @@ protected:
   void check_fitted() const;
   void check_indices(const size_t tree, const size_t edge) const;
   void check_var_types(const std::vector<std::string>& var_types) const;
-  void set_continuous_var_types() const;
-  void set_var_types_internal(const std::vector<std::string>& var_types) const;
+  void set_continuous_var_types();
+  void set_var_types_internal(const std::vector<std::string>& var_types);
   int get_n_discrete() const;
   bool is_discrete() const;
   Eigen::MatrixXd collapse_data(const Eigen::MatrixXd& u) const;

--- a/include/vinecopulib/vinecop/implementation/class.ipp
+++ b/include/vinecopulib/vinecop/implementation/class.ipp
@@ -1019,7 +1019,7 @@ Vinecop::check_var_types(const std::vector<std::string>& var_types) const
 //! @param var_types A vector specifying the types of the variables,
 //!   e.g., `{"c", "d"}` means first varible continuous, second discrete.
 inline void
-Vinecop::set_var_types_internal(const std::vector<std::string>& var_types) const
+Vinecop::set_var_types_internal(const std::vector<std::string>& var_types)
 {
   var_types_ = var_types;
   n_discrete_ = 0;
@@ -3161,9 +3161,17 @@ inline Eigen::MatrixXd
 Vinecop::inverse_rosenblatt(const Eigen::MatrixXd& u,
                             const size_t num_threads) const
 {
-  auto var_types = get_var_types();
-  set_continuous_var_types();
-  check_data(u);
+  const size_t n_cols = static_cast<size_t>(u.cols());
+  if ((n_cols != d_) && (n_cols != 2 * d_)) {
+    throw std::runtime_error(
+      "data has wrong number of columns; expected: " + std::to_string(d_) +
+      " or " + std::to_string(2 * d_) + ", actual: " + std::to_string(n_cols) +
+      ".");
+  }
+  if (u.rows() < 1) {
+    throw std::runtime_error("data must have at least one row");
+  }
+  tools_eigen::check_if_in_unit_cube(u);
 
   size_t n = u.rows();
   size_t d = d_;
@@ -3209,8 +3217,6 @@ Vinecop::inverse_rosenblatt(const Eigen::MatrixXd& u,
         static_cast<double>(n) * static_cast<double>(d) > 1e5);
       size_t tree_start = std::min(trunc_lvl - 1, d - var - 2);
       for (ptrdiff_t tree = tree_start; tree >= 0; --tree) {
-        // var types have already been set to continuous above, so no copy
-        // via as_continuous() is needed
         const Bicop& edge_copula = pair_copulas_[tree][var];
 
         // extract data for conditional pair
@@ -3223,13 +3229,13 @@ Vinecop::inverse_rosenblatt(const Eigen::MatrixXd& u,
         }
 
         // inverse Rosenblatt transform simulates data for conditional pair
-        hinv2(tree, var) = edge_copula.hinv2(U_e);
+        hinv2(tree, var) = edge_copula.hinv2_continuous(U_e);
 
-        // if required at later stage, also calculate hfunc2
+        // if required at a later stage, also calculate hfunc1
         if (var < static_cast<ptrdiff_t>(d_) - 1) {
           if (rvine_structure_.needed_hfunc1(tree, var)) {
             U_e.col(0) = hinv2(tree, var);
-            hfunc1(tree + 1, var) = edge_copula.hfunc1(U_e);
+            hfunc1(tree + 1, var) = edge_copula.hfunc1_continuous(U_e);
           }
         }
       }
@@ -3246,7 +3252,6 @@ Vinecop::inverse_rosenblatt(const Eigen::MatrixXd& u,
     pool.join();
   }
 
-  set_var_types_internal(var_types);
   return U_vine;
 }
 
@@ -3387,9 +3392,8 @@ Vinecop::truncate(size_t trunc_lvl)
 
 //! @brief Sets all variable types to continuous.
 //!
-//! @details The function can be const, because var_types_ is mutable.
 inline void
-Vinecop::set_continuous_var_types() const
+Vinecop::set_continuous_var_types()
 {
   var_types_ = std::vector<std::string>(d_);
   for (auto& t : var_types_)

--- a/test/src_test/include/test_vinecop_class.hpp
+++ b/test/src_test/include/test_vinecop_class.hpp
@@ -8,6 +8,7 @@
 
 #include "test_utils.hpp"
 #include "vinecop_test.hpp"
+#include <future>
 #include <string>
 #include <vinecopulib.hpp>
 #include <vinecopulib/misc/tools_stl.hpp>
@@ -398,6 +399,81 @@ TEST_F(VinecopTest, simulate_is_correct)
   vinecop.simulate(10, true, 1, { 1 });
   Vinecop vinecop2(301);
   vinecop.simulate(10, true, 1, { 1 });
+}
+
+TEST_F(VinecopTest, inverse_rosenblatt_does_not_mutate_discrete_model)
+{
+  const size_t d = 5;
+  auto pair_copulas = Vinecop::make_pair_copula_store(d);
+  auto par = Eigen::VectorXd::Constant(1, 2.0);
+  for (size_t tree = 0; tree < pair_copulas.size(); ++tree) {
+    for (auto& pc : pair_copulas[tree]) {
+      pc = Bicop(BicopFamily::clayton, tree % 2 == 0 ? 90 : 270, par);
+    }
+  }
+  auto structure = DVineStructure(std::vector<size_t>{ 1, 2, 3, 4, 5 });
+  auto var_types = std::vector<std::string>{ "d", "c", "d", "d", "c" };
+  Vinecop discrete(structure, pair_copulas, var_types);
+  Vinecop continuous(structure, pair_copulas);
+  auto w = tools_stats::simulate_uniform(100, d, false, { 17 });
+
+  EXPECT_TRUE(all_close(discrete.inverse_rosenblatt(w),
+                        continuous.inverse_rosenblatt(w),
+                        1e-12,
+                        1e-12));
+  EXPECT_EQ(discrete.get_var_types(), var_types);
+
+  auto pair_copulas_before = discrete.get_all_pair_copulas();
+  EXPECT_ANY_THROW(discrete.inverse_rosenblatt(w.leftCols(d - 1)));
+  EXPECT_EQ(discrete.get_var_types(), var_types);
+  auto pair_copulas_after = discrete.get_all_pair_copulas();
+  for (size_t tree = 0; tree < pair_copulas_before.size(); ++tree) {
+    for (size_t edge = 0; edge < pair_copulas_before[tree].size(); ++edge) {
+      EXPECT_EQ(pair_copulas_after[tree][edge].get_var_types(),
+                pair_copulas_before[tree][edge].get_var_types());
+    }
+  }
+
+  auto tll_data =
+    Bicop(BicopFamily::gaussian, 0, Eigen::VectorXd::Constant(1, 0.5))
+      .simulate(200, false, { 29 });
+  Bicop tll(tll_data, FitControlsBicop({ BicopFamily::tll }));
+  std::vector<std::vector<Bicop>> tll_pair_copulas{ { tll } };
+  auto tll_structure = DVineStructure(std::vector<size_t>{ 1, 2 });
+  Vinecop tll_continuous(tll_structure, tll_pair_copulas);
+  Vinecop tll_discrete(tll_structure, tll_pair_copulas, { "d", "c" });
+  auto w_tll = tools_stats::simulate_uniform(20, 2, false, { 31 });
+  EXPECT_TRUE(all_close(tll_discrete.inverse_rosenblatt(w_tll),
+                        tll_continuous.inverse_rosenblatt(w_tll),
+                        1e-12,
+                        1e-12));
+}
+
+TEST_F(VinecopTest, inverse_rosenblatt_is_safe_for_concurrent_calls)
+{
+  const size_t d = 5;
+  auto pair_copulas = Vinecop::make_pair_copula_store(d);
+  auto par = Eigen::VectorXd::Constant(1, 2.0);
+  for (auto& tree : pair_copulas) {
+    for (auto& pc : tree) {
+      pc = Bicop(BicopFamily::clayton, 90, par);
+    }
+  }
+  const Vinecop model(DVineStructure(std::vector<size_t>{ 1, 2, 3, 4, 5 }),
+                      pair_copulas,
+                      { "d", "c", "d", "d", "c" });
+  auto w = tools_stats::simulate_uniform(100, d, false, { 23 });
+  auto expected = model.inverse_rosenblatt(w);
+
+  std::vector<std::future<Eigen::MatrixXd>> results;
+  for (size_t i = 0; i < 4; ++i) {
+    results.emplace_back(std::async(std::launch::async, [&model, &w]() {
+      return model.inverse_rosenblatt(w);
+    }));
+  }
+  for (auto& result : results) {
+    EXPECT_TRUE(all_close(result.get(), expected, 1e-12, 1e-12));
+  }
 }
 
 TEST_F(VinecopTest, rosenblatt_is_correct)


### PR DESCRIPTION
## Summary

- evaluate inverse Rosenblatt h-functions continuously without mutating stored variable types
- avoid materializing TLL parameter grids in the new internal evaluation path
- add regression coverage for discrete, TLL, exception, and concurrent-call behavior

## Testing

- release/precompiled test_vinecop_class (53/53 passed)
- debug/header-only focused tests with ASan/UBSan
- clang-format 14