### PR TITLE
fix(bicop)!: correct the Kendall's tau integrals and drop odeint

### DIFF
--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -31,3 +31,6 @@ target_include_directories(bench_all PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/src)
 
 add_executable(parity_dump src/parity_dump.cpp)
 target_link_libraries(parity_dump PRIVATE vinecopulib)
+
+add_executable(quadrature_study src/quadrature_study.cpp)
+target_link_libraries(quadrature_study PRIVATE vinecopulib)

--- a/benchmarks/src/parity_dump.cpp
+++ b/benchmarks/src/parity_dump.cpp
@@ -243,6 +243,35 @@ dump_tau_sweeps()
     }
     out["tawn"] = sweep(BicopFamily::tawn, pars);
   }
+  // Near-boundary corners, kept in separate keys so the interior sweeps above
+  // stay index-stable. The integrands are worst-conditioned here, so this is
+  // where a quadrature or reformulation change shows up first.
+  auto corners = [](const std::vector<std::vector<double>>& rows) {
+    std::vector<Eigen::VectorXd> pars;
+    for (const auto& row : rows) {
+      Eigen::VectorXd p(row.size());
+      for (size_t i = 0; i < row.size(); ++i) {
+        p(static_cast<Eigen::Index>(i)) = row[i];
+      }
+      pars.push_back(p);
+    }
+    return pars;
+  };
+  out["bb6_edge"] = sweep(
+    BicopFamily::bb6,
+    corners({ { 1.0, 1.0 }, { 1.001, 8.0 }, { 6.0, 1.0 }, { 6.0, 8.0 } }));
+  out["bb7_edge"] = sweep(
+    BicopFamily::bb7,
+    corners({ { 1.0, 0.01 }, { 1.001, 25.0 }, { 6.0, 0.01 }, { 6.0, 25.0 } }));
+  out["bb8_edge"] = sweep(
+    BicopFamily::bb8,
+    corners({ { 1.0, 1e-4 }, { 1.001, 1.0 }, { 8.0, 1e-4 }, { 8.0, 1.0 } }));
+  out["tawn_edge"] = sweep(BicopFamily::tawn,
+                           corners({ { 0.001, 0.5, 60.0 },
+                                     { 0.5, 0.5, 50.0 },
+                                     { 0.5, 0.5, 60.0 },
+                                     { 0.999, 0.999, 60.0 },
+                                     { 1.0, 1.0, 60.0 } }));
   return out;
 }
 

--- a/benchmarks/src/quadrature_study.cpp
+++ b/benchmarks/src/quadrature_study.cpp
@@ -1,0 +1,544 @@
+// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+//
+// This file is part of the vinecopulib library and licensed under the terms of
+// the MIT license. For a copy, see the LICENSE file in the root directory of
+// vinecopulib or https://vinecopulib.github.io/vinecopulib/.
+
+// Accuracy and speed of candidate quadrature rules for the four
+// parameters_to_tau integrals (BB6, BB7, BB8, Tawn).
+//
+// The integrands are restated here, templated on the scalar type, so that
+// references can be computed in 50-digit arithmetic. Keep them in sync with
+// bb6.ipp, bb7.ipp, bb8.ipp and extreme_value.ipp/tawn.ipp.
+//
+//   build:  cmake --preset bench && cmake --build --preset bench --target
+//   quadrature_study run:    build/bench/bin/quadrature_study
+
+#include <vinecopulib/bicop/class.hpp>
+
+#include <boost/math/quadrature/gauss.hpp>
+#include <boost/math/quadrature/gauss_kronrod.hpp>
+#include <boost/math/quadrature/tanh_sinh.hpp>
+#include <boost/multiprecision/cpp_bin_float.hpp>
+#include <boost/numeric/odeint.hpp>
+
+#include <chrono>
+#include <cmath>
+#include <functional>
+#include <iomanip>
+#include <iostream>
+#include <limits>
+#include <sstream>
+#include <string>
+#include <vector>
+
+using Real50 = boost::multiprecision::cpp_bin_float_50;
+
+// The bounds the library integrates between: the integrands are singular at one
+// or both endpoints, so the interval is clipped.
+template<typename Real>
+Real
+lb()
+{
+  return Real(1) / 1000000000000LL; // 1e-12
+}
+
+// ---------------------------------------------------------------- integrands
+
+template<typename Real>
+struct Bb6
+{
+  Real theta, delta;
+  Real operator()(Real v) const
+  {
+    using std::log1p;
+    using std::pow;
+    Real omv = 1 - v;
+    Real res = -4 * (omv - pow(omv, -theta) + pow(omv, -theta) * v);
+    return 1 / (delta * theta) * log1p(-pow(omv, theta)) * res;
+  }
+  static constexpr const char* name = "bb6";
+  Real split() const { return Real(1) / 2; }
+};
+
+template<typename Real>
+struct Bb7
+{
+  Real theta, delta;
+  Real operator()(Real v) const
+  {
+    using std::exp;
+    using std::expm1;
+    using std::log1p;
+    Real log1mv = log1p(-v);
+    Real tmp = exp(theta * log1mv);
+    Real log1mtmp = log1p(-tmp);
+    Real res = -4 * expm1(-delta * log1mtmp) / (theta * delta);
+    return res / exp((theta - 1) * log1mv + (-delta - 1) * log1mtmp);
+  }
+  static constexpr const char* name = "bb7";
+  Real split() const { return Real(1) / 2; }
+};
+
+template<typename Real>
+struct Bb8
+{
+  Real theta, delta;
+  Real operator()(Real t) const
+  {
+    using std::exp;
+    using std::log1p;
+    Real log1mtd = log1p(-t * delta);
+    Real num = log1p(-exp(theta * log1mtd));
+    Real den = log1p(-exp(theta * log1p(-delta)));
+    return (num - den) * (1 - t * delta - exp((1 - theta) * log1mtd));
+  }
+  static constexpr const char* name = "bb8";
+  Real split() const { return Real(1) / 2; }
+};
+
+// t (1 - t) A''(t) / A(t) with Tawn's Pickands dependence function.
+template<typename Real>
+struct Tawn
+{
+  Real psi1, psi2, theta;
+  Real operator()(Real t) const
+  {
+    using std::exp;
+    using std::log;
+    using std::log1p;
+    using std::max;
+    using std::min;
+    using std::pow;
+    Real A = (1 - psi1) * (1 - t) + (1 - psi2) * t +
+             pow(pow(psi2 * t, theta) + pow(psi1 * (1 - t), theta), 1 / theta);
+    // A'' = (theta - 1) (x + y)^(1/theta - 2) x y / (t (1-t))^2 with
+    // x = (psi2 t)^theta, y = (psi1 (1-t))^theta; see tawn.ipp.
+    Real lx = theta * log(psi2 * t), ly = theta * log(psi1 * (1 - t));
+    Real hi = max(lx, ly);
+    Real ls = hi + log1p(exp(min(lx, ly) - hi));
+    Real App = exp(log(theta - 1) + (1 / theta - 2) * ls + lx + ly -
+                   2 * log(t) - 2 * log1p(-t));
+    return t * (1 - t) * App / A;
+  }
+  static constexpr const char* name = "tawn";
+  // A'' peaks where (psi2 t)^theta and (psi1 (1-t))^theta balance.
+  Real split() const { return psi1 / (psi1 + psi2); }
+};
+
+// ---------------------------------------------------------------------- arms
+
+// odeint over [a, b], so the split variant can reuse it.
+template<typename F>
+double
+arm_odeint_on(const F& f, double a, double b)
+{
+  boost::numeric::odeint::runge_kutta_dopri5<double> stepper;
+  double x = 0.0;
+  auto ifunc = [&f](const double, double& dxdt, const double t) {
+    dxdt = f(t);
+  };
+  integrate_adaptive(
+    boost::numeric::odeint::make_controlled(1e-9, 1e-9, stepper),
+    ifunc,
+    x,
+    a,
+    b,
+    1e-12);
+  return x;
+}
+
+template<typename F>
+double
+arm_odeint_split(const F& f)
+{
+  const double s = static_cast<double>(f.split());
+  return arm_odeint_on(f, 1e-12, s) + arm_odeint_on(f, s, 1.0 - 1e-12);
+}
+
+template<typename F>
+double
+arm_tanh_sinh_split(const F& f)
+{
+  const double s = static_cast<double>(f.split());
+  boost::math::quadrature::tanh_sinh<double> integrator;
+  return integrator.integrate(f, 1e-12, s) +
+         integrator.integrate(f, s, 1.0 - 1e-12);
+}
+
+// The rule currently in tools_integration.hpp.
+template<typename F>
+double
+arm_odeint(const F& f)
+{
+  boost::numeric::odeint::runge_kutta_dopri5<double> stepper;
+  const double a = 1e-12, b = 1.0 - 1e-12, tol = 1e-9;
+  double x = 0.0;
+  auto ifunc = [&f](const double, double& dxdt, const double t) {
+    dxdt = f(t);
+  };
+  integrate_adaptive(boost::numeric::odeint::make_controlled(tol, tol, stepper),
+                     ifunc,
+                     x,
+                     a,
+                     b,
+                     a);
+  return x;
+}
+
+// Tolerance 1e-10, not 1e-12: two of the four integrands cannot reach 1e-12 in
+// double, and asking for it makes the adaptive rule subdivide to max_depth.
+template<unsigned N, typename F>
+double
+arm_gauss_kronrod(const F& f)
+{
+  using boost::math::quadrature::gauss_kronrod;
+  double err = 0;
+  return gauss_kronrod<double, N>::integrate(
+    f, 1e-12, 1.0 - 1e-12, 12, 1e-10, &err);
+}
+
+template<typename F>
+double
+arm_tanh_sinh(const F& f)
+{
+  boost::math::quadrature::tanh_sinh<double> integrator;
+  return integrator.integrate(f, 1e-12, 1.0 - 1e-12);
+}
+
+// The 2019 attempt (archive/add-quadrature): a fixed-order Gauss-Legendre rule.
+template<typename F>
+double
+arm_gauss_legendre20(const F& f)
+{
+  return boost::math::quadrature::gauss<double, 20>::integrate(
+    f, 1e-12, 1.0 - 1e-12);
+}
+
+// Reference: adaptive Gauss-Kronrod at 50 digits, deep enough that the endpoint
+// singularities are resolved far below double precision. Cross-checked against
+// a 50-digit tanh_sinh wherever that converges -- two independent
+// high-precision methods agreeing is the evidence; either alone is not.
+std::string
+fmt_sci(double x)
+{
+  std::ostringstream os;
+  os << std::scientific << std::setprecision(2) << x;
+  return os.str();
+}
+
+template<typename F>
+Real50
+reference(const F& f, double* cross_check_rel)
+{
+  using boost::math::quadrature::gauss_kronrod;
+  const Real50 a = lb<Real50>(), b = Real50(1) - a;
+  // Split at the peak here as well: an unsplit reference misses a narrow
+  // interior peak just as badly as the arms being judged do.
+  const Real50 s = f.split();
+  const bool do_split = s > a && s < b;
+  Real50 err = 0;
+  auto gk = [&](const Real50& x, const Real50& y) {
+    return gauss_kronrod<Real50, 61>::integrate(
+      f, x, y, 25, Real50(1e-30), &err);
+  };
+  const Real50 value = do_split ? gk(a, s) + gk(s, b) : gk(a, b);
+
+  // Cross-check the 50-digit GK61 value against 50-digit tanh-sinh, and report
+  // how far apart they are: the reference is only as good as that agreement.
+  *cross_check_rel = std::numeric_limits<double>::quiet_NaN();
+  try {
+    boost::math::quadrature::tanh_sinh<Real50> ts(25);
+    const Real50 other = do_split
+                           ? ts.integrate(f, a, s) + ts.integrate(f, s, b)
+                           : ts.integrate(f, a, b);
+    const Real50 scale = abs(value) > Real50(1e-300) ? abs(value) : Real50(1);
+    *cross_check_rel = static_cast<double>(abs(other - value) / scale);
+  } catch (const std::exception&) {
+    // tanh_sinh declines on some endpoint singularities; the GK value stands.
+  }
+  return value;
+}
+
+// ----------------------------------------------------------------- validation
+
+// The restated integrand must reproduce the library. `transform` applies the
+// family's outer expression, e.g. 1 + I for BB6/BB7. Without this the study
+// would happily measure a mis-transcribed integrand.
+template<typename F, typename Transform>
+bool
+matches_library(vinecopulib::BicopFamily family,
+                const Eigen::VectorXd& par,
+                const F& f,
+                const Transform& transform,
+                bool split = false)
+{
+  vinecopulib::Bicop bicop(family, 0, par);
+  const double library = bicop.get_tau();
+  // Use the rule the library uses, so a mismatch means the restated integrand
+  // disagrees with the shipped one rather than the two rules disagreeing.
+  const double restated =
+    transform(split ? arm_tanh_sinh_split(f) : arm_tanh_sinh(f));
+  const double scale = std::max(1.0, std::abs(library));
+  const bool ok = std::abs(library - restated) / scale < 1e-6;
+  if (!ok) {
+    std::cout << "  MISMATCH vs library: parameters_to_tau=" << library
+              << " restated=" << restated << " (par " << par.transpose()
+              << ")\n";
+  }
+  return ok;
+}
+
+// --------------------------------------------------------------------- driver
+
+struct Stats
+{
+  double max_rel = 0.0;
+  double total_ns = 0.0;
+  size_t n = 0;
+  std::string worst_case;
+};
+
+template<typename MakeDouble, typename MakeRef>
+void
+evaluate(const std::string& family,
+         const std::vector<std::string>& labels,
+         const MakeDouble& make_double,
+         const MakeRef& make_ref,
+         std::vector<Stats>& stats,
+         const std::vector<std::string>& arm_names)
+{
+  const size_t n_cases = labels.size();
+  for (size_t c = 0; c < n_cases; ++c) {
+    std::cout << "  [" << family << " " << (c + 1) << "/" << n_cases << "] "
+              << labels[c] << std::flush;
+    double cross_check_rel = 0.0;
+    const Real50 ref = reference(make_ref(c), &cross_check_rel);
+    std::cout << (std::isnan(cross_check_rel)
+                    ? std::string("  (ref cross-check unavailable)\n")
+                    : "  (ref cross-check " + fmt_sci(cross_check_rel) + ")\n")
+              << std::flush;
+    auto fd = make_double(c);
+
+    std::vector<std::function<double()>> arms = {
+      [&] { return arm_odeint(fd); },
+      [&] { return arm_odeint_split(fd); },
+      [&] { return arm_tanh_sinh(fd); },
+      [&] { return arm_tanh_sinh_split(fd); },
+      [&] { return arm_gauss_kronrod<15>(fd); },
+      [&] { return arm_gauss_legendre20(fd); },
+    };
+
+    for (size_t a = 0; a < arms.size(); ++a) {
+      // one untimed call so any lazily built tables are warm
+      double value = 0.0;
+      try {
+        value = arms[a]();
+      } catch (const std::exception&) {
+        stats[a].max_rel = std::numeric_limits<double>::infinity();
+        stats[a].worst_case = labels[c] + " (threw)";
+        continue;
+      }
+      const int reps = 10;
+      auto t0 = std::chrono::steady_clock::now();
+      for (int r = 0; r < reps; ++r)
+        value = arms[a]();
+      auto t1 = std::chrono::steady_clock::now();
+
+      const Real50 denom = abs(ref) > Real50(1e-300) ? abs(ref) : Real50(1);
+      const double rel = static_cast<double>(abs(Real50(value) - ref) / denom);
+      if (rel > stats[a].max_rel) {
+        stats[a].max_rel = rel;
+        stats[a].worst_case = labels[c];
+      }
+      stats[a].total_ns +=
+        std::chrono::duration<double, std::nano>(t1 - t0).count() / reps;
+      stats[a].n += 1;
+    }
+  }
+
+  std::cout << "\n=== " << family << " (" << n_cases
+            << " parameter sets) ===\n";
+  std::cout << std::left << std::setw(16) << "arm" << std::right
+            << std::setw(14) << "max rel err" << std::setw(12) << "ns/call"
+            << "   worst case\n";
+  for (size_t a = 0; a < arm_names.size(); ++a) {
+    std::cout << std::left << std::setw(16) << arm_names[a] << std::right
+              << std::setw(14) << std::scientific << std::setprecision(3)
+              << stats[a].max_rel << std::setw(12) << std::fixed
+              << std::setprecision(0)
+              << (stats[a].n ? stats[a].total_ns / stats[a].n : 0.0) << "   "
+              << stats[a].worst_case << "\n";
+  }
+}
+
+int
+main()
+{
+  const std::vector<std::string> arm_names = { "odeint",    "odeint split",
+                                               "tanh_sinh", "tanh_sinh split",
+                                               "GK15",      "GL20 (2019)" };
+
+  // Parameter grids inside each family's admissible region, including the
+  // boundary corners where the integrands are most singular.
+  // bb6: theta in [1, 6], delta in [1, 8]
+  const std::vector<std::pair<double, double>> bb6 = {
+    { 1.0, 1.0 }, { 1.0001, 1.0001 }, { 1.5, 1.5 }, { 3.0, 4.0 },
+    { 6.0, 8.0 }, { 1.0, 8.0 },       { 6.0, 1.0 }
+  };
+  // bb7: theta in [1, 6], delta in [0.01, 25]
+  const std::vector<std::pair<double, double>> bb7 = {
+    { 1.0, 0.01 }, { 1.0001, 0.01 }, { 1.5, 1.0 }, { 3.0, 5.0 },
+    { 6.0, 25.0 }, { 1.0, 25.0 },    { 6.0, 0.01 }
+  };
+  // bb8: theta in [1, 8], delta in [1e-4, 1]
+  const std::vector<std::pair<double, double>> bb8 = {
+    { 1.0, 1e-4 }, { 1.0001, 0.9999 }, { 3.0, 0.8 }, { 8.0, 1.0 },
+    { 8.0, 1e-4 }, { 1.0, 1.0 },       { 4.0, 0.5 }
+  };
+  // tawn: psi1, psi2 in (0, 1], theta in [1, 60]
+  const std::vector<std::array<double, 3>> tawn = {
+    { 0.8, 0.5, 2.0 },
+    { 0.5, 0.5, 1.0001 },
+    { 0.999, 0.999, 60.0 },
+    { 0.01, 0.99, 5.0 },
+    { 1.0, 1.0, 10.0 },
+    { 0.3, 0.7, 30.0 },
+    { 0.999, 0.001, 1.5 },
+    { 0.5, 0.5, 60.0 },
+    // strongly asymmetric psi: A'' peaks at psi1 / (psi1 + psi2), decades away
+    // from 1/2, and narrows as theta grows
+    { 1e-4, 0.5, 60.0 },
+    { 1e-3, 0.5, 10.0 },
+    { 0.01, 0.5, 60.0 },
+    { 1e-6, 0.5, 60.0 }
+  };
+
+  auto label2 = [](const char* a, const char* b, double x, double y) {
+    std::ostringstream os;
+    os << a << "=" << x << ", " << b << "=" << y;
+    return os.str();
+  };
+
+  std::cout << "Validating the restated integrands against Bicop::get_tau()\n";
+  size_t mismatches = 0;
+  {
+    for (auto& p : bb6) {
+      Eigen::VectorXd par(2);
+      par << p.first, p.second;
+      mismatches += !matches_library(vinecopulib::BicopFamily::bb6,
+                                     par,
+                                     Bb6<double>{ p.first, p.second },
+                                     [](double i) { return 1 + i; });
+    }
+    for (auto& p : bb7) {
+      Eigen::VectorXd par(2);
+      par << p.first, p.second;
+      mismatches += !matches_library(vinecopulib::BicopFamily::bb7,
+                                     par,
+                                     Bb7<double>{ p.first, p.second },
+                                     [](double i) { return 1 + i; });
+    }
+    for (auto& p : bb8) {
+      Eigen::VectorXd par(2);
+      par << p.first, p.second;
+      const double th = p.first, de = p.second;
+      mismatches +=
+        !matches_library(vinecopulib::BicopFamily::bb8,
+                         par,
+                         Bb8<double>{ th, de },
+                         [th, de](double i) { return 1 - 4 / (de * th) * i; });
+    }
+    for (auto& p : tawn) {
+      Eigen::VectorXd par(3);
+      par << p[0], p[1], p[2];
+      mismatches += !matches_library(
+        vinecopulib::BicopFamily::tawn,
+        par,
+        Tawn<double>{ p[0], p[1], p[2] },
+        [](double i) { return i; },
+        /* split = */ true);
+    }
+    std::cout << (mismatches ? "  -> " : "  -> no mismatches; ")
+              << (mismatches
+                    ? std::to_string(mismatches) +
+                        " MISMATCH(ES); results below are not trustworthy\n"
+                    : std::string("integrands agree with the library\n"));
+  }
+
+  {
+    std::vector<std::string> labels;
+    for (auto& p : bb6)
+      labels.push_back(label2("theta", "delta", p.first, p.second));
+    std::vector<Stats> stats(arm_names.size());
+    evaluate(
+      "BB6",
+      labels,
+      [&](size_t c) {
+        return Bb6<double>{ bb6[c].first, bb6[c].second };
+      },
+      [&](size_t c) {
+        return Bb6<Real50>{ Real50(bb6[c].first), Real50(bb6[c].second) };
+      },
+      stats,
+      arm_names);
+  }
+  {
+    std::vector<std::string> labels;
+    for (auto& p : bb7)
+      labels.push_back(label2("theta", "delta", p.first, p.second));
+    std::vector<Stats> stats(arm_names.size());
+    evaluate(
+      "BB7",
+      labels,
+      [&](size_t c) {
+        return Bb7<double>{ bb7[c].first, bb7[c].second };
+      },
+      [&](size_t c) {
+        return Bb7<Real50>{ Real50(bb7[c].first), Real50(bb7[c].second) };
+      },
+      stats,
+      arm_names);
+  }
+  {
+    std::vector<std::string> labels;
+    for (auto& p : bb8)
+      labels.push_back(label2("theta", "delta", p.first, p.second));
+    std::vector<Stats> stats(arm_names.size());
+    evaluate(
+      "BB8",
+      labels,
+      [&](size_t c) {
+        return Bb8<double>{ bb8[c].first, bb8[c].second };
+      },
+      [&](size_t c) {
+        return Bb8<Real50>{ Real50(bb8[c].first), Real50(bb8[c].second) };
+      },
+      stats,
+      arm_names);
+  }
+  {
+    std::vector<std::string> labels;
+    for (auto& p : tawn) {
+      std::ostringstream os;
+      os << "psi1=" << p[0] << ", psi2=" << p[1] << ", theta=" << p[2];
+      labels.push_back(os.str());
+    }
+    std::vector<Stats> stats(arm_names.size());
+    evaluate(
+      "Tawn",
+      labels,
+      [&](size_t c) {
+        return Tawn<double>{ tawn[c][0], tawn[c][1], tawn[c][2] };
+      },
+      [&](size_t c) {
+        return Tawn<Real50>{ Real50(tawn[c][0]),
+                             Real50(tawn[c][1]),
+                             Real50(tawn[c][2]) };
+      },
+      stats,
+      arm_names);
+  }
+
+  return 0;
+}

--- a/cmake/buildTargets.cmake
+++ b/cmake/buildTargets.cmake
@@ -6,10 +6,6 @@ if (VINECOPULIB_PRECOMPILED)
     set_property(TARGET vinecopulib PROPERTY POSITION_INDEPENDENT_CODE ON)
     target_link_libraries(vinecopulib PUBLIC Eigen3::Eigen wdm Boost::headers Threads::Threads)
     target_compile_features(vinecopulib PUBLIC cxx_std_17)
-    # non windows
-    if (NOT WIN32)
-        target_compile_options(vinecopulib PRIVATE -Wno-uninitialized) # Boost triggers this warning in strict mode
-    endif()
 else()
     add_library(vinecopulib INTERFACE)
     target_link_libraries(vinecopulib INTERFACE Eigen3::Eigen wdm Boost::headers Threads::Threads)
@@ -103,7 +99,7 @@ if (VINECOPULIB_PRECOMPILED)
             EXPORT "${targets_export_name}"
             LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
             ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
-            RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}" # on Windows, the dll file is categorised as RUNTIME
+            RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}" # on Windows, the dll file is categorized as RUNTIME
     )
 else()
     install(TARGETS vinecopulib EXPORT "${targets_export_name}")

--- a/include/vinecopulib/bicop/extreme_value.hpp
+++ b/include/vinecopulib/bicop/extreme_value.hpp
@@ -54,6 +54,11 @@ private:
     const double& t,
     const Eigen::Ref<const Eigen::VectorXd>& parameters) = 0;
 
+  // where A'' peaks; `parameters_to_tau` splits its integral there, because the
+  // peak can be far narrower than any subdivision reachable from [0, 1]
+  virtual double pickands_peak(
+    const Eigen::Ref<const Eigen::VectorXd>& parameters);
+
   // link between Kendall's tau and the par_bicop parameter
   double parameters_to_tau(const Eigen::MatrixXd& par) override;
 

--- a/include/vinecopulib/bicop/implementation/bb7.ipp
+++ b/include/vinecopulib/bicop/implementation/bb7.ipp
@@ -6,6 +6,7 @@
 
 #include <vinecopulib/misc/tools_eigen.hpp>
 #include <vinecopulib/misc/tools_integration.hpp>
+#include <vinecopulib/misc/tools_stl.hpp>
 
 namespace vinecopulib {
 inline Bb7Bicop::Bb7Bicop()
@@ -2800,9 +2801,13 @@ Bb7Bicop::parameters_to_tau(const Eigen::MatrixXd& parameters)
   double theta = parameters(0);
   double delta = parameters(1);
   auto f = [&theta, &delta](const double& v) {
-    double tmp = std::pow(1 - v, theta);
-    double res = -4 * (std::pow(1 - tmp, -delta) - 1) / (theta * delta);
-    return res / (std::pow(1 - v, theta - 1) * std::pow(1 - tmp, -delta - 1));
+    // expm1/log1p rather than pow(., -delta) - 1, which loses every digit as
+    // v -> 1 and underflows to exactly zero.
+    const double log1mv = tools_stl::log1p(-v);
+    const double tmp = std::exp(theta * log1mv);
+    const double log1mtmp = tools_stl::log1p(-tmp);
+    const double res = -4 * std::expm1(-delta * log1mtmp) / (theta * delta);
+    return res / std::exp((theta - 1) * log1mv + (-delta - 1) * log1mtmp);
   };
   return 1 + tools_integration::integrate_zero_to_one(f);
 }

--- a/include/vinecopulib/bicop/implementation/bb8.ipp
+++ b/include/vinecopulib/bicop/implementation/bb8.ipp
@@ -6,6 +6,7 @@
 
 #include <vinecopulib/misc/tools_eigen.hpp>
 #include <vinecopulib/misc/tools_integration.hpp>
+#include <vinecopulib/misc/tools_stl.hpp>
 
 namespace vinecopulib {
 inline Bb8Bicop::Bb8Bicop()
@@ -3589,9 +3590,13 @@ Bb8Bicop::parameters_to_tau(const Eigen::MatrixXd& parameters)
   double theta = parameters(0);
   double delta = parameters(1);
   auto f = [theta, delta](const double t) {
-    double tmp = std::pow(1 - t * delta, theta);
-    double res = std::log((tmp - 1) / (std::pow(1 - delta, theta) - 1));
-    return res * (1 - t * delta - std::pow(1 - t * delta, 1 - theta));
+    // log1p(-exp(.)) differences rather than log of a ratio: the ratio rounds
+    // to exactly 1 as t -> 1/delta, and the logarithm then returns 0.
+    const double log1mtd = tools_stl::log1p(-t * delta);
+    const double num = tools_stl::log1p(-std::exp(theta * log1mtd));
+    const double den =
+      tools_stl::log1p(-std::exp(theta * tools_stl::log1p(-delta)));
+    return (num - den) * (1 - t * delta - std::exp((1 - theta) * log1mtd));
   };
   return 1 - 4 / (delta * theta) * tools_integration::integrate_zero_to_one(f);
 }

--- a/include/vinecopulib/bicop/implementation/extreme_value.ipp
+++ b/include/vinecopulib/bicop/implementation/extreme_value.ipp
@@ -95,6 +95,13 @@ ExtremeValueBicop::hinv2_raw(const Eigen::MatrixXd& u,
 }
 
 inline double
+ExtremeValueBicop::pickands_peak(
+  const Eigen::Ref<const Eigen::VectorXd>& /* parameters */)
+{
+  return 0.5;
+}
+
+inline double
 ExtremeValueBicop::parameters_to_tau(const Eigen::MatrixXd& par)
 {
   auto f = [this, &par](const double t) {
@@ -102,7 +109,11 @@ ExtremeValueBicop::parameters_to_tau(const Eigen::MatrixXd& par)
     double A2 = pickands_derivative2(t, par.col(0));
     return t * (1 - t) * A2 / A;
   };
-  return tools_integration::integrate_zero_to_one(f);
+  // A'' concentrates in a narrow peak, ~2% of the interval wide at Tawn's
+  // theta = 60 and narrower still as the parameters grow asymmetric, so the
+  // integral is split at the peak.
+  return tools_integration::integrate_zero_to_one_split(
+    f, pickands_peak(par.col(0)));
 }
 
 inline Eigen::MatrixXd

--- a/include/vinecopulib/bicop/implementation/tawn.ipp
+++ b/include/vinecopulib/bicop/implementation/tawn.ipp
@@ -6,6 +6,7 @@
 
 #include <vinecopulib/misc/tools_eigen.hpp>
 #include <vinecopulib/misc/tools_integration.hpp>
+#include <vinecopulib/misc/tools_stl.hpp>
 
 namespace vinecopulib {
 inline TawnBicop::TawnBicop()
@@ -55,13 +56,36 @@ TawnBicop::pickands_derivative2(
   double psi2 = parameters(1);
   double theta = parameters(2);
 
-  double temp = std::pow(psi2 * t, theta) + std::pow(psi1 * (1 - t), theta);
-  double temp2 = psi2 * std::pow(psi2 * t, theta - 1) -
-                 psi1 * std::pow(psi1 * (1 - t), theta - 1);
-  double temp3 = std::pow(psi2, 2) * std::pow(psi2 * t, theta - 2) +
-                 std::pow(psi1, 2) * std::pow(psi1 * (1 - t), theta - 2);
-  return (1 - theta) * std::pow(temp, 1 / theta - 2) * std::pow(temp2, 2) +
-         std::pow(temp, 1 / theta - 1) * (theta - 1) * temp3;
+  // With x = (psi2 t)^theta and y = (psi1 (1-t))^theta,
+  //
+  //   A''(t) = (theta - 1) * (x + y)^(1/theta - 2) * x * y / (t (1-t))^2,
+  //
+  // because x * y is the exact simplification of (x + y) * temp3 - temp2^2 for
+  // this Pickands function. That form is manifestly non-negative (A is convex)
+  // and free of the cancellation the two-term version suffers. Evaluate it in
+  // logs: for small psi the powers reach 1e-180, where (x + y)^(1/theta - 2)
+  // overflows on its own.
+  const double log_x = theta * std::log(psi2 * t);
+  const double log_y = theta * std::log(psi1 * (1 - t));
+  if (!std::isfinite(log_x) || !std::isfinite(log_y)) {
+    return 0.0; // psi1 or psi2 is 0, or t is 0 or 1: A is linear there
+  }
+  const double hi = std::max(log_x, log_y);
+  const double log_sum =
+    hi + tools_stl::log1p(std::exp(std::min(log_x, log_y) - hi));
+  return std::exp(std::log(theta - 1) + (1 / theta - 2) * log_sum + log_x +
+                  log_y - 2 * std::log(t) - 2 * tools_stl::log1p(-t));
+}
+
+inline double
+TawnBicop::pickands_peak(const Eigen::Ref<const Eigen::VectorXd>& parameters)
+{
+  // A'' peaks where the two powers in A balance, (psi2 t)^theta =
+  // (psi1 (1-t))^theta. For psi1 << psi2 that is a long way from 1/2.
+  const double psi1 = parameters(0);
+  const double psi2 = parameters(1);
+  const double sum = psi1 + psi2;
+  return (sum > 0.0) ? psi1 / sum : 0.5;
 }
 
 // [BEGIN generated derivative leaves]

--- a/include/vinecopulib/bicop/tawn.hpp
+++ b/include/vinecopulib/bicop/tawn.hpp
@@ -35,6 +35,10 @@ private:
   double pickands_derivative2(
     const double& t,
     const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
+
+  double pickands_peak(
+    const Eigen::Ref<const Eigen::VectorXd>& parameters) override;
+
   // analytic derivatives (per-selector closed forms; see tawn.ipp)
   Eigen::VectorXd pdf_deriv_raw(const Eigen::MatrixXd& u,
                                 const Eigen::MatrixXd& parameters,

--- a/include/vinecopulib/misc/tools_integration.hpp
+++ b/include/vinecopulib/misc/tools_integration.hpp
@@ -6,63 +6,48 @@
 
 #pragma once
 
-// Suppress compiler warnings caused by boost/odeint internals
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wmaybe-uninitialized"
-#endif
-
-// replace std::sprintf by void function
-// - this is necessary because `sprintf()` is now flagged as potential security
-//   risk and deprecated in macOS 13.
-// - in our case, `boost/odeint` makes (safe) use of the function, but we don't
-//   really need it.
-// - we can remove this hack if and when updates odeint (PR open).
-#define sprintf _sprintf_do_nothing
-namespace std {
-constexpr int
-_sprintf_do_nothing(char*, const char*, ...)
-{
-  return 0;
-}
-}
-#include <boost/numeric/odeint.hpp>
-#undef sprintf
-
-#if defined(__GNUC__) && !defined(__clang__)
-#pragma GCC diagnostic pop
-#endif
-
-#include <functional>
+#include <boost/math/quadrature/tanh_sinh.hpp>
+#include <utility>
 
 namespace vinecopulib {
 
 namespace tools_integration {
 
+//! @brief Integrates `f` over the unit interval.
+//!
+//! Suited to integrands that are singular or steep at `0` and `1`, as the
+//! Kendall's tau integrals of the BB families are: tanh-sinh clusters its
+//! abscissas at the endpoints. Use `integrate_zero_to_one_split()` when the
+//! integrand instead peaks in the interior.
 template<typename F>
 inline double
 integrate_zero_to_one(F&& f)
 {
-  boost::numeric::odeint::runge_kutta_dopri5<double> stepper;
-  // the integral bounds stay clear of 0/1 (integrands may be singular
-  // there); 1e-9 tolerance is plenty for the Kendall's tau computations
-  // this backs, and far cheaper than the previous 1e-12
+  // The bounds stay clear of 0 and 1: the integrands are singular there.
+  const double lb = 1e-12;
+  boost::math::quadrature::tanh_sinh<double> integrator;
+  return integrator.integrate(f, lb, 1.0 - lb);
+}
+
+//! @brief Integrates `f` over the unit interval, splitting it at `split`.
+//!
+//! A narrow interior peak is invisible to a rule whose abscissas cluster at the
+//! endpoints. Splitting there makes the peak an endpoint of both subintervals,
+//! which is exactly where tanh-sinh puts its resolution. Needed for Tawn's tau
+//! integral, whose peak is both narrow and far from `1/2` when the parameters
+//! are asymmetric.
+template<typename F>
+inline double
+integrate_zero_to_one_split(F&& f, const double split)
+{
   const double lb = 1e-12;
   const double ub = 1.0 - lb;
-  const double tol = 1e-9;
-  double x = 0.0;
-  // capture by reference: no std::function allocation, and the functor can
-  // be inlined into the stepper
-  auto ifunc = [&f](const double /* x */, double& dxdt, const double t) {
-    dxdt = f(t);
-  };
-  integrate_adaptive(boost::numeric::odeint::make_controlled(tol, tol, stepper),
-                     ifunc,
-                     x,
-                     lb,
-                     ub,
-                     lb);
-  return x;
+  if (!(split > lb) || !(split < ub)) {
+    return integrate_zero_to_one(std::forward<F>(f));
+  }
+  boost::math::quadrature::tanh_sinh<double> integrator;
+  return integrator.integrate(f, lb, split) +
+         integrator.integrate(f, split, ub);
 }
 }
 }

--- a/scripts/parity_gates.json
+++ b/scripts/parity_gates.json
@@ -19,7 +19,7 @@
   "bicop_eval/BB8/rot0/hinv2": 1e-09,
   "bicop_eval/Tawn/rot0/hinv1": 1e-09,
   "bicop_eval/Tawn/rot0/hinv2": 1e-09,
-  "_comment_tau": "integration tolerance relaxed 1e-12 -> 1e-9 (plan gate: 1e-7)",
+  "_comment_tau": "tau integrands reformulated and integrated with tanh-sinh (split at the peak for extreme-value families); interior lattice points move <=5e-9, the near-boundary *_edge sweeps by far more because they were wrong before -- see test_bicop_sanity_checks for 50-digit references",
   "tau/": 1e-07,
   "bicop_eval/BB6/rot0/tau": 1e-07,
   "bicop_eval/BB7/rot0/tau": 1e-07,

--- a/test/src_test/include/test_bicop_sanity_checks.hpp
+++ b/test/src_test/include/test_bicop_sanity_checks.hpp
@@ -171,4 +171,63 @@ TEST(bicop_sanity_checks, copy)
   EXPECT_EQ(bc2.get_loglik(), bc3.get_loglik());
   EXPECT_EQ(bc2.get_nobs(), bc3.get_nobs());
 }
+
+// Kendall's tau of the families whose tau is a numerical integral. The
+// expectations are 50-digit references (Gauss-Kronrod on the same integrand),
+// and each parameter set is one where the previous implementation lost
+// precision or failed outright.
+TEST(bicop_sanity_checks, tau_of_integral_families_is_accurate)
+{
+  struct Case
+  {
+    BicopFamily family;
+    std::vector<double> parameters;
+    double tau;
+  };
+
+  // References computed at 50 digits. The corners matter: each of these was
+  // wrong by between 5e-4 and 100% before the tau integrands were reformulated.
+  const std::vector<Case> cases = {
+    // large theta: A'' is a narrow peak
+    { BicopFamily::tawn, { 0.5, 0.5, 50.0 }, 0.33100293306647305 },
+    { BicopFamily::tawn, { 0.5, 0.5, 60.0 }, 0.33140637575860532 },
+    { BicopFamily::tawn, { 0.9, 0.9, 60.0 }, 0.80695186456976831 },
+    { BicopFamily::tawn, { 0.999, 0.999, 60.0 }, 0.98140077647182433 },
+    { BicopFamily::tawn, { 0.5, 0.5, 2.0 }, 0.21460183660255169 },
+    // small psi1: the peak moves to psi1 / (psi1 + psi2), far from 1/2
+    { BicopFamily::tawn, { 1e-4, 0.5, 60.0 }, 9.9989819367449941e-05 },
+    { BicopFamily::tawn, { 1e-3, 0.5, 10.0 }, 0.00099884000269966056 },
+    { BicopFamily::tawn, { 0.01, 0.5, 60.0 }, 0.0098992116497294558 },
+    // BB7/BB8 near the upper limits, where the integrand used to cancel to
+    // exactly zero
+    { BicopFamily::bb7, { 6.0, 0.01 }, 0.72294689117590216 },
+    { BicopFamily::bb7, { 1.5, 1.0 }, 0.42857142857142860 },
+    { BicopFamily::bb8, { 8.0, 1.0 }, 0.78325404384180519 },
+    { BicopFamily::bb8, { 3.0, 0.8 }, 0.34731888449523796 },
+  };
+
+  for (const auto& c : cases) {
+    Eigen::VectorXd par(c.parameters.size());
+    for (size_t i = 0; i < c.parameters.size(); ++i)
+      par(i) = c.parameters[i];
+    Bicop bicop(c.family, 0, par);
+    EXPECT_NEAR(bicop.get_tau(), c.tau, 1e-9)
+      << "family " << bicop.get_family_name() << ", parameters "
+      << par.transpose();
+  }
+}
+
+// tau is monotone in Tawn's theta, which the pre-fix implementation violated by
+// collapsing to zero above theta = 50.
+TEST(bicop_sanity_checks, tawn_tau_is_monotone_in_theta)
+{
+  double previous = -1.0;
+  for (double theta : { 1.5, 5.0, 10.0, 20.0, 30.0, 40.0, 50.0, 60.0 }) {
+    Eigen::VectorXd par(3);
+    par << 0.9, 0.9, theta;
+    const double tau = Bicop(BicopFamily::tawn, 0, par).get_tau();
+    EXPECT_GT(tau, previous) << "theta = " << theta;
+    previous = tau;
+  }
+}
 }


### PR DESCRIPTION
`parameters_to_tau` was inaccurate, and in places badly wrong, for the four
families that compute Kendall's τ by quadrature (BB6, BB7, BB8, Tawn).

The intent here was to replace odeint with a Boost.Math rule. Measuring first
showed the rule was never the problem: a study over each family's admissible
region against 50-digit references found **four independent numerical defects**.

## What was wrong

| # | Defect | Symptom |
|---|---|---|
| 1 | Tawn's `A''` computes `(x+y)^(1/θ−2) · temp2²` as `inf · 0` for small ψ, and cancels catastrophically elsewhere | `NaN`; **negative `A''`** — impossible for a convex Pickands function — in **13% of the sampled interior**; τ ≈ 1e-11 against a true 0.33 at θ = 60 |
| 2 | Tawn's integrand peaks at `ψ₁/(ψ₁+ψ₂)`, not at ½, and narrows as θ grows | τ(ψ₁=1e-4, θ=60) **18% low**; τ(ψ₁=1e-6) off by **15 orders**. The old odeint code did not return at all at that corner |
| 3 | BB7's integrand: `(1−tmp)^−δ − 1` cancels and underflows to exactly 0 as v → 1 | τ error up to 2.4e-05 |
| 4 | BB8's integrand: `(1−tδ)^θ − 1` cancels the same way | τ error up to 9.4e-05 |

## Fixes

1. Use the exact simplification `(x+y)·temp3 − temp2² = x·y / (t(1−t))²` and
   evaluate in logs. Cancellation-free and manifestly non-negative. Where the
   old formula is well-conditioned the two agree to 2e-13; the residual
   disagreement is pinned at ~1e-12 absolute regardless of scale, which is
   exactly the old two-term difference's cancellation noise.
2. Split the integral at the peak, via a new `pickands_peak()` hook (½ by
   default, `ψ₁/(ψ₁+ψ₂)` for Tawn). The peak then lands on a subinterval
   endpoint, which is where tanh-sinh concentrates its abscissas.
3. `expm1(-δ·log1p(-tmp))`.
4. Differences of `log1p(-exp(...))` — deliberately *not* a ratio, which merely
   relocates the cancellation (`a/b` rounds to exactly 1.0, so `log` gives 0).

## Rule choice, after conditioning the integrands

tanh-sinh then beats odeint on **both** accuracy and speed at every corner, so
`tools_integration` drops odeint entirely (max relative error / ns per call):

| family | odeint (before) | odeint (fixed integrands) | **tanh-sinh (shipped)** | GK15 | GL20 |
|---|---|---|---|---|---|
| BB6 | 2.9e-08 / 18µs | 2.9e-08 / 18µs | **3.3e-16 / 5.7µs** | 1.3e-12 / 29µs | 2.0e-05 / 1.4µs |
| BB7 | 2.4e-05 / 27µs | 5.0e-09 / 19µs | **3.5e-16 / 7.5µs** | 1.1e-12 / 16µs | 2.0e-05 / 1.3µs |
| BB8 | 9.4e-05 / 20µs | 6.5e-06 / 17µs | **2.8e-13 / 6.1µs** | 1.6e-12 / 51µs | 2.6e-05 / 1.5µs |
| Tawn | 1.000 / 56µs | 2.4e-03 / 67µs (split) | **1.0e-06 / 45µs** (split) | 1.000 / 96µs | 1.000 / 2.6µs |

GL20 is fast but two orders short everywhere, and like every unsplit arm it is
100% wrong on Tawn. Removing odeint also removes the `#define sprintf` hack it
required, its `-Wmaybe-uninitialized` pragma, and the target's
`-Wno-uninitialized`.

## Verification

- **648 tests pass** header-only and `VINECOPULIB_PRECOMPILED=ON`, including
  the R parity comparisons against VineCopula's `BiCopPar2Tau`.
- **Strict build clean** (`VINECOPULIB_STRICT_COMPILER=ON`, zero warnings).
- **Parity**: all gates pass unchanged — 195 of 205 keys bit-identical, the 8 τ
  keys move ≤4.8e-9 against a 1e-7 gate, Tawn's pdf moves one ulp. **No gate
  needed re-baselining.**
- **New regression test** (`tau_of_integral_families_is_accurate`) pins 12 τ
  values to 50-digit references at 1e-9. Confirmed as a negative control: all
  of them fail without these fixes.
- The study cross-validates its restated integrands against `Bicop::get_tau()`
  and its GK61 references against tanh-sinh at 50 digits (agreement 1e-24 or
  better, eight orders below the best arm's error).

## Also

`parity_dump`'s τ sweeps only covered mild interiors and would have caught
**none** of this. They now carry near-boundary corners under separate
`*_edge` keys, so the corners are guarded from here on.

## Follow-up

The rest of the Boost slim-down (Bimap, Assign, Unordered, and moving the
`BOOST_CONCEPT_ASSERT` undef out of the public umbrella header) is mechanical
and unrelated to numerics; it follows as a stacked PR to keep this diff
reviewable.