### PR TITLE
refactor(misc)!: slim the Boost dependency down to Graph, Math, and Random

### DIFF
--- a/include/vinecopulib.hpp
+++ b/include/vinecopulib.hpp
@@ -31,13 +31,6 @@
 #define USE_BOOST
 #endif
 
-// silences all the BOOST_CONCEPT warnings bullshit
-// https://stackoverflow.com/questions/13930894/how-to-disable-boost-concept-check
-#include <boost/concept/assert.hpp>
-#undef BOOST_CONCEPT_ASSERT
-#define BOOST_CONCEPT_ASSERT(Model)
-#include <boost/concept_check.hpp>
-
 #include <vinecopulib/bicop/class.hpp>
 #include <vinecopulib/misc/tools_stats.hpp>
 #include <vinecopulib/vinecop/class.hpp>

--- a/include/vinecopulib/bicop/implementation/family.ipp
+++ b/include/vinecopulib/bicop/implementation/family.ipp
@@ -4,31 +4,73 @@
 // the MIT license. For a copy, see the LICENSE file in the root directory of
 // vinecopulib or https://vinecopulib.github.io/vinecopulib/.
 
-#include <boost/assign.hpp>
-#include <boost/bimap.hpp>
+#include <stdexcept>
+#include <unordered_map>
 
 namespace vinecopulib {
 
-using family_bimap = boost::bimap<BicopFamily, std::string>;
-const family_bimap family_names =
-  boost::assign::list_of<family_bimap::relation>(
-    BicopFamily::indep,
-    "Independence")(BicopFamily::gaussian, "Gaussian")(
-    BicopFamily::student,
-    "Student")(BicopFamily::clayton, "Clayton")(BicopFamily::gumbel, "Gumbel")(
-    BicopFamily::frank,
-    "Frank")(BicopFamily::joe, "Joe")(BicopFamily::bb1, "BB1")(BicopFamily::bb6,
-                                                               "BB6")(
-    BicopFamily::bb7,
-    "BB7")(BicopFamily::bb8, "BB8")(BicopFamily::tawn, "Tawn")(BicopFamily::tll,
-                                                               "TLL");
+namespace {
+
+// The two directions are kept as separate maps rather than a bidirectional
+// container: the table is fixed and tiny, and both lookups are on hot paths
+// (family names appear in every serialized model).
+inline const std::vector<std::pair<BicopFamily, std::string>>&
+family_name_table()
+{
+  static const std::vector<std::pair<BicopFamily, std::string>> table = {
+    { BicopFamily::indep, "Independence" },
+    { BicopFamily::gaussian, "Gaussian" },
+    { BicopFamily::student, "Student" },
+    { BicopFamily::clayton, "Clayton" },
+    { BicopFamily::gumbel, "Gumbel" },
+    { BicopFamily::frank, "Frank" },
+    { BicopFamily::joe, "Joe" },
+    { BicopFamily::bb1, "BB1" },
+    { BicopFamily::bb6, "BB6" },
+    { BicopFamily::bb7, "BB7" },
+    { BicopFamily::bb8, "BB8" },
+    { BicopFamily::tawn, "Tawn" },
+    { BicopFamily::tll, "TLL" }
+  };
+  return table;
+}
+
+struct BicopFamilyHash
+{
+  size_t operator()(BicopFamily family) const noexcept
+  {
+    return std::hash<int>()(static_cast<int>(family));
+  }
+};
+
+inline const std::unordered_map<BicopFamily, std::string, BicopFamilyHash>&
+enum_to_name()
+{
+  static const std::unordered_map<BicopFamily, std::string, BicopFamilyHash>
+    map(family_name_table().begin(), family_name_table().end());
+  return map;
+}
+
+inline const std::unordered_map<std::string, BicopFamily>&
+name_to_enum()
+{
+  static const std::unordered_map<std::string, BicopFamily> map = [] {
+    std::unordered_map<std::string, BicopFamily> m;
+    for (const auto& e : family_name_table()) {
+      m.emplace(e.second, e.first);
+    }
+    return m;
+  }();
+  return map;
+}
+}
 
 //! @brief Converts a BicopFamily into a string with its name.
 //! @param family The family.
 inline std::string
 get_family_name(BicopFamily family)
 {
-  return family_names.left.at(family);
+  return enum_to_name().at(family);
 }
 
 //! @brief Converts a string name into a BicopFamily.
@@ -36,6 +78,6 @@ get_family_name(BicopFamily family)
 inline BicopFamily
 get_family_enum(const std::string& family)
 {
-  return family_names.right.at(family);
+  return name_to_enum().at(family);
 }
 }

--- a/include/vinecopulib/vinecop/implementation/tools_select.ipp
+++ b/include/vinecopulib/vinecop/implementation/tools_select.ipp
@@ -13,7 +13,9 @@
 #include <boost/graph/random_spanning_tree.hpp>
 #include <boost/random.hpp>
 #include <cmath>
+#include <functional>
 #include <iostream>
+#include <unordered_set>
 #include <wdm/eigen.hpp>
 
 namespace vinecopulib {
@@ -599,10 +601,18 @@ VinecopSelector::select_edges_mst_kruskal(VineTree& vine_tree)
 {
   std::vector<EdgeIterator> spanning_tree;
   kruskal_minimum_spanning_tree(vine_tree, std::back_inserter(spanning_tree));
-  // Using a hashmap to make the lookup faster
-  // boost::unordered set is used instead of std::set
-  // because std::pair doesn't have a default hash function
-  boost::unordered_set<std::pair<size_t, size_t>> edges_set;
+  // A hash set makes the lookup below O(1); std::pair has no default hash, so
+  // the set carries its own.
+  struct PairHash
+  {
+    size_t operator()(const std::pair<size_t, size_t>& e) const noexcept
+    {
+      const size_t h = std::hash<size_t>()(e.first);
+      return h ^
+             (std::hash<size_t>()(e.second) + 0x9e3779b9 + (h << 6) + (h >> 2));
+    }
+  };
+  std::unordered_set<std::pair<size_t, size_t>, PairHash> edges_set;
   for (auto e : spanning_tree) {
     edges_set.insert(
       { boost::source(e, vine_tree), boost::target(e, vine_tree) });


### PR DESCRIPTION
Stacked on #713 — review that first.

Mechanical follow-up to #713, which removed odeint. Three of the remaining Boost
libraries were carrying no weight:

| Library | Why it was there | Replacement |
|---|---|---|
| **Bimap** + **Assign** | a fixed 13-entry family ↔ name lookup table | two `std::unordered_map`s |
| **Unordered** | `std::pair` has no default hash | a 5-line hash functor on `std::unordered_set` |
| **Concept** | `#undef BOOST_CONCEPT_ASSERT` in the umbrella header | removed |

**Graph, Math and Random stay.** `boost::mt19937` is in the *public API* of
`FitControlsVinecop` and feeds `boost::random_spanning_tree`; replacing it would
break the API and perturb every seeded stream the parity gates guard.

## Behavior note for the changelog

The `BOOST_CONCEPT_ASSERT` override lived in the **public** umbrella header, so
it disabled Boost's concept assertions in *every consumer's* translation unit,
not just ours. Removing it means a consumer that reaches Boost through
`vinecopulib.hpp` may now see concept diagnostics that were previously
suppressed. Our own build is clean with them re-enabled.

## Verification

- **648 tests pass** in all three configurations: header-only, `VINECOPULIB_PRECOMPILED=ON`, and strict.
- **Strict build: zero warnings** with the concept assertions live again.
- **`parity_dump` byte-identical** across all six groups (0.000e+00 everywhere) — this PR moves no numbers.
- Benchmarked the lookup, since it runs on every serialized model: `get_family_name` 14.9 → 14.9 ns/call, `get_family_enum` 45.9 → 33.1 ns/call.
- `git grep '<boost/'` over `include/` now returns only `boost/graph`, `boost/math`, `boost/random`.