### PR TITLE
feat(vinecop): support conditioning sets in Rosenblatt transforms

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -17,6 +17,11 @@
   taking the address of `&Bicop::simulate` must now disambiguate, e.g. with
   `py::overload_cast<const size_t&, bool, const std::vector<int>&>(
   &Bicop::simulate, py::const_)` (#719)
+
+* Add conditioning-set overloads to `Vinecop::rosenblatt()` and
+  `Vinecop::inverse_rosenblatt()`. The transforms internally reorient the vine
+  through non-owning views, leaving the fitted model unchanged and avoiding
+  pair-copula copies, including TLL interpolation grids (#715)
 * Add scores, gradient, and Hessian of the log-likelihood to `Bicop`:
   `scores` (the n x p per-observation score matrix), `gradient` (its
   observation-average), `hessian` and `hessian_full` (the averaged and

--- a/include/vinecopulib/bicop/class.hpp
+++ b/include/vinecopulib/bicop/class.hpp
@@ -420,19 +420,22 @@ private:
 class BicopView
 {
 public:
-  explicit BicopView(const Bicop& bicop, bool flipped = false);
+  explicit BicopView(const Bicop& bicop,
+                     bool flipped = false,
+                     bool continuous = false);
 
+  BicopView as_continuous() const;
   std::vector<std::string> get_var_types() const;
   Eigen::VectorXd hfunc1(const Eigen::MatrixXd& u) const;
   Eigen::VectorXd hfunc2(const Eigen::MatrixXd& u) const;
-  Eigen::VectorXd hfunc1_continuous(const Eigen::MatrixXd& u) const;
-  Eigen::VectorXd hinv2_continuous(const Eigen::MatrixXd& u) const;
+  Eigen::VectorXd hinv2(const Eigen::MatrixXd& u) const;
 
 private:
   static Eigen::MatrixXd swap_arguments(const Eigen::MatrixXd& u);
 
   const Bicop* bicop_;
   bool flipped_;
+  bool continuous_;
 };
 //! @endcond
 }

--- a/include/vinecopulib/bicop/class.hpp
+++ b/include/vinecopulib/bicop/class.hpp
@@ -13,6 +13,7 @@ namespace vinecopulib {
 
 // forward declaration of Abstract class
 class AbstractBicop;
+class BicopView;
 using BicopPtr = std::shared_ptr<AbstractBicop>;
 
 //! @brief A class for bivariate copula models.
@@ -44,7 +45,7 @@ using BicopPtr = std::shared_ptr<AbstractBicop>;
 //!
 class Bicop
 {
-  friend class Vinecop;
+  friend class BicopView;
 
 public:
   // Constructors
@@ -344,9 +345,11 @@ private:
   // inverse Rosenblatt transform, whose input and output always have
   // continuous uniform margins even when the fitted model has discrete
   // variables.
-  Eigen::VectorXd hfunc1_continuous(const Eigen::MatrixXd& u) const;
+  Eigen::VectorXd hfunc1_continuous(const Eigen::MatrixXd& u,
+                                    bool flipped) const;
 
-  Eigen::VectorXd hinv2_continuous(const Eigen::MatrixXd& u) const;
+  Eigen::VectorXd hinv2_continuous(const Eigen::MatrixXd& u,
+                                   bool flipped) const;
 
   Eigen::MatrixXd format_data(const Eigen::MatrixXd& u) const;
 
@@ -411,6 +414,27 @@ private:
   size_t nobs_{ 0 };
   mutable std::vector<std::string> var_types_;
 };
+
+//! @cond INTERNAL
+//! A non-owning, optionally transposed view of a bivariate copula.
+class BicopView
+{
+public:
+  explicit BicopView(const Bicop& bicop, bool flipped = false);
+
+  std::vector<std::string> get_var_types() const;
+  Eigen::VectorXd hfunc1(const Eigen::MatrixXd& u) const;
+  Eigen::VectorXd hfunc2(const Eigen::MatrixXd& u) const;
+  Eigen::VectorXd hfunc1_continuous(const Eigen::MatrixXd& u) const;
+  Eigen::VectorXd hinv2_continuous(const Eigen::MatrixXd& u) const;
+
+private:
+  static Eigen::MatrixXd swap_arguments(const Eigen::MatrixXd& u);
+
+  const Bicop* bicop_;
+  bool flipped_;
+};
+//! @endcond
 }
 
 #include <vinecopulib/bicop/implementation/class.ipp>

--- a/include/vinecopulib/bicop/implementation/class.ipp
+++ b/include/vinecopulib/bicop/implementation/class.ipp
@@ -401,57 +401,92 @@ Bicop::hinv2(const Eigen::MatrixXd& u) const
 }
 
 inline Eigen::VectorXd
-Bicop::hfunc1_continuous(const Eigen::MatrixXd& u) const
+Bicop::hfunc1_continuous(const Eigen::MatrixXd& u, bool flipped) const
 {
-  auto u_new = prep_for_abstract_continuous(u);
+  auto u_new =
+    prep_for_abstract_continuous(flipped ? tools_eigen::swap_cols(u) : u);
   // TLL leaves read their interpolation grid directly and ignore the parameter
   // argument; do not materialize the full grid merely to pass it unused.
   Eigen::MatrixXd parameters = get_family() == BicopFamily::tll
                                  ? Eigen::MatrixXd()
                                  : bicop_->get_parameters().transpose();
-  Eigen::VectorXd h(u.rows());
-  switch (rotation_) {
-    default:
-      h = bicop_->hfunc1_raw(u_new, parameters);
-      break;
-    case 90:
-      h = bicop_->hfunc2_raw(u_new, parameters);
-      break;
-    case 180:
-      h = 1.0 - bicop_->hfunc1_raw(u_new, parameters).array();
-      break;
-    case 270:
-      h = 1.0 - bicop_->hfunc2_raw(u_new, parameters).array();
-      break;
-  }
+  bool use_hfunc1 = (rotation_ % 180 == 0) != flipped;
+  Eigen::VectorXd h = use_hfunc1 ? bicop_->hfunc1_raw(u_new, parameters)
+                                 : bicop_->hfunc2_raw(u_new, parameters);
+  bool complement =
+    rotation_ == 180 || (flipped ? rotation_ == 90 : rotation_ == 270);
+  if (complement)
+    h = 1.0 - h.array();
   tools_eigen::trim(h, 0.0, 1.0);
   return h;
 }
 
 inline Eigen::VectorXd
-Bicop::hinv2_continuous(const Eigen::MatrixXd& u) const
+Bicop::hinv2_continuous(const Eigen::MatrixXd& u, bool flipped) const
 {
-  auto u_new = prep_for_abstract_continuous(u);
+  auto u_new =
+    prep_for_abstract_continuous(flipped ? tools_eigen::swap_cols(u) : u);
   Eigen::MatrixXd parameters = get_family() == BicopFamily::tll
                                  ? Eigen::MatrixXd()
                                  : bicop_->get_parameters().transpose();
-  Eigen::VectorXd hi(u.rows());
-  switch (rotation_) {
-    default:
-      hi = bicop_->hinv2_raw(u_new, parameters);
-      break;
-    case 90:
-      hi = 1.0 - bicop_->hinv1_raw(u_new, parameters).array();
-      break;
-    case 180:
-      hi = 1.0 - bicop_->hinv2_raw(u_new, parameters).array();
-      break;
-    case 270:
-      hi = bicop_->hinv1_raw(u_new, parameters);
-      break;
-  }
+  bool use_hinv1 = (rotation_ % 180 != 0) != flipped;
+  Eigen::VectorXd hi = use_hinv1 ? bicop_->hinv1_raw(u_new, parameters)
+                                 : bicop_->hinv2_raw(u_new, parameters);
+  bool complement =
+    rotation_ == 180 || (flipped ? rotation_ == 270 : rotation_ == 90);
+  if (complement)
+    hi = 1.0 - hi.array();
   tools_eigen::trim(hi, 0.0, 1.0);
   return hi;
+}
+
+inline BicopView::BicopView(const Bicop& bicop, bool flipped)
+  : bicop_(&bicop)
+  , flipped_(flipped)
+{
+}
+
+inline std::vector<std::string>
+BicopView::get_var_types() const
+{
+  auto var_types = bicop_->get_var_types();
+  if (flipped_)
+    std::swap(var_types[0], var_types[1]);
+  return var_types;
+}
+
+inline Eigen::VectorXd
+BicopView::hfunc1(const Eigen::MatrixXd& u) const
+{
+  return flipped_ ? bicop_->hfunc2(swap_arguments(u)) : bicop_->hfunc1(u);
+}
+
+inline Eigen::VectorXd
+BicopView::hfunc2(const Eigen::MatrixXd& u) const
+{
+  return flipped_ ? bicop_->hfunc1(swap_arguments(u)) : bicop_->hfunc2(u);
+}
+
+inline Eigen::VectorXd
+BicopView::hfunc1_continuous(const Eigen::MatrixXd& u) const
+{
+  return bicop_->hfunc1_continuous(u, flipped_);
+}
+
+inline Eigen::VectorXd
+BicopView::hinv2_continuous(const Eigen::MatrixXd& u) const
+{
+  return bicop_->hinv2_continuous(u, flipped_);
+}
+
+inline Eigen::MatrixXd
+BicopView::swap_arguments(const Eigen::MatrixXd& u)
+{
+  Eigen::MatrixXd swapped = u;
+  swapped.col(0).swap(swapped.col(1));
+  if (swapped.cols() == 4)
+    swapped.col(2).swap(swapped.col(3));
+  return swapped;
 }
 //! @}
 

--- a/include/vinecopulib/bicop/implementation/class.ipp
+++ b/include/vinecopulib/bicop/implementation/class.ipp
@@ -440,15 +440,24 @@ Bicop::hinv2_continuous(const Eigen::MatrixXd& u, bool flipped) const
   return hi;
 }
 
-inline BicopView::BicopView(const Bicop& bicop, bool flipped)
+inline BicopView::BicopView(const Bicop& bicop, bool flipped, bool continuous)
   : bicop_(&bicop)
   , flipped_(flipped)
+  , continuous_(continuous)
 {
+}
+
+inline BicopView
+BicopView::as_continuous() const
+{
+  return BicopView(*bicop_, flipped_, true);
 }
 
 inline std::vector<std::string>
 BicopView::get_var_types() const
 {
+  if (continuous_)
+    return { "c", "c" };
   auto var_types = bicop_->get_var_types();
   if (flipped_)
     std::swap(var_types[0], var_types[1]);
@@ -458,25 +467,25 @@ BicopView::get_var_types() const
 inline Eigen::VectorXd
 BicopView::hfunc1(const Eigen::MatrixXd& u) const
 {
+  if (continuous_)
+    return bicop_->hfunc1_continuous(u, flipped_);
   return flipped_ ? bicop_->hfunc2(swap_arguments(u)) : bicop_->hfunc1(u);
 }
 
 inline Eigen::VectorXd
 BicopView::hfunc2(const Eigen::MatrixXd& u) const
 {
+  if (continuous_)
+    return bicop_->hfunc1_continuous(swap_arguments(u), !flipped_);
   return flipped_ ? bicop_->hfunc1(swap_arguments(u)) : bicop_->hfunc2(u);
 }
 
 inline Eigen::VectorXd
-BicopView::hfunc1_continuous(const Eigen::MatrixXd& u) const
+BicopView::hinv2(const Eigen::MatrixXd& u) const
 {
-  return bicop_->hfunc1_continuous(u, flipped_);
-}
-
-inline Eigen::VectorXd
-BicopView::hinv2_continuous(const Eigen::MatrixXd& u) const
-{
-  return bicop_->hinv2_continuous(u, flipped_);
+  if (continuous_)
+    return bicop_->hinv2_continuous(u, flipped_);
+  return flipped_ ? bicop_->hinv1(swap_arguments(u)) : bicop_->hinv2(u);
 }
 
 inline Eigen::MatrixXd

--- a/include/vinecopulib/vinecop/class.hpp
+++ b/include/vinecopulib/vinecop/class.hpp
@@ -216,8 +216,29 @@ public:
                              const size_t num_threads = 1,
                              bool randomize_discrete = true,
                              std::vector<int> seeds = {}) const;
+  //! Evaluates the Rosenblatt transform in an admissible sampling order whose
+  //! tail contains exactly `conditioning_set`.
+  //! @param u An n x d matrix of evaluation points.
+  //! @param conditioning_set 1-based indices of the conditioning variables.
+  //! @param num_threads Number of threads to use.
+  //! @param randomize_discrete Whether to randomize discrete variables.
+  //! @param seeds Seeds used for discrete randomization.
+  Eigen::MatrixXd rosenblatt(Eigen::MatrixXd u,
+                             const std::vector<size_t>& conditioning_set,
+                             const size_t num_threads = 1,
+                             bool randomize_discrete = true,
+                             std::vector<int> seeds = {}) const;
   Eigen::MatrixXd inverse_rosenblatt(const Eigen::MatrixXd& u,
                                      const size_t num_threads = 1) const;
+  //! Evaluates the inverse Rosenblatt transform in an admissible sampling
+  //! order whose tail contains exactly `conditioning_set`.
+  //! @param u An n x d matrix of independent uniform variates.
+  //! @param conditioning_set 1-based indices of the conditioning variables.
+  //! @param num_threads Number of threads to use.
+  Eigen::MatrixXd inverse_rosenblatt(
+    const Eigen::MatrixXd& u,
+    const std::vector<size_t>& conditioning_set,
+    const size_t num_threads = 1) const;
 
   //! Sets every pair copula in one shot.
   //! @param pair_copulas nested list of `Bicop` instances, shaped like
@@ -332,6 +353,45 @@ public:
                              const size_t num_threads = 1);
 
 private:
+  struct PairCopulaLocation
+  {
+    size_t tree{ 0 };
+    size_t edge{ 0 };
+    bool flipped{ false };
+  };
+
+  struct ReorientationMap
+  {
+    RVineStructure structure;
+    TriangularArray<PairCopulaLocation> pair_copulas;
+    bool identity{ false };
+  };
+
+  class VinecopView
+  {
+  public:
+    explicit VinecopView(const Vinecop& vinecop);
+    VinecopView(const Vinecop& vinecop, const ReorientationMap& reorientation);
+
+    const RVineStructure& get_structure() const;
+    BicopView get_pair_copula(size_t tree, size_t edge) const;
+
+  private:
+    const Vinecop* vinecop_;
+    const ReorientationMap* reorientation_;
+  };
+
+  ReorientationMap make_reorientation_map(
+    const std::vector<size_t>& conditioning_set) const;
+  Eigen::MatrixXd rosenblatt_impl(Eigen::MatrixXd u,
+                                  const VinecopView& view,
+                                  size_t num_threads,
+                                  bool randomize_discrete,
+                                  std::vector<int> seeds) const;
+  Eigen::MatrixXd inverse_rosenblatt_impl(const Eigen::MatrixXd& u,
+                                          const VinecopView& view,
+                                          size_t num_threads) const;
+
   // Per-edge derivative caches shared by the analytic score/gradient/Hessian
   // cascades. One forward walk over the vine (build_deriv_cache) fills them;
   // the cascades then only read them.

--- a/include/vinecopulib/vinecop/class.hpp
+++ b/include/vinecopulib/vinecop/class.hpp
@@ -216,15 +216,6 @@ public:
                              const size_t num_threads = 1,
                              bool randomize_discrete = true,
                              std::vector<int> seeds = {}) const;
-  //! Evaluates the Rosenblatt transform in an admissible sampling order whose
-  //! tail contains exactly `conditioning_set`.
-  //! The model itself is not modified.
-  //! @param u An n x d matrix of evaluation points.
-  //! @param conditioning_set 1-based indices of the conditioning variables.
-  //! @param num_threads Number of threads to use.
-  //! @param randomize_discrete Whether to randomize discrete variables.
-  //! @param seeds Seeds used for discrete randomization.
-  //! @return An n x d matrix of independent uniform variates.
   Eigen::MatrixXd rosenblatt(Eigen::MatrixXd u,
                              const std::vector<size_t>& conditioning_set,
                              const size_t num_threads = 1,
@@ -232,13 +223,6 @@ public:
                              std::vector<int> seeds = {}) const;
   Eigen::MatrixXd inverse_rosenblatt(const Eigen::MatrixXd& u,
                                      const size_t num_threads = 1) const;
-  //! Evaluates the inverse Rosenblatt transform in an admissible sampling
-  //! order whose tail contains exactly `conditioning_set`.
-  //! The model itself is not modified.
-  //! @param u An n x d matrix of independent uniform variates.
-  //! @param conditioning_set 1-based indices of the conditioning variables.
-  //! @param num_threads Number of threads to use.
-  //! @return An n x d matrix of transformed values.
   Eigen::MatrixXd inverse_rosenblatt(
     const Eigen::MatrixXd& u,
     const std::vector<size_t>& conditioning_set,

--- a/include/vinecopulib/vinecop/class.hpp
+++ b/include/vinecopulib/vinecop/class.hpp
@@ -218,11 +218,13 @@ public:
                              std::vector<int> seeds = {}) const;
   //! Evaluates the Rosenblatt transform in an admissible sampling order whose
   //! tail contains exactly `conditioning_set`.
+  //! The model itself is not modified.
   //! @param u An n x d matrix of evaluation points.
   //! @param conditioning_set 1-based indices of the conditioning variables.
   //! @param num_threads Number of threads to use.
   //! @param randomize_discrete Whether to randomize discrete variables.
   //! @param seeds Seeds used for discrete randomization.
+  //! @return An n x d matrix of independent uniform variates.
   Eigen::MatrixXd rosenblatt(Eigen::MatrixXd u,
                              const std::vector<size_t>& conditioning_set,
                              const size_t num_threads = 1,
@@ -232,9 +234,11 @@ public:
                                      const size_t num_threads = 1) const;
   //! Evaluates the inverse Rosenblatt transform in an admissible sampling
   //! order whose tail contains exactly `conditioning_set`.
+  //! The model itself is not modified.
   //! @param u An n x d matrix of independent uniform variates.
   //! @param conditioning_set 1-based indices of the conditioning variables.
   //! @param num_threads Number of threads to use.
+  //! @return An n x d matrix of transformed values.
   Eigen::MatrixXd inverse_rosenblatt(
     const Eigen::MatrixXd& u,
     const std::vector<size_t>& conditioning_set,
@@ -353,17 +357,10 @@ public:
                              const size_t num_threads = 1);
 
 private:
-  struct PairCopulaLocation
-  {
-    size_t tree{ 0 };
-    size_t edge{ 0 };
-    bool flipped{ false };
-  };
-
   struct ReorientationMap
   {
     RVineStructure structure;
-    TriangularArray<PairCopulaLocation> pair_copulas;
+    TriangularArray<RVineTrees::PairCopulaLocation> pair_copulas;
     bool identity{ false };
   };
 

--- a/include/vinecopulib/vinecop/implementation/class.ipp
+++ b/include/vinecopulib/vinecop/implementation/class.ipp
@@ -3093,6 +3093,18 @@ Vinecop::rosenblatt(Eigen::MatrixXd u,
                          std::move(seeds));
 }
 
+//! @brief Evaluates the Rosenblatt transform for a conditioning set.
+//!
+//! @details The vine is evaluated in an admissible sampling order whose tail
+//! contains exactly `conditioning_set`. The model itself is not modified.
+//!
+//! @param u An \f$ n \times d \f$ matrix of evaluation points.
+//! @param conditioning_set The 1-based indices of the conditioning variables.
+//! @param num_threads The number of threads to use for computations.
+//! @param randomize_discrete Whether to randomize the transform for discrete
+//!   variables.
+//! @param seeds Seeds used for discrete randomization.
+//! @return An \f$ n \times d \f$ matrix of independent uniform variates.
 inline Eigen::MatrixXd
 Vinecop::rosenblatt(Eigen::MatrixXd u,
                     const std::vector<size_t>& conditioning_set,
@@ -3269,6 +3281,15 @@ Vinecop::inverse_rosenblatt(const Eigen::MatrixXd& u,
   return inverse_rosenblatt_impl(u, VinecopView(*this), num_threads);
 }
 
+//! @brief Evaluates the inverse Rosenblatt transform for a conditioning set.
+//!
+//! @details The vine is evaluated in an admissible sampling order whose tail
+//! contains exactly `conditioning_set`. The model itself is not modified.
+//!
+//! @param u An \f$ n \times d \f$ matrix of independent uniform variates.
+//! @param conditioning_set The 1-based indices of the conditioning variables.
+//! @param num_threads The number of threads to use for computations.
+//! @return An \f$ n \times d \f$ matrix of transformed values.
 inline Eigen::MatrixXd
 Vinecop::inverse_rosenblatt(const Eigen::MatrixXd& u,
                             const std::vector<size_t>& conditioning_set,

--- a/include/vinecopulib/vinecop/implementation/class.ipp
+++ b/include/vinecopulib/vinecop/implementation/class.ipp
@@ -423,23 +423,40 @@ Vinecop::check_tree_criterion_function(const FitControlsVinecop& controls)
   }
 }
 
-//! @brief Relabels the vine to an equivalent one whose order tail equals
-//! `conditioning_set`.
-//!
-//! @details A value-preserving re-orientation: the fitted model is unchanged
-//! (both the density `pdf` and the log-likelihood `loglik` are invariant), only
-//! its sampling-order representation changes, so that the variables in
-//! `conditioning_set` are drawn first and can be conditioned on with
-//! `simulate_conditional`. It chooses, per tree, which conditioned variable
-//! sits on the matrix diagonal, and flips each pair copula whose stored
-//! orientation no longer matches its new position. Throws if the current
-//! structure admits no sampling order ending in `conditioning_set` (fit with a
-//! conditioning set via `FitControlsVinecop` to guarantee one exists).
-//!
-//! @param conditioning_set 1-based variable indices to place at the tail of the
-//! variable order.
-inline void
-Vinecop::reorient(const std::vector<size_t>& conditioning_set)
+inline Vinecop::VinecopView::VinecopView(const Vinecop& vinecop)
+  : vinecop_(&vinecop)
+  , reorientation_(nullptr)
+{
+}
+
+inline Vinecop::VinecopView::VinecopView(const Vinecop& vinecop,
+                                         const ReorientationMap& reorientation)
+  : vinecop_(&vinecop)
+  , reorientation_(reorientation.identity ? nullptr : &reorientation)
+{
+}
+
+inline const RVineStructure&
+Vinecop::VinecopView::get_structure() const
+{
+  return reorientation_ ? reorientation_->structure
+                        : vinecop_->rvine_structure_;
+}
+
+inline BicopView
+Vinecop::VinecopView::get_pair_copula(size_t tree, size_t edge) const
+{
+  if (!reorientation_)
+    return BicopView(vinecop_->pair_copulas_[tree][edge]);
+
+  auto location = reorientation_->pair_copulas(tree, edge);
+  return BicopView(vinecop_->pair_copulas_[location.tree][location.edge],
+                   location.flipped);
+}
+
+inline Vinecop::ReorientationMap
+Vinecop::make_reorientation_map(
+  const std::vector<size_t>& conditioning_set) const
 {
   size_t k = conditioning_set.size();
 
@@ -472,19 +489,18 @@ Vinecop::reorient(const std::vector<size_t>& conditioning_set)
     return true;
   };
 
-  // early no-op: the conditioning set is already the tail of the order
+  // Preserve the exact representation if the requested variables already
+  // form the sampling-order tail.
   if (tail_is_b(rvine_structure_.get_order())) {
-    return;
+    ReorientationMap identity;
+    identity.identity = true;
+    return identity;
   }
 
-  // Re-orient via the shared RVineTrees primitive: decompose the fitted vine
-  // into its tree list (carrying pair copulas), then peel it back into a
-  // matrix while steering the diagonal so the conditioning set lands at the
-  // tail. For the leading columns we put a non-conditioning leaf on the
-  // diagonal, for the trailing columns a conditioning one. Because the
-  // conditioning set forms a self-contained sub-vine block (guaranteed when
-  // fitted via `set_conditioning_set()`), the required leaf is always present;
-  // the tail check + `RVineStructure` validation below guard the general case.
+  TriangularArray<PairCopulaLocation> locations(d_, d_ - 1);
+
+  // Peel the structure while steering the diagonal so that the conditioning
+  // set lands at the tail. No fitted pair copulas are copied here.
   auto to_tail =
     [&](size_t col,
         const std::vector<std::vector<size_t>>& leaf_edges) noexcept -> size_t {
@@ -496,28 +512,95 @@ Vinecop::reorient(const std::vector<size_t>& conditioning_set)
     return leaf_edges.front().front();
   };
 
-  std::vector<size_t> new_order;
-  TriangularArray<size_t> new_struct_array(d_, d_ - 1);
-  std::vector<std::vector<Bicop>> new_pair_copulas;
-  bool ok = true;
+  auto source_trees = rvine_structure_.get_trees();
+  RVineTrees::Decomposition decomposition;
   try {
-    auto dec = get_trees().to_struct_array(to_tail);
-    new_order = std::move(dec.order);
-    new_struct_array = std::move(dec.struct_array);
-    new_pair_copulas = std::move(dec.pair_copulas);
+    decomposition = source_trees.to_struct_array(to_tail);
   } catch (const std::exception&) {
-    ok = false; // infeasible (proximity / no admissible leaf)
+    throw std::runtime_error(
+      "conditioning set is not admissible as a sampling-order tail of this "
+      "vine; fit with FitControlsVinecop::set_conditioning_set() or condition "
+      "on an admissible set.");
   }
-  if (!ok || !tail_is_b(new_order)) {
+  if (!tail_is_b(decomposition.order)) {
     throw std::runtime_error(
       "conditioning set is not admissible as a sampling-order tail of this "
       "vine; fit with FitControlsVinecop::set_conditioning_set() or condition "
       "on an admissible set.");
   }
 
-  // full R-vine validation (proximity etc.); loglik/threshold/nobs invariant
-  rvine_structure_ = RVineStructure(new_order, new_struct_array, false, true);
-  pair_copulas_ = std::move(new_pair_copulas);
+  RVineStructure structure(
+    decomposition.order, decomposition.struct_array, false, true);
+
+  // Match every edge in the new representation to the same logical edge in
+  // the original representation. A transpose is needed exactly when the new
+  // diagonal variable was the original edge's second argument.
+  using EdgeKey = std::tuple<size_t, size_t, std::vector<size_t>>;
+  auto edge_key = [](const RVineTrees::Edge& edge) {
+    return EdgeKey{ std::min(edge.a, edge.b),
+                    std::max(edge.a, edge.b),
+                    edge.C };
+  };
+  auto target_trees = structure.get_trees();
+  for (size_t tree = 0; tree < d_ - 1; ++tree) {
+    std::map<EdgeKey, size_t> source_locations;
+    const auto& source_edges = source_trees.get_trees()[tree];
+    for (size_t edge = 0; edge < source_edges.size(); ++edge)
+      source_locations.emplace(edge_key(source_edges[edge]), edge);
+
+    const auto& target_edges = target_trees.get_trees()[tree];
+    for (size_t edge = 0; edge < target_edges.size(); ++edge) {
+      auto source = source_locations.find(edge_key(target_edges[edge]));
+      if (source == source_locations.end()) {
+        throw std::runtime_error(
+          "could not map a pair copula into the reoriented structure.");
+      }
+      const auto& source_edge = source_edges[source->second];
+      locations(tree, edge) = { tree,
+                                source->second,
+                                target_edges[edge].a != source_edge.a };
+    }
+  }
+
+  return { std::move(structure), std::move(locations), false };
+}
+
+//! @brief Relabels the vine to an equivalent one whose order tail equals
+//! `conditioning_set`.
+//!
+//! @details A value-preserving re-orientation: the fitted model is unchanged
+//! (both the density `pdf` and the log-likelihood `loglik` are invariant), only
+//! its sampling-order representation changes, so that the variables in
+//! `conditioning_set` are drawn first and can be conditioned on with
+//! `simulate_conditional`. It chooses, per tree, which conditioned variable
+//! sits on the matrix diagonal, and flips each pair copula whose stored
+//! orientation no longer matches its new position. Throws if the current
+//! structure admits no sampling order ending in `conditioning_set` (fit with a
+//! conditioning set via `FitControlsVinecop` to guarantee one exists).
+//!
+//! @param conditioning_set 1-based variable indices to place at the tail of the
+//! variable order.
+inline void
+Vinecop::reorient(const std::vector<size_t>& conditioning_set)
+{
+  auto reorientation = make_reorientation_map(conditioning_set);
+  if (reorientation.identity)
+    return;
+
+  std::vector<std::vector<Bicop>> pair_copulas(d_ - 1);
+  for (size_t tree = 0; tree < d_ - 1; ++tree) {
+    pair_copulas[tree].reserve(d_ - 1 - tree);
+    for (size_t edge = 0; edge < d_ - 1 - tree; ++edge) {
+      auto location = reorientation.pair_copulas(tree, edge);
+      pair_copulas[tree].emplace_back(
+        pair_copulas_[location.tree][location.edge]);
+      if (location.flipped)
+        pair_copulas[tree].back().flip();
+    }
+  }
+
+  rvine_structure_ = std::move(reorientation.structure);
+  pair_copulas_ = std::move(pair_copulas);
 }
 
 //! @brief Fits the parameters of a pre-specified vine copula model.
@@ -3037,6 +3120,46 @@ Vinecop::rosenblatt(Eigen::MatrixXd u,
                     bool randomize_discrete,
                     std::vector<int> seeds) const
 {
+  return rosenblatt_impl(std::move(u),
+                         VinecopView(*this),
+                         num_threads,
+                         randomize_discrete,
+                         std::move(seeds));
+}
+
+//! @brief Evaluates the Rosenblatt transform after internally reorienting the
+//! vine so that `conditioning_set` forms the sampling-order tail.
+//!
+//! @param u An \f$ n \times d \f$ matrix of evaluation points.
+//! @param conditioning_set 1-based variable indices to place at the tail of the
+//! sampling order.
+//! @param num_threads The number of threads to use for computations.
+//! @param randomize_discrete Whether to randomize the transform for discrete
+//! variables.
+//! @param seeds Seeds for the discrete randomization.
+//! @return An \f$ n \times d \f$ matrix of independent uniform variates.
+inline Eigen::MatrixXd
+Vinecop::rosenblatt(Eigen::MatrixXd u,
+                    const std::vector<size_t>& conditioning_set,
+                    const size_t num_threads,
+                    bool randomize_discrete,
+                    std::vector<int> seeds) const
+{
+  auto reorientation = make_reorientation_map(conditioning_set);
+  return rosenblatt_impl(std::move(u),
+                         VinecopView(*this, reorientation),
+                         num_threads,
+                         randomize_discrete,
+                         std::move(seeds));
+}
+
+inline Eigen::MatrixXd
+Vinecop::rosenblatt_impl(Eigen::MatrixXd u,
+                         const VinecopView& view,
+                         size_t num_threads,
+                         bool randomize_discrete,
+                         std::vector<int> seeds) const
+{
   check_data(u);
   collapse_data_inplace(u);
 
@@ -3044,8 +3167,9 @@ Vinecop::rosenblatt(Eigen::MatrixXd u,
   size_t n = u.rows();
 
   // info about the vine structure
-  size_t trunc_lvl = rvine_structure_.get_trunc_lvl();
-  auto order = rvine_structure_.get_order();
+  const auto& structure = view.get_structure();
+  size_t trunc_lvl = structure.get_trunc_lvl();
+  auto order = structure.get_order();
   auto inverse_order = tools_stl::invert_permutation(order);
   auto disc_cols = tools_select::get_disc_cols(var_types_);
 
@@ -3075,13 +3199,13 @@ Vinecop::rosenblatt(Eigen::MatrixXd u,
         tools_interface::check_user_interrupt(edge % 100 == 0);
         // extract evaluation point from hfunction matrices (have been
         // computed in previous tree level)
-        Bicop* edge_copula = &pair_copulas_[tree][edge];
-        auto var_types = edge_copula->get_var_types();
-        size_t m = rvine_structure_.min_array(tree, edge);
+        auto edge_copula = view.get_pair_copula(tree, edge);
+        auto var_types = edge_copula.get_var_types();
+        size_t m = structure.min_array(tree, edge);
 
         u_e.resize(b.size, 2);
         u_e.col(0) = hfunc2.block(b.begin, edge, b.size, 1);
-        if (m == rvine_structure_.struct_array(tree, edge, true)) {
+        if (m == structure.struct_array(tree, edge, true)) {
           u_e.col(1) = hfunc2.block(b.begin, m - 1, b.size, 1);
         } else {
           u_e.col(1) = hfunc1.block(b.begin, m - 1, b.size, 1);
@@ -3090,7 +3214,7 @@ Vinecop::rosenblatt(Eigen::MatrixXd u,
         if ((var_types[0] == "d") || (var_types[1] == "d")) {
           u_e.conservativeResize(b.size, 4);
           u_e.col(2) = hfunc2_sub.block(b.begin, edge, b.size, 1);
-          if (m == rvine_structure_.struct_array(tree, edge, true)) {
+          if (m == structure.struct_array(tree, edge, true)) {
             u_e.col(3) = hfunc2_sub.block(b.begin, m - 1, b.size, 1);
           } else {
             u_e.col(3) = hfunc1_sub.block(b.begin, m - 1, b.size, 1);
@@ -3098,21 +3222,21 @@ Vinecop::rosenblatt(Eigen::MatrixXd u,
         }
 
         // h-functions are only evaluated if needed in next step
-        if (rvine_structure_.needed_hfunc1(tree, edge)) {
-          hfunc1.block(b.begin, edge, b.size, 1) = edge_copula->hfunc1(u_e);
+        if (structure.needed_hfunc1(tree, edge)) {
+          hfunc1.block(b.begin, edge, b.size, 1) = edge_copula.hfunc1(u_e);
           if (var_types[1] == "d") {
             u_e_sub = u_e;
             u_e_sub.col(1) = u_e.col(3);
             hfunc1_sub.block(b.begin, edge, b.size, 1) =
-              edge_copula->hfunc1(u_e_sub);
+              edge_copula.hfunc1(u_e_sub);
           }
         }
-        hfunc2.block(b.begin, edge, b.size, 1) = edge_copula->hfunc2(u_e);
+        hfunc2.block(b.begin, edge, b.size, 1) = edge_copula.hfunc2(u_e);
         if (var_types[0] == "d") {
           u_e_sub = u_e;
           u_e_sub.col(0) = u_e.col(2);
           hfunc2_sub.block(b.begin, edge, b.size, 1) =
-            edge_copula->hfunc2(u_e_sub);
+            edge_copula.hfunc2(u_e_sub);
         }
       }
     }
@@ -3187,6 +3311,33 @@ inline Eigen::MatrixXd
 Vinecop::inverse_rosenblatt(const Eigen::MatrixXd& u,
                             const size_t num_threads) const
 {
+  return inverse_rosenblatt_impl(u, VinecopView(*this), num_threads);
+}
+
+//! @brief Evaluates the inverse Rosenblatt transform after internally
+//! reorienting the vine so that `conditioning_set` forms the sampling-order
+//! tail.
+//!
+//! @param u An \f$ n \times d \f$ matrix of independent uniform variates.
+//! @param conditioning_set 1-based variable indices to place at the tail of the
+//! sampling order.
+//! @param num_threads The number of threads to use for computations.
+//! @return An \f$ n \times d \f$ matrix of transformed values.
+inline Eigen::MatrixXd
+Vinecop::inverse_rosenblatt(const Eigen::MatrixXd& u,
+                            const std::vector<size_t>& conditioning_set,
+                            const size_t num_threads) const
+{
+  auto reorientation = make_reorientation_map(conditioning_set);
+  return inverse_rosenblatt_impl(
+    u, VinecopView(*this, reorientation), num_threads);
+}
+
+inline Eigen::MatrixXd
+Vinecop::inverse_rosenblatt_impl(const Eigen::MatrixXd& u,
+                                 const VinecopView& view,
+                                 size_t num_threads) const
+{
   const size_t n_cols = static_cast<size_t>(u.cols());
   if ((n_cols != d_) && (n_cols != 2 * d_)) {
     throw std::runtime_error(
@@ -3212,15 +3363,16 @@ Vinecop::inverse_rosenblatt(const Eigen::MatrixXd& u,
     size_t n_half = n / 2;
     size_t n_left = n - n_half;
     U_vine.block(0, 0, n_half, d) =
-      inverse_rosenblatt(u.block(0, 0, n_half, d), num_threads);
+      inverse_rosenblatt_impl(u.block(0, 0, n_half, d), view, num_threads);
     U_vine.block(n_half, 0, n_left, d) =
-      inverse_rosenblatt(u.block(n_half, 0, n_left, d), num_threads);
+      inverse_rosenblatt_impl(u.block(n_half, 0, n_left, d), view, num_threads);
     return U_vine;
   }
 
   // info about the vine structure (in upper triangular matrix notation)
-  size_t trunc_lvl = rvine_structure_.get_trunc_lvl();
-  auto order = rvine_structure_.get_order();
+  const auto& structure = view.get_structure();
+  size_t trunc_lvl = structure.get_trunc_lvl();
+  auto order = structure.get_order();
   auto inverse_order = tools_stl::invert_permutation(order);
 
   auto do_batch = [&](const tools_batch::Batch& b) {
@@ -3243,12 +3395,12 @@ Vinecop::inverse_rosenblatt(const Eigen::MatrixXd& u,
         static_cast<double>(n) * static_cast<double>(d) > 1e5);
       size_t tree_start = std::min(trunc_lvl - 1, d - var - 2);
       for (ptrdiff_t tree = tree_start; tree >= 0; --tree) {
-        const Bicop& edge_copula = pair_copulas_[tree][var];
+        auto edge_copula = view.get_pair_copula(tree, var);
 
         // extract data for conditional pair
-        size_t m = rvine_structure_.min_array(tree, var);
+        size_t m = structure.min_array(tree, var);
         U_e.col(0) = hinv2(tree + 1, var);
-        if (m == rvine_structure_.struct_array(tree, var, true)) {
+        if (m == structure.struct_array(tree, var, true)) {
           U_e.col(1) = hinv2(tree, m - 1);
         } else {
           U_e.col(1) = hfunc1(tree, m - 1);
@@ -3259,7 +3411,7 @@ Vinecop::inverse_rosenblatt(const Eigen::MatrixXd& u,
 
         // if required at a later stage, also calculate hfunc1
         if (var < static_cast<ptrdiff_t>(d_) - 1) {
-          if (rvine_structure_.needed_hfunc1(tree, var)) {
+          if (structure.needed_hfunc1(tree, var)) {
             U_e.col(0) = hinv2(tree, var);
             hfunc1(tree + 1, var) = edge_copula.hfunc1_continuous(U_e);
           }

--- a/include/vinecopulib/vinecop/implementation/class.ipp
+++ b/include/vinecopulib/vinecop/implementation/class.ipp
@@ -497,8 +497,6 @@ Vinecop::make_reorientation_map(
     return identity;
   }
 
-  TriangularArray<PairCopulaLocation> locations(d_, d_ - 1);
-
   // Peel the structure while steering the diagonal so that the conditioning
   // set lands at the tail. No fitted pair copulas are copied here.
   auto to_tail =
@@ -512,57 +510,25 @@ Vinecop::make_reorientation_map(
     return leaf_edges.front().front();
   };
 
-  auto source_trees = rvine_structure_.get_trees();
+  const std::string inadmissible =
+    "conditioning set is not admissible as a sampling-order tail of this "
+    "vine; fit with FitControlsVinecop::set_conditioning_set() or condition "
+    "on an admissible set.";
   RVineTrees::Decomposition decomposition;
   try {
-    decomposition = source_trees.to_struct_array(to_tail);
+    decomposition = rvine_structure_.get_trees().to_struct_array_map(to_tail);
   } catch (const std::exception&) {
-    throw std::runtime_error(
-      "conditioning set is not admissible as a sampling-order tail of this "
-      "vine; fit with FitControlsVinecop::set_conditioning_set() or condition "
-      "on an admissible set.");
+    throw std::runtime_error(inadmissible);
   }
   if (!tail_is_b(decomposition.order)) {
-    throw std::runtime_error(
-      "conditioning set is not admissible as a sampling-order tail of this "
-      "vine; fit with FitControlsVinecop::set_conditioning_set() or condition "
-      "on an admissible set.");
+    throw std::runtime_error(inadmissible);
   }
 
   RVineStructure structure(
     decomposition.order, decomposition.struct_array, false, true);
-
-  // Match every edge in the new representation to the same logical edge in
-  // the original representation. A transpose is needed exactly when the new
-  // diagonal variable was the original edge's second argument.
-  using EdgeKey = std::tuple<size_t, size_t, std::vector<size_t>>;
-  auto edge_key = [](const RVineTrees::Edge& edge) {
-    return EdgeKey{ std::min(edge.a, edge.b),
-                    std::max(edge.a, edge.b),
-                    edge.C };
-  };
-  auto target_trees = structure.get_trees();
-  for (size_t tree = 0; tree < d_ - 1; ++tree) {
-    std::map<EdgeKey, size_t> source_locations;
-    const auto& source_edges = source_trees.get_trees()[tree];
-    for (size_t edge = 0; edge < source_edges.size(); ++edge)
-      source_locations.emplace(edge_key(source_edges[edge]), edge);
-
-    const auto& target_edges = target_trees.get_trees()[tree];
-    for (size_t edge = 0; edge < target_edges.size(); ++edge) {
-      auto source = source_locations.find(edge_key(target_edges[edge]));
-      if (source == source_locations.end()) {
-        throw std::runtime_error(
-          "could not map a pair copula into the reoriented structure.");
-      }
-      const auto& source_edge = source_edges[source->second];
-      locations(tree, edge) = { tree,
-                                source->second,
-                                target_edges[edge].a != source_edge.a };
-    }
-  }
-
-  return { std::move(structure), std::move(locations), false };
+  return { std::move(structure),
+           std::move(decomposition.pair_copula_locations),
+           false };
 }
 
 //! @brief Relabels the vine to an equivalent one whose order tail equals
@@ -3127,17 +3093,6 @@ Vinecop::rosenblatt(Eigen::MatrixXd u,
                          std::move(seeds));
 }
 
-//! @brief Evaluates the Rosenblatt transform after internally reorienting the
-//! vine so that `conditioning_set` forms the sampling-order tail.
-//!
-//! @param u An \f$ n \times d \f$ matrix of evaluation points.
-//! @param conditioning_set 1-based variable indices to place at the tail of the
-//! sampling order.
-//! @param num_threads The number of threads to use for computations.
-//! @param randomize_discrete Whether to randomize the transform for discrete
-//! variables.
-//! @param seeds Seeds for the discrete randomization.
-//! @return An \f$ n \times d \f$ matrix of independent uniform variates.
 inline Eigen::MatrixXd
 Vinecop::rosenblatt(Eigen::MatrixXd u,
                     const std::vector<size_t>& conditioning_set,
@@ -3314,15 +3269,6 @@ Vinecop::inverse_rosenblatt(const Eigen::MatrixXd& u,
   return inverse_rosenblatt_impl(u, VinecopView(*this), num_threads);
 }
 
-//! @brief Evaluates the inverse Rosenblatt transform after internally
-//! reorienting the vine so that `conditioning_set` forms the sampling-order
-//! tail.
-//!
-//! @param u An \f$ n \times d \f$ matrix of independent uniform variates.
-//! @param conditioning_set 1-based variable indices to place at the tail of the
-//! sampling order.
-//! @param num_threads The number of threads to use for computations.
-//! @return An \f$ n \times d \f$ matrix of transformed values.
 inline Eigen::MatrixXd
 Vinecop::inverse_rosenblatt(const Eigen::MatrixXd& u,
                             const std::vector<size_t>& conditioning_set,
@@ -3395,7 +3341,7 @@ Vinecop::inverse_rosenblatt_impl(const Eigen::MatrixXd& u,
         static_cast<double>(n) * static_cast<double>(d) > 1e5);
       size_t tree_start = std::min(trunc_lvl - 1, d - var - 2);
       for (ptrdiff_t tree = tree_start; tree >= 0; --tree) {
-        auto edge_copula = view.get_pair_copula(tree, var);
+        auto edge_copula = view.get_pair_copula(tree, var).as_continuous();
 
         // extract data for conditional pair
         size_t m = structure.min_array(tree, var);
@@ -3407,13 +3353,13 @@ Vinecop::inverse_rosenblatt_impl(const Eigen::MatrixXd& u,
         }
 
         // inverse Rosenblatt transform simulates data for conditional pair
-        hinv2(tree, var) = edge_copula.hinv2_continuous(U_e);
+        hinv2(tree, var) = edge_copula.hinv2(U_e);
 
         // if required at a later stage, also calculate hfunc1
         if (var < static_cast<ptrdiff_t>(d_) - 1) {
           if (structure.needed_hfunc1(tree, var)) {
             U_e.col(0) = hinv2(tree, var);
-            hfunc1(tree + 1, var) = edge_copula.hfunc1_continuous(U_e);
+            hfunc1(tree + 1, var) = edge_copula.hfunc1(U_e);
           }
         }
       }

--- a/include/vinecopulib/vinecop/implementation/rvine_trees.ipp
+++ b/include/vinecopulib/vinecop/implementation/rvine_trees.ipp
@@ -89,6 +89,20 @@ RVineTrees::default_diagonal_policy()
 inline RVineTrees::Decomposition
 RVineTrees::to_struct_array(const DiagonalPolicy& diagonal_policy) const
 {
+  check_tree_sizes();
+  return peel(diagonal_policy, true);
+}
+
+inline RVineTrees::Decomposition
+RVineTrees::to_struct_array_map(const DiagonalPolicy& diagonal_policy) const
+{
+  check_tree_sizes();
+  return peel(diagonal_policy, false);
+}
+
+inline void
+RVineTrees::check_tree_sizes() const
+{
   for (size_t t = 0; t < trunc_lvl_; ++t) {
     if (trees_[t].size() != d_ - 1 - t) {
       throw std::runtime_error(
@@ -98,7 +112,6 @@ RVineTrees::to_struct_array(const DiagonalPolicy& diagonal_policy) const
         std::to_string(trees_[t].size()) + ".");
     }
   }
-  return peel(diagonal_policy, true);
 }
 
 //! @brief Shared leaf-peeling: fills the R-vine matrix column by column.
@@ -110,6 +123,7 @@ RVineTrees::peel(const DiagonalPolicy& diagonal_policy,
 
   std::vector<size_t> order(d_);
   TriangularArray<size_t> struct_array(d_, trunc_lvl_);
+  TriangularArray<PairCopulaLocation> pair_copula_locations(d_, trunc_lvl_);
   std::vector<std::vector<Bicop>> pair_copulas;
   if (carry_copulas) {
     pair_copulas.resize(trunc_lvl_);
@@ -162,6 +176,8 @@ RVineTrees::peel(const DiagonalPolicy& diagonal_policy,
         if (diag != ed.a)
           pair_copulas[t - 1][col].flip();
       }
+      pair_copula_locations(t - 1,
+                            col) = { t - 1, e.source_edge, diag != ed.a };
       check_set = ed.C;
       tree.degrees[e.node1]--;
       tree.degrees[e.node2]--;
@@ -193,6 +209,8 @@ RVineTrees::peel(const DiagonalPolicy& diagonal_policy,
           if (diag != ed.a)
             pair_copulas[tree_idx][col].flip();
         }
+        pair_copula_locations(tree_idx,
+                              col) = { tree_idx, e.source_edge, diag != ed.a };
         check_set = ed.C;
         ltree.degrees[e.node1]--;
         ltree.degrees[e.node2]--;
@@ -210,7 +228,8 @@ RVineTrees::peel(const DiagonalPolicy& diagonal_policy,
   order[d_ - 1] = struct_array(0, d_ - 2);
   return Decomposition{ std::move(order),
                         std::move(struct_array),
-                        std::move(pair_copulas) };
+                        std::move(pair_copulas),
+                        std::move(pair_copula_locations) };
 }
 
 //! @brief Builds the map from `(variable, conditioning ∪ partner)` to the edge
@@ -268,8 +287,10 @@ RVineTrees::trees_to_augmented() const
     atree.edges.reserve(edges.size());
     if (t == 0) {
       check_missing_vars(edges, d_);
-      for (const auto& ed : edges)
-        atree.edges.push_back({ ed.a, ed.b, &ed, false });
+      for (size_t i = 0; i < edges.size(); ++i) {
+        const auto& ed = edges[i];
+        atree.edges.push_back({ ed.a, ed.b, i, &ed, false });
+      }
       atree.degrees.assign(d_ + 1, 0); // 1-based labels; index 0 unused
     } else {
       auto lookup = build_lookup(augmented[t - 1].edges);
@@ -287,7 +308,7 @@ RVineTrees::trees_to_augmented() const
           problem += ")";
           throw std::runtime_error(problem);
         }
-        atree.edges.push_back({ it1->second, it2->second, &ed, false });
+        atree.edges.push_back({ it1->second, it2->second, i, &ed, false });
       }
       atree.degrees.assign(augmented[t - 1].edges.size(), 0);
     }

--- a/include/vinecopulib/vinecop/rvine_trees.hpp
+++ b/include/vinecopulib/vinecop/rvine_trees.hpp
@@ -82,12 +82,21 @@ public:
     std::function<size_t(size_t col,
                          const std::vector<std::vector<size_t>>& leaf_edges)>;
 
-  //! @brief The result of a copula-aware `to_struct_array()`.
+  //! @brief The source of a pair copula in a matrix representation.
+  struct PairCopulaLocation
+  {
+    size_t tree{ 0 };
+    size_t edge{ 0 };
+    bool flipped{ false };
+  };
+
+  //! @brief The result of `to_struct_array()`.
   struct Decomposition
   {
     std::vector<size_t> order;
     TriangularArray<size_t> struct_array;
     std::vector<std::vector<Bicop>> pair_copulas; //!< indexed `[tree][edge]`
+    TriangularArray<PairCopulaLocation> pair_copula_locations;
   };
 
   //! @brief One edge of the augmented (line-graph) view: its two incident node
@@ -96,6 +105,7 @@ public:
   {
     size_t node1{ 0 };
     size_t node2{ 0 };
+    size_t source_edge{ 0 };
     const Edge* edge{ nullptr };
     bool consumed{ false };
   };
@@ -137,6 +147,10 @@ public:
   Decomposition to_struct_array(
     const DiagonalPolicy& diagonal_policy = default_diagonal_policy()) const;
 
+  //! @brief Converts back to matrix form without copying pair copulas.
+  Decomposition to_struct_array_map(
+    const DiagonalPolicy& diagonal_policy = default_diagonal_policy()) const;
+
   size_t get_dim() const { return d_; }
   size_t get_trunc_lvl() const { return trunc_lvl_; }
 
@@ -147,6 +161,7 @@ private:
 
   std::map<std::pair<size_t, std::vector<size_t>>, size_t> build_lookup(
     const std::vector<AugmentedEdge>& edges) const;
+  void check_tree_sizes() const;
   void check_missing_vars(const std::vector<Edge>& edges, size_t d) const;
   std::vector<AugmentedTree> trees_to_augmented() const;
   Decomposition peel(const DiagonalPolicy& diagonal_policy,

--- a/test/src_test/include/test_rvine_structure.hpp
+++ b/test/src_test/include/test_rvine_structure.hpp
@@ -89,6 +89,53 @@ TEST(rvine_structure, rvine_trees_works)
   auto rt = rvt.to_struct_array();
   EXPECT_EQ(order, rt.order);
   EXPECT_EQ(struct_array, rt.struct_array);
+  auto map = rvt.to_struct_array_map();
+  EXPECT_TRUE(map.pair_copulas.empty());
+  for (size_t tree = 0; tree < struct_array.get_trunc_lvl(); ++tree) {
+    for (size_t edge = 0; edge < order.size() - 1 - tree; ++edge) {
+      auto location = map.pair_copula_locations(tree, edge);
+      EXPECT_EQ(location.tree, tree);
+      EXPECT_EQ(location.edge, edge);
+      EXPECT_FALSE(location.flipped);
+    }
+  }
+
+  // The source map reconstructs exactly the pair copulas carried and flipped
+  // by the materializing path, including under a different diagonal policy.
+  std::vector<std::vector<Bicop>> pair_copulas(order.size() - 1);
+  for (size_t tree = 0; tree < order.size() - 1; ++tree) {
+    pair_copulas[tree].resize(order.size() - 1 - tree);
+    for (size_t edge = 0; edge < pair_copulas[tree].size(); ++edge) {
+      Eigen::VectorXd parameters(3);
+      parameters << 0.2 + 0.01 * edge, 0.8 - 0.01 * tree, 2.0;
+      pair_copulas[tree][edge] = Bicop(BicopFamily::tawn, 0, parameters);
+    }
+  }
+  auto reverse_policy = [](size_t,
+                           const std::vector<std::vector<size_t>>& leaves) {
+    return leaves.back().back();
+  };
+  auto carried = RVineTrees(order, struct_array, pair_copulas)
+                   .to_struct_array(reverse_policy);
+  auto mapped = rvt.to_struct_array_map(reverse_policy);
+  bool has_flip = false;
+  for (size_t tree = 0; tree < struct_array.get_trunc_lvl(); ++tree) {
+    for (size_t edge = 0; edge < order.size() - 1 - tree; ++edge) {
+      auto location = mapped.pair_copula_locations(tree, edge);
+      auto reconstructed = pair_copulas[location.tree][location.edge];
+      if (location.flipped) {
+        reconstructed.flip();
+        has_flip = true;
+      }
+      EXPECT_EQ(reconstructed.get_family(),
+                carried.pair_copulas[tree][edge].get_family());
+      EXPECT_EQ(reconstructed.get_rotation(),
+                carried.pair_copulas[tree][edge].get_rotation());
+      EXPECT_TRUE(reconstructed.get_parameters().isApprox(
+        carried.pair_copulas[tree][edge].get_parameters()));
+    }
+  }
+  EXPECT_TRUE(has_flip);
 
   // RVineStructure <-> RVineTrees round-trips
   RVineStructure rvs(order, struct_array);

--- a/test/src_test/include/test_rvine_structure.hpp
+++ b/test/src_test/include/test_rvine_structure.hpp
@@ -107,14 +107,15 @@ TEST(rvine_structure, rvine_trees_works)
     pair_copulas[tree].resize(order.size() - 1 - tree);
     for (size_t edge = 0; edge < pair_copulas[tree].size(); ++edge) {
       Eigen::VectorXd parameters(3);
-      parameters << 0.2 + 0.01 * edge, 0.8 - 0.01 * tree, 2.0;
+      parameters << 0.2 + 0.01 * static_cast<double>(edge),
+        0.8 - 0.01 * static_cast<double>(tree), 2.0;
       pair_copulas[tree][edge] = Bicop(BicopFamily::tawn, 0, parameters);
     }
   }
-  auto reverse_policy = [](size_t,
-                           const std::vector<std::vector<size_t>>& leaves) {
-    return leaves.back().back();
-  };
+  auto reverse_policy =
+    [](size_t, const std::vector<std::vector<size_t>>& leaves) noexcept {
+      return leaves.back().back();
+    };
   auto carried = RVineTrees(order, struct_array, pair_copulas)
                    .to_struct_array(reverse_policy);
   auto mapped = rvt.to_struct_array_map(reverse_policy);

--- a/test/src_test/include/test_vinecop_class.hpp
+++ b/test/src_test/include/test_vinecop_class.hpp
@@ -537,6 +537,131 @@ make_clayton_dvine(size_t d, double par_value = 4.0, int rotation = 0)
 }
 }
 
+TEST_F(VinecopTest, reoriented_transforms_match_materialized_model)
+{
+  const size_t d = 5;
+  auto pcs = Vinecop::make_pair_copula_store(d);
+  auto clayton_par = Eigen::VectorXd::Constant(1, 2.0);
+  for (size_t tree = 0; tree < pcs.size(); ++tree) {
+    for (size_t edge = 0; edge < pcs[tree].size(); ++edge) {
+      int rotation = static_cast<int>(90 * ((tree + edge) % 4));
+      pcs[tree][edge] = Bicop(BicopFamily::clayton, rotation, clayton_par);
+    }
+  }
+  Eigen::VectorXd tawn_par(3);
+  tawn_par << 0.3, 0.8, 2.0;
+  pcs[0][0] = Bicop(BicopFamily::tawn, 90, tawn_par);
+
+  std::vector<size_t> order{ 1, 2, 3, 4, 5 };
+  Vinecop model(DVineStructure(order), pcs);
+  std::vector<size_t> conditioning_set{ 1, 2 };
+  Vinecop materialized = model;
+  materialized.reorient(conditioning_set);
+
+  auto w = tools_stats::simulate_uniform(50, d, false, { 41 });
+  auto expected_inverse = materialized.inverse_rosenblatt(w, 2);
+  auto actual_inverse = model.inverse_rosenblatt(w, conditioning_set, 2);
+  EXPECT_TRUE(all_close(actual_inverse, expected_inverse, 1e-10, 1e-10));
+
+  auto expected = materialized.rosenblatt(expected_inverse, 2, false);
+  auto actual = model.rosenblatt(expected_inverse, conditioning_set, 2, false);
+  EXPECT_TRUE(all_close(actual, expected, 1e-10, 1e-10));
+  EXPECT_TRUE(all_close(actual, w, 1e-6, 1e-6));
+
+  // The view-based transform leaves the model representation untouched.
+  EXPECT_EQ(model.get_order(), order);
+
+  // Requesting the existing tail is exactly the original transform.
+  std::vector<size_t> current_tail{ 5 };
+  EXPECT_TRUE(all_close(model.inverse_rosenblatt(w, current_tail),
+                        model.inverse_rosenblatt(w),
+                        1e-12,
+                        1e-12));
+  EXPECT_TRUE(
+    all_close(model.rosenblatt(expected_inverse, current_tail, 1, false),
+              model.rosenblatt(expected_inverse, 1, false),
+              1e-12,
+              1e-12));
+}
+
+TEST_F(VinecopTest, reoriented_transforms_handle_discrete_variables)
+{
+  const size_t d = 4;
+  auto pcs = Vinecop::make_pair_copula_store(d);
+  auto par = Eigen::VectorXd::Constant(1, 1.5);
+  for (size_t tree = 0; tree < pcs.size(); ++tree) {
+    for (auto& pc : pcs[tree])
+      pc = Bicop(BicopFamily::clayton, tree % 2 == 0 ? 90 : 270, par);
+  }
+  std::vector<std::string> var_types{ "d", "c", "d", "c" };
+  Vinecop model(DVineStructure({ 1, 2, 3, 4 }), pcs, var_types);
+  std::vector<size_t> conditioning_set{ 1 };
+  Vinecop materialized = model;
+  materialized.reorient(conditioning_set);
+
+  auto values = tools_stats::simulate_uniform(60, d, false, { 43 });
+  Eigen::MatrixXd data(values.rows(), d + 2);
+  data.leftCols(d) = values;
+  data.col(d) = 0.7 * values.col(0);
+  data.col(d + 1) = 0.7 * values.col(2);
+
+  EXPECT_TRUE(all_close(model.rosenblatt(data, conditioning_set, 2, false),
+                        materialized.rosenblatt(data, 2, false),
+                        1e-12,
+                        1e-12));
+  EXPECT_TRUE(
+    all_close(model.rosenblatt(data, conditioning_set, 2, true, { 47 }),
+              materialized.rosenblatt(data, 2, true, { 47 }),
+              1e-12,
+              1e-12));
+
+  auto w = tools_stats::simulate_uniform(60, d, false, { 53 });
+  EXPECT_TRUE(all_close(model.inverse_rosenblatt(w, conditioning_set, 2),
+                        materialized.inverse_rosenblatt(w, 2),
+                        1e-12,
+                        1e-12));
+  EXPECT_EQ(model.get_var_types(), var_types);
+}
+
+TEST_F(VinecopTest, reoriented_transforms_handle_tll_without_materializing_grid)
+{
+  auto training_data =
+    Bicop(BicopFamily::gaussian, 0, Eigen::VectorXd::Constant(1, 0.6))
+      .simulate(300, false, { 59 });
+  Bicop tll(training_data, FitControlsBicop({ BicopFamily::tll }));
+  auto pcs = Vinecop::make_pair_copula_store(3);
+  for (auto& tree : pcs)
+    for (auto& pc : tree)
+      pc = tll;
+
+  Vinecop model(DVineStructure({ 1, 2, 3 }), pcs);
+  std::vector<size_t> conditioning_set{ 1 };
+  Vinecop materialized = model;
+  materialized.reorient(conditioning_set);
+
+  auto w = tools_stats::simulate_uniform(20, 3, false, { 61 });
+  auto expected_inverse = materialized.inverse_rosenblatt(w);
+  auto actual_inverse = model.inverse_rosenblatt(w, conditioning_set);
+  EXPECT_TRUE(all_close(actual_inverse, expected_inverse, 1e-8, 1e-8));
+  EXPECT_TRUE(
+    all_close(model.rosenblatt(actual_inverse, conditioning_set, 1, false),
+              materialized.rosenblatt(expected_inverse, 1, false),
+              1e-8,
+              1e-8));
+}
+
+TEST_F(VinecopTest, reoriented_transforms_validate_conditioning_set)
+{
+  auto model = make_clayton_dvine(4, 2.0);
+  auto u = tools_stats::simulate_uniform(10, 4, false, { 67 });
+  EXPECT_ANY_THROW(model.rosenblatt(u, std::vector<size_t>{}, 1, false));
+  EXPECT_ANY_THROW(model.inverse_rosenblatt(u, std::vector<size_t>{ 2, 2 }));
+  EXPECT_ANY_THROW(model.rosenblatt(u, std::vector<size_t>{ 5 }, 1, false));
+
+  model.truncate(2);
+  EXPECT_ANY_THROW(model.inverse_rosenblatt(u, std::vector<size_t>{ 1 }));
+}
+
 TEST_F(VinecopTest, simulate_conditional_is_correct)
 {
   size_t d = 4;

--- a/test/src_test/include/test_vinecop_class.hpp
+++ b/test/src_test/include/test_vinecop_class.hpp
@@ -452,6 +452,31 @@ TEST_F(VinecopTest, inverse_rosenblatt_does_not_mutate_discrete_model)
                         1e-12));
 }
 
+TEST_F(VinecopTest, bicop_view_as_continuous_matches_materialized_copula)
+{
+  Eigen::VectorXd parameters(3);
+  parameters << 0.3, 0.8, 2.0;
+  auto u = tools_stats::simulate_uniform(40, 2, false, { 37 });
+
+  for (int rotation : { 0, 90, 180, 270 }) {
+    Bicop bicop(BicopFamily::tawn, rotation, parameters, { "d", "c" });
+    for (bool flipped : { false, true }) {
+      Bicop materialized = bicop;
+      if (flipped)
+        materialized.flip();
+      materialized = materialized.as_continuous();
+      auto view = BicopView(bicop, flipped).as_continuous();
+
+      EXPECT_EQ(view.get_var_types(), std::vector<std::string>({ "c", "c" }));
+      EXPECT_TRUE(
+        all_close(view.hfunc1(u), materialized.hfunc1(u), 1e-10, 1e-10));
+      EXPECT_TRUE(
+        all_close(view.hfunc2(u), materialized.hfunc2(u), 1e-10, 1e-10));
+      EXPECT_TRUE(all_close(view.hinv2(u), materialized.hinv2(u), 1e-8, 1e-8));
+    }
+  }
+}
+
 TEST_F(VinecopTest, inverse_rosenblatt_is_safe_for_concurrent_calls)
 {
   const size_t d = 5;
@@ -657,6 +682,7 @@ TEST_F(VinecopTest, reoriented_transforms_validate_conditioning_set)
   EXPECT_ANY_THROW(model.rosenblatt(u, std::vector<size_t>{}, 1, false));
   EXPECT_ANY_THROW(model.inverse_rosenblatt(u, std::vector<size_t>{ 2, 2 }));
   EXPECT_ANY_THROW(model.rosenblatt(u, std::vector<size_t>{ 5 }, 1, false));
+  EXPECT_ANY_THROW(model.inverse_rosenblatt(u, std::vector<size_t>{ 1, 3 }));
 
   model.truncate(2);
   EXPECT_ANY_THROW(model.inverse_rosenblatt(u, std::vector<size_t>{ 1 }));
@@ -941,6 +967,7 @@ TEST_F(VinecopTest, reorient_preserves_model)
     vc.select(data, c);
   }
   auto pdf0 = vc.pdf(data);
+  auto w = tools_stats::simulate_uniform(50, d, false, { 71 });
 
   size_t feasible = 0;
   std::vector<std::vector<size_t>> candidates{
@@ -957,6 +984,12 @@ TEST_F(VinecopTest, reorient_preserves_model)
     ++feasible;
     // reorient is a pure relabeling: the density is unchanged (up to fp)
     EXPECT_TRUE(all_close(vr.pdf(data), pdf0, 1e-6, 1e-6));
+    EXPECT_TRUE(all_close(
+      vc.inverse_rosenblatt(w, B), vr.inverse_rosenblatt(w), 1e-10, 1e-10));
+    EXPECT_TRUE(all_close(vc.rosenblatt(data, B, 1, false),
+                          vr.rosenblatt(data, 1, false),
+                          1e-10,
+                          1e-10));
     // the conditioning set is now the tail of the order
     auto o = vr.get_order();
     std::vector<size_t> tail(o.end() - static_cast<ptrdiff_t>(B.size()),

--- a/test/src_test/include/test_vinecop_class.hpp
+++ b/test/src_test/include/test_vinecop_class.hpp
@@ -456,7 +456,7 @@ TEST_F(VinecopTest, bicop_view_as_continuous_matches_materialized_copula)
 {
   Eigen::VectorXd parameters(3);
   parameters << 0.3, 0.8, 2.0;
-  auto u = tools_stats::simulate_uniform(40, 2, false, { 37 });
+  auto eval_data = tools_stats::simulate_uniform(40, 2, false, { 37 });
 
   for (int rotation : { 0, 90, 180, 270 }) {
     Bicop bicop(BicopFamily::tawn, rotation, parameters, { "d", "c" });
@@ -468,11 +468,12 @@ TEST_F(VinecopTest, bicop_view_as_continuous_matches_materialized_copula)
       auto view = BicopView(bicop, flipped).as_continuous();
 
       EXPECT_EQ(view.get_var_types(), std::vector<std::string>({ "c", "c" }));
-      EXPECT_TRUE(
-        all_close(view.hfunc1(u), materialized.hfunc1(u), 1e-10, 1e-10));
-      EXPECT_TRUE(
-        all_close(view.hfunc2(u), materialized.hfunc2(u), 1e-10, 1e-10));
-      EXPECT_TRUE(all_close(view.hinv2(u), materialized.hinv2(u), 1e-8, 1e-8));
+      EXPECT_TRUE(all_close(
+        view.hfunc1(eval_data), materialized.hfunc1(eval_data), 1e-10, 1e-10));
+      EXPECT_TRUE(all_close(
+        view.hfunc2(eval_data), materialized.hfunc2(eval_data), 1e-10, 1e-10));
+      EXPECT_TRUE(all_close(
+        view.hinv2(eval_data), materialized.hinv2(eval_data), 1e-8, 1e-8));
     }
   }
 }
@@ -678,14 +679,19 @@ TEST_F(VinecopTest, reoriented_transforms_handle_tll_without_materializing_grid)
 TEST_F(VinecopTest, reoriented_transforms_validate_conditioning_set)
 {
   auto model = make_clayton_dvine(4, 2.0);
-  auto u = tools_stats::simulate_uniform(10, 4, false, { 67 });
-  EXPECT_ANY_THROW(model.rosenblatt(u, std::vector<size_t>{}, 1, false));
-  EXPECT_ANY_THROW(model.inverse_rosenblatt(u, std::vector<size_t>{ 2, 2 }));
-  EXPECT_ANY_THROW(model.rosenblatt(u, std::vector<size_t>{ 5 }, 1, false));
-  EXPECT_ANY_THROW(model.inverse_rosenblatt(u, std::vector<size_t>{ 1, 3 }));
+  auto eval_data = tools_stats::simulate_uniform(10, 4, false, { 67 });
+  EXPECT_ANY_THROW(
+    model.rosenblatt(eval_data, std::vector<size_t>{}, 1, false));
+  EXPECT_ANY_THROW(
+    model.inverse_rosenblatt(eval_data, std::vector<size_t>{ 2, 2 }));
+  EXPECT_ANY_THROW(
+    model.rosenblatt(eval_data, std::vector<size_t>{ 5 }, 1, false));
+  EXPECT_ANY_THROW(
+    model.inverse_rosenblatt(eval_data, std::vector<size_t>{ 1, 3 }));
 
   model.truncate(2);
-  EXPECT_ANY_THROW(model.inverse_rosenblatt(u, std::vector<size_t>{ 1 }));
+  EXPECT_ANY_THROW(
+    model.inverse_rosenblatt(eval_data, std::vector<size_t>{ 1 }));
 }
 
 TEST_F(VinecopTest, simulate_conditional_is_correct)


### PR DESCRIPTION
## Summary

- add conditioning-set overloads for the Rosenblatt and inverse Rosenblatt transforms
- evaluate through non-owning vine and pair-copula views, including flipped and continuous evaluations, without mutating the fitted model or materializing TLL grids
- emit pair-copula source locations and flip indicators directly while reorienting RVineTrees
- cover parametric, asymmetric, discrete, threaded, TLL, validation, parity, and round-trip cases

## Tests

- Release precompiled build
- bin/test_all (655 tests passed)