### PR TITLE
docs: sync AGENTS.md and setup.dox with the C++17/CMake build

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ across PRs.
 
 ## Project overview
 
-`vinecopulib` is a **header-only C++14 library** for vine-copula and
+`vinecopulib` is a **header-only C++17 library** for vine-copula and
 bivariate-copula inference, built on
 [Eigen](https://eigen.tuxfamily.org/). It provides high-performance
 implementations of the core features of the
@@ -103,7 +103,7 @@ Three design principles inform the rest of this file:
 ## API stability & releases
 
 `vinecopulib` follows **semantic versioning** (`MAJOR.MINOR.PATCH`;
-currently 0.7.3). Because the R and Python interfaces pin a tag of this
+currently 0.8.0). Because the R and Python interfaces pin a tag of this
 repo, public-API changes are real breaks for downstream users.
 
 - **Record every change in [NEWS.md](NEWS.md).** Each release has
@@ -112,9 +112,9 @@ repo, public-API changes are real breaks for downstream users.
   There is no separate `CHANGELOG.md`.
 - **Bump both version macros in
   [version.hpp](include/vinecopulib/version.hpp)** on release:
-  `VINECOPULIB_VERSION` (encoded integer, `000703` for 0.7.3 —
+  `VINECOPULIB_VERSION` (encoded integer, `800` for 0.8.0 —
   `major*100000 + minor*100 + patch`) and `VINECOPULIB_LIB_VERSION`
-  (string, `"0_7_3"`).
+  (string, `"x_y[_z]"` — currently `"0_8"`).
 - **Prefer deprecation over a hard break.** The `DEPRECATED` macro
   (defined in
   [vinecop/fit_controls.hpp](include/vinecopulib/vinecop/fit_controls.hpp))
@@ -133,7 +133,7 @@ repo, public-API changes are real breaks for downstream users.
 vinecopulib/
   AGENTS.md, CLAUDE.md           # this file + thin pointer (`@AGENTS.md`)
   README.md, NEWS.md, LICENSE, .zenodo.json
-  CMakeLists.txt                 # 19-line entry point; includes the cmake/ modules
+  CMakeLists.txt                 # 24-line entry point; includes the cmake/ modules
   .clang-format, .clang-tidy     # Mozilla style; advisory tidy checks
   codecov.yml, .codacy.yml       # coverage / static-analysis service config
 
@@ -165,7 +165,7 @@ vinecopulib/
         tools_interpolation.hpp  # InterpolationGrid (TLL)
         tools_serialization.hpp, nlohmann_json.hpp # JSON
         tools_thread.hpp, tools_interface.hpp, tools_batch.hpp  # parallelism
-        tools_integration.hpp, tools_constants.hpp, tools_optional.hpp
+        tools_integration.hpp, tools_constants.hpp
         triangular_array.hpp     # TriangularArray<T> (vine container)
         fit_controls.hpp         # FitControlsConfig (optional-field builder)
         implementation/*.ipp
@@ -187,7 +187,7 @@ There is **no** `src/` of library `.cpp` files, **no** `lib/` /
 
 ## Build & tooling
 
-CMake **≥ 3.10**, C++ **14**. The 19-line root
+CMake **≥ 3.14**, C++ **17**. The 24-line root
 [CMakeLists.txt](CMakeLists.txt) sets the standard, the project version,
 and includes the `cmake/` modules in order.
 
@@ -216,12 +216,16 @@ a `.cpp` under the generated tree.
 | --- | --- | --- |
 | `VINECOPULIB_PRECOMPILED` | `OFF` | Compile a real library vs. header-only `INTERFACE`. |
 | `BUILD_TESTING` | `ON` | Build the GoogleTest suite (fetches GoogleTest + finds Rscript). |
-| `OPT_ASAN` | `ON` | Add `-fsanitize=address,undefined` to Debug builds. |
-| `CODE_COVERAGE` | `OFF` | Add `--coverage` flags (Debug + `BUILD_TESTING`, non-Windows). |
-| `STRICT_COMPILER` | `OFF` | GCC: `-Werror` plus a long list of `-W…` flags. |
-| `BUILD_DOC` | `OFF` | Add the Doxygen `doc` target. |
+| `VINECOPULIB_SANITIZERS` | `OFF` | Add `-fsanitize=address,undefined` to Debug builds. |
+| `VINECOPULIB_CODE_COVERAGE` | `OFF` | Add `--coverage` flags (Debug + `BUILD_TESTING`, non-Windows). |
+| `VINECOPULIB_STRICT_COMPILER` | `OFF` | GCC: `-Werror` plus a long list of `-W…` flags. |
+| `VINECOPULIB_BUILD_DOC` | `OFF` | Add the Doxygen `doc` target. |
+| `VINECOPULIB_BUILD_BENCHMARKS` | `OFF` | Build the benchmark suite (fetches google/benchmark). |
+| `VINECOPULIB_NATIVE_ARCH` | `OFF` | Tune Release for the build machine's CPU (not redistributable). |
 
-Default `CMAKE_BUILD_TYPE` is `Release` when unset.
+Default `CMAKE_BUILD_TYPE` is `Release` when unset. The developer-facing
+switches apply to a top-level build only, so consumers pulling the project in
+via `add_subdirectory` / `FetchContent` keep their own settings.
 
 ### Dependencies
 
@@ -230,10 +234,13 @@ Discovered in
 
 - **Eigen3** — `find_package(Eigen3 REQUIRED CONFIG)`; or set
   `EIGEN3_INCLUDE_DIR`. Target: `Eigen3::Eigen`.
-- **Boost ≥ 1.56** — CONFIG mode then MODULE fallback; or set
-  `Boost_INCLUDE_DIRS`. Used for math distributions (Student-t etc.), RNG
-  (`boost::random`), `boost::optional` (C++14), and `odeint`
-  (integration). Target: `Boost::boost`.
+- **Boost ≥ 1.75** — CONFIG mode then MODULE fallback; or set
+  `Boost_INCLUDE_DIRS`. Target: `Boost::boost`. Deliberately narrowed to three
+  header-only components — keep it that way, and prefer the standard library
+  when it suffices: **Graph** (`adjacency_list` and the spanning-tree engines
+  behind `tree_algorithm`), **Math** (distributions, constants, special
+  functions, `quadrature::tanh_sinh` for 1-d integration, `tools::minima`),
+  and **Random** (`mt19937`, behind QRNG scrambling and structure simulation).
 - **wdm 0.2.6** — `find_package(wdm 0.2.6 QUIET)` with a **FetchContent
   fallback** that clones `tnagler/wdm`. Installed under
   `<prefix>/include/vinecopulib/wdm/`.
@@ -241,15 +248,17 @@ Discovered in
 - **GoogleTest 1.14** — FetchContent, only when `BUILD_TESTING`.
 - **Rscript** (optional) — enables the R parity tests; see
   [cmake/findR.cmake](cmake/findR.cmake).
-- **Doxygen** — only when `BUILD_DOC`.
+- **Doxygen** — only when `VINECOPULIB_BUILD_DOC`.
 
 Global compile definitions set in
 [cmake/compilerDefOpt.cmake](cmake/compilerDefOpt.cmake) (and mirrored in
 the umbrella header): `BOOST_NO_AUTO_PTR`,
 `BOOST_ALLOW_DEPRECATED_HEADERS`, `BOOST_MATH_PROMOTE_DOUBLE_POLICY=false`,
-`BOOST_ALL_NO_LIB`, `USE_BOOST`. Release flags `-O3 -march=native -DNDEBUG`
-(an `-mcpu=apple-m1` variant on Apple silicon); always-on warnings
-`-Wall -Wextra -Werror=return-type`.
+`BOOST_ALL_NO_LIB`, `USE_BOOST`. Release flags `-O3 -DNDEBUG`, Debug
+`-g -O0 -DDEBUG`; always-on warnings `-Wall -Wextra -Werror=return-type`.
+`-march=native` (`-mcpu=apple-m1` on Apple silicon) is opt-in behind
+`VINECOPULIB_NATIVE_ARCH`, since the result only runs on CPUs at least as new
+as the builder's.
 
 ### Build / test / install
 
@@ -287,8 +296,8 @@ up via `gtest_discover_tests(test_all)` on non-Windows and
   (`bugprone-*`, `performance-*`, `modernize-*`, `cppcoreguidelines-*`,
   …) but is **advisory**: the CI clang-tidy job is commented out and not
   enforced.
-- **docs** — `cmake .. -DBUILD_DOC=ON && make doc` runs Doxygen. The
-  website is built with [m.css](https://github.com/mosra/m.css) via
+- **docs** — `cmake .. -DVINECOPULIB_BUILD_DOC=ON && make doc` runs Doxygen.
+  The website is built with [m.css](https://github.com/mosra/m.css) via
   `doxygen.py docs/Doxyfile-mcss`; see
   [docs/create-docs.md](docs/create-docs.md).
 
@@ -404,7 +413,7 @@ For any behavior change:
   parameters that are stored (the `FitControls` setters) are likewise by value
   and `std::move`d into the member. Converting either kind to `const&` is a
   performance regression, not a cleanup, even though clang-tidy may suggest it.
-- **C++14 + Eigen.** `Eigen::MatrixXd` / `VectorXd` are the workhorse
+- **C++17 + Eigen.** `Eigen::MatrixXd` / `VectorXd` are the workhorse
   types; prefer `.array()`, `.unaryExpr`, and the helpers in
   [misc/tools_eigen.hpp](include/vinecopulib/misc/tools_eigen.hpp)
   (`trim`, `remove_nans`, `unaryExpr_or_nan`, …) over hand-rolled loops.
@@ -505,9 +514,9 @@ Infrastructure shared across both modules:
   directly; always pull it implicitly through `tools_interface.hpp`.**
 - **`triangular_array.hpp`** — `TriangularArray<T>`, the ragged container
   that mirrors a (possibly truncated) vine.
-- **`tools_eigen`, `tools_stl`, `tools_integration`, `tools_constants`,
-  `tools_optional`** — Eigen/STL helpers, 1-d numerical integration
-  (Boost.odeint), constants, and a C++14/17 `optional` shim.
+- **`tools_eigen`, `tools_stl`, `tools_integration`, `tools_constants`** —
+  Eigen/STL helpers, 1-d numerical integration (Boost.Math `tanh_sinh`
+  quadrature), and constants.
 
 ## Public API
 
@@ -533,7 +542,7 @@ headers (`vinecopulib/bicop/class.hpp`, etc.).
 GoogleTest, under [test/](test/). The layout is split: thin
 `test/test_<topic>.cpp` translation units register the suites, while the
 actual logic lives in `test/src_test/*.cpp` with fixtures in
-`test/src_test/include/*.hpp`. The executable list (12 binaries, including
+`test/src_test/include/*.hpp`. The executable list (13 binaries, including
 the aggregate `test_all`) is in
 [cmake/buildTargets.cmake](cmake/buildTargets.cmake); each links
 `gtest vinecopulib … src_test`.
@@ -543,9 +552,9 @@ Conventions:
 - **Run** `bin/test_all` (or `ctest`) from the build directory after
   `make`.
 - **Coverage** is collected on the Ubuntu/GNU Debug CI build
-  (`-DCODE_COVERAGE=ON`, target `vinecopulib_coverage`) and uploaded to
-  Codecov; [codecov.yml](codecov.yml) ignores `test/` and the vendored
-  `nlohmann_json.hpp`.
+  (`-DVINECOPULIB_CODE_COVERAGE=ON`, target `vinecopulib_coverage`) and
+  uploaded to Codecov; [codecov.yml](codecov.yml) ignores `test/` and the
+  vendored `nlohmann_json.hpp`.
 - **R parity tests** are optional: with Rscript available, the
   `cmake/templates/*.R` scripts cross-check parametric bicop / vinecop
   results against the VineCopula R package.

--- a/docs/setup.dox
+++ b/docs/setup.dox
@@ -14,9 +14,9 @@
 
 To build the library, you'll need at minimum:
 
-   - [a C++11-compatible compiler](https://en.wikipedia.org/wiki/List_of_compilers#C.2B.2B_compilers) (tested with GCC 6.3.0 and Clang 3.5.0 on Linux and AppleClang 8.0.0 on OSX)
-   - [CMake 3.2 (or later)](https://cmake.org/)
-   - [Boost 1.71 (or later)](http://www.boost.org/)
+   - [a C++17-compatible compiler](https://en.wikipedia.org/wiki/List_of_compilers#C.2B.2B_compilers) (CI covers GCC and Clang on Linux, AppleClang on macOS, and MSVC on Windows)
+   - [CMake 3.14 (or later)](https://cmake.org/)
+   - [Boost 1.75 (or later)](http://www.boost.org/)
    - [Eigen 3.3 (or later)](http://eigen.tuxfamily.org/index.php?title=Main_Page)
    - [wdm](https://github.com/tnagler/wdm)
 
@@ -98,7 +98,7 @@ To install the library without unit tests, the `MakeFile` can be created via
 `cmake .. -DBUILD_TESTING=OFF`.
 Additionally, a `Debug` mode is available via
 `cmake .. -DCMAKE_BUILD_TYPE=Debug`; to enable strict compiler warnings, use
-`-DSTRICT_COMPILER=ON`.
+`-DVINECOPULIB_STRICT_COMPILER=ON`.
 Finally, note that using `-DCMAKE_EXPORT_COMPILE_COMMANDS=ON` is useful if
 one is interested in using autocomplete or linting when working with the library.
 


### PR DESCRIPTION
> **Stacked on #714** (`refactor/slim-boost`). Review/merge that one first; GitHub will retarget this to `main` automatically once it lands.

The CMake modernization (#711) and the odeint removal (#713) left `AGENTS.md` and `docs/setup.dox` describing a build that no longer exists. `AGENTS.md` is what coding agents read first and `setup.dox` is the install page, so the stale option names are worse than cosmetic: the unprefixed switches were **removed outright**, and `cmake/options.cmake` notes that passing one is now silently inert rather than an error.

It stacks on #714 rather than racing it: #714 changes *what Boost is used for*, which is precisely what the dependency section documents, so basing this on `main` would have re-staled the file the moment #714 merged. There is no file overlap between the two — #714 touches only three code files.

Documentation only — no code, CMake or CI changes. CI already uses the prefixed option names.

## What was wrong

Each corrected fact was verified against the tree, not against memory.

| Claim | Was | Now |
| --- | --- | --- |
| Language standard | C++14 | **C++17** (`CMakeLists.txt:6`) |
| CMake floor | ≥ 3.10 | **≥ 3.14** (`CMakeLists.txt:2`) |
| Sanitizers | `OPT_ASAN`, default `ON` | **`VINECOPULIB_SANITIZERS`, default `OFF`** |
| Coverage / warnings / docs | `CODE_COVERAGE`, `STRICT_COMPILER`, `BUILD_DOC` | `VINECOPULIB_*`-prefixed |
| Missing options | — | added `VINECOPULIB_BUILD_BENCHMARKS`, `VINECOPULIB_NATIVE_ARCH` |
| Release flags | `-O3 -march=native -DNDEBUG` unconditional | `-march=native` / `-mcpu=apple-m1` are **opt-in** behind `VINECOPULIB_NATIVE_ARCH` |
| Boost | ≥ 1.56, uses `boost::optional` + `odeint` | **≥ 1.75**, spelled out as the three components #714 leaves: **Graph**, **Math**, **Random** |
| `misc/tools_optional.hpp` | listed as a C++14/17 `optional` shim | **file no longer exists**; `misc/fit_controls.hpp` uses `std::optional` directly |
| Version | 0.7.3 / `000703` / `"0_7_3"` | **0.8.0 / `800` / `"0_8"`** (`version.hpp`) |
| Counts | 19-line `CMakeLists.txt`, 12 test binaries | **24 lines**, **13 binaries** (`unit_tests` in `buildTargets.cmake`) |

Boost.Graph was **not documented at all** before, despite being what backs `tree_algorithm`. The bullet now names all three components and asks that the surface stay narrow, so #714's intent is recorded where the next contributor will look.

`docs/setup.dox` additionally listed a **C++11** compiler, CMake 3.2 and Boost 1.71 as prerequisites, and documented the now-inert `-DSTRICT_COMPILER=ON`. Its "tested with" list named GCC 6.3.0 / Clang 3.5.0 / AppleClang 8.0.0 — all predating C++17 — so it now points at the CI matrix rather than naming versions the workflow does not pin.

## Deliberately left alone

- `NEWS.md:694` mentions `STRICT_COMPILER` as a historical release note — an accurate record of the release it describes.
- The `# 3.14 is the real floor: the previous 3.10 could not configure at all.` line in `AGENTS.md` is the *illustrative example* of a history-style comment, not a factual claim.
- `docs/setup.dox` also carries a consumer-facing example with `cmake_minimum_required(VERSION 3.5)` and a hardcoded `-march=native` in `CMAKE_CXX_FLAGS`. Worth a separate look — CMake 4.x errors on a `< 3.5` compatibility request, so that snippet may no longer configure for readers who copy it — but it describes the *reader's* project rather than this build, so I kept it out of a docs-sync PR.

Happy to trim any of this back if it is broader than you want in one change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
