### PR TITLE
refactor(vinecop)!: remove members deprecated since 0.3.1

### DIFF
--- a/docs/overview-vinecop.dox
+++ b/docs/overview-vinecop.dox
@@ -106,15 +106,14 @@ when `RVineStructure()` is called:
 
 @section vinecop-fit Fit and select a vine copula model
 
-The method `select_all()` performs parameter estimation and automatic
-model selection when the vine structure is unknown (i.e., it modifies the
-structure of the object), using the sequential procedure proposed by
-    [Dissman et al. (2013)](https://mediatum.ub.tum.de/doc/1079277/1079277.pdf).
-    Alternatively, `select_families()` performs parameter estimation and automatic
-    model selection for a known structure (i.e., using the structure of the
-    object). In both cases, the only mandatory argument is the data
-    (stored in a `Eigen::MatrixXd`), while controls argument allow for
-    customization of the fit.
+The method `select()` performs parameter estimation and automatic model
+selection, using the sequential procedure proposed by
+[Dissman et al. (2013)](https://mediatum.ub.tum.de/doc/1079277/1079277.pdf).
+It selects the structure as well as the families unless the object already
+carries a structure, in which case that structure is kept. `fit()` refits
+families and parameters on a fixed structure. The only mandatory argument is
+the data (stored in a `Eigen::MatrixXd`); the controls argument allows for
+customization of the fit.
 ```
 // specify the dimension of the model
 int d = 5;
@@ -122,15 +121,16 @@ int d = 5;
 // simulate dummy data
 Eigen::MatrixXd data = tools_stats::simulate_uniform(100, d);
 
-// instantiate a D-vine and select the families
+// select the structure along with the families
 Vinecop model(d);
-model.select_families(data);
+model.select(data);
 
-// alternatively, select the structure along with the families
-model.select_all(data);
+// keep a known structure and select only the families
+Vinecop model2(structure);
+model2.select(data);
 ```
 
-Note that the second argument to `select_all()` and `select_families()` is
+Note that the second argument to `select()` is
 similar to the one of `select()` for `Bicop` objects. Objects of the class
 `FitControlsVinecop` inherit from `FitControlsBicop` and extend them with
 additional data members to control the structure selection:
@@ -155,9 +155,9 @@ automatically (default is `false`).
 - `size_t num_threads` number of threads to run in parallel when fitting pair
 copulas within one tree.
 
-As mentioned [above](#set-up-a-custom-vine-copula-model), the arguments
-of `select_all()` and `select_families()` can be used as arguments to a
-    constructor allowing to instantiate a new object directly:
+As mentioned [above](#set-up-a-custom-vine-copula-model), the arguments of
+`select()` can be used as arguments to a constructor allowing to instantiate a
+new object directly:
 
 ```
 // specify the dimension of the model

--- a/include/vinecopulib/vinecop/class.hpp
+++ b/include/vinecopulib/vinecop/class.hpp
@@ -71,14 +71,6 @@ public:
            const FitControlsBicop& controls = FitControlsBicop(),
            const size_t num_threads = 1);
 
-  DEPRECATED void select_all(
-    const Eigen::MatrixXd& data,
-    const FitControlsVinecop& controls = FitControlsVinecop());
-
-  DEPRECATED void select_families(
-    const Eigen::MatrixXd& data,
-    const FitControlsVinecop& controls = FitControlsVinecop());
-
   // Getters for a single pair copula
 
   //! @return the pair copula at the given `(tree, edge)` position.
@@ -177,7 +169,7 @@ public:
   };
 
   PdfWithHfuncsResult pdf_full(Eigen::MatrixXd u,
-                               const size_t num_threads,
+                               const size_t num_threads = 1,
                                const bool keep_all = true) const;
 
   // Stats methods with per-observation parameters. `parameters` is an
@@ -190,7 +182,7 @@ public:
 
   PdfWithHfuncsResult pdf_full(Eigen::MatrixXd u,
                                const Eigen::MatrixXd& parameters,
-                               const size_t num_threads,
+                               const size_t num_threads = 1,
                                const bool keep_all = true) const;
 
   Eigen::VectorXd cdf(const Eigen::MatrixXd& u,

--- a/include/vinecopulib/vinecop/fit_controls.hpp
+++ b/include/vinecopulib/vinecop/fit_controls.hpp
@@ -10,15 +10,6 @@
 #include <limits>
 #include <vinecopulib/bicop/fit_controls.hpp>
 
-#if defined(__GNUC__) || defined(__clang__)
-#define DEPRECATED __attribute__((deprecated))
-#elif defined(_MSC_VER)
-#define DEPRECATED __declspec(deprecated)
-#else
-#pragma message("WARNING: You need to implement DEPRECATED for this compiler")
-#define DEPRECATED
-#endif
-
 namespace vinecopulib {
 //! @brief A class for controlling fits of vine copula models.
 //!
@@ -65,7 +56,6 @@ public:
   explicit FitControlsVinecop(const FitControlsConfig& config);
 
   // Getters
-  DEPRECATED size_t get_truncation_level() const;
   //! @return the truncation level (the number of trees that will be fit;
   //! pair copulas above this level are forced to independence).
   size_t get_trunc_lvl() const;
@@ -86,7 +76,6 @@ public:
   //! @return whether progress information is printed during fitting.
   bool get_show_trace() const;
 
-  DEPRECATED bool get_select_truncation_level() const;
   //! @return whether the truncation level is selected automatically via
   //! the mBICv criterion during fitting.
   bool get_select_trunc_lvl() const;
@@ -123,7 +112,6 @@ public:
   boost::random::mt19937 get_rng() const;
 
   // Setters
-  DEPRECATED void set_truncation_level(size_t trunc_lvl);
   void set_trunc_lvl(size_t trunc_lvl);
 
   void set_tree_criterion(std::string tree_criterion);
@@ -142,7 +130,6 @@ public:
 
   void set_show_trace(bool show_trace);
 
-  DEPRECATED void set_select_truncation_level(bool select_trunc_lvl);
   void set_select_trunc_lvl(bool select_trunc_lvl);
 
   void set_select_threshold(bool select_threshold);

--- a/include/vinecopulib/vinecop/implementation/class.ipp
+++ b/include/vinecopulib/vinecop/implementation/class.ipp
@@ -690,63 +690,6 @@ Vinecop::fit(const Eigen::MatrixXd& data,
   }
 }
 
-//! @brief Automatically fits and selects a vine copula model.
-//!
-//! Selection of the structure is performed using the algorithm of
-//! Dissmann, J. F., E. C. Brechmann, C. Czado, and D. Kurowicka (2013).
-//! *Selecting and estimating regular vine copulae and application to
-//! financial returns.* Computational Statistics & Data Analysis, 59 (1),
-//! 52-69.
-//!
-//! @details When at least one variable is discrete, two types of "observations"
-//! are required: the first \f$ n \times d \f$ block contains realizations of
-//! \f$ F_Y(Y), F_X(X) \f$; the second \f$ n \times d \f$ block contains
-//! realizations of \f$ F_Y(Y^-), F_X(X^-), ... \f$. The minus indicates a
-//! left-sided limit of the cdf. For continuous variables the left limit and the
-//! cdf itself coincide. For, e.g., an integer-valued variable, it holds \f$
-//! F_Y(Y^-) = F_Y(Y - 1) \f$. Continuous variables in the second block can
-//! be omitted.
-//!
-//! @param data \f$ n \times (d + k) \f$ or \f$ n \times 2d \f$ matrix of
-//!   observations, where \f$ k \f$ is the number of discrete variables.
-//! @param controls The controls to the algorithm (see `FitControlsVinecop()`).
-inline void
-Vinecop::select_all(const Eigen::MatrixXd& data,
-                    const FitControlsVinecop& controls)
-{
-  rvine_structure_ = RVineStructure(d_, static_cast<size_t>(0));
-  select(data, controls);
-}
-
-//! @brief Automatically selects all pair-copula families and fits all.
-//! parameters.
-//!
-//!
-//! @details When at least one variable is discrete, two types of "observations"
-//! are required: the first \f$ n \times d \f$ block contains realizations of
-//! \f$ F_Y(Y), F_X(X) \f$; the second \f$ n \times d \f$ block contains
-//! realizations of \f$ F_Y(Y^-), F_X(X^-), ... \f$. The minus indicates a
-//! left-sided limit of the cdf. For continuous variables the left limit and the
-//! cdf itself coincide. For, e.g., an integer-valued variable, it holds \f$
-//! F_Y(Y^-) = F_Y(Y - 1) \f$. Continuous variables in the second block can
-//! be omitted.
-//!
-//! If there are missing data (i.e., NaN entries), incomplete observations are
-//! discarded before fitting a pair-copula. This is done on a pair-by-pair basis
-//! so that the maximal available information is used.
-//!
-//! @param data \f$ n \times (d + k) \f$ or \f$ n \times 2d \f$ matrix of
-//!   observations, where \f$ k \f$ is the number of discrete variables.
-//! @param controls The controls to the algorithm (see `FitControlsVinecop()`).
-inline void
-Vinecop::select_families(const Eigen::MatrixXd& data,
-                         const FitControlsVinecop& controls)
-{
-  auto controls_trunc_lvl = controls;
-  controls_trunc_lvl.set_trunc_lvl(rvine_structure_.get_trunc_lvl());
-  select(data, controls);
-}
-
 //! @name Getters and setters
 //! @{
 


### PR DESCRIPTION
Stacked on #717 — review that first.

| Removed | Use instead |
|---|---|
| `FitControlsVinecop::get_truncation_level` | `get_trunc_lvl` |
| `FitControlsVinecop::get_select_truncation_level` | `get_select_trunc_lvl` |
| `FitControlsVinecop::set_truncation_level` | `set_trunc_lvl` |
| `FitControlsVinecop::set_select_truncation_level` | `set_select_trunc_lvl` |
| `Vinecop::select_all` | `select` |
| `Vinecop::select_families` | `select` |

Two findings worth recording in the changelog:

- **The four `FitControlsVinecop` members were declared but never defined.**
  There is no definition in `fit_controls.ipp`, so calling one has been a
  *link error*, not a deprecation warning. They have been unusable, not merely
  discouraged.
- **`Vinecop::select_families` was buggy.** It copied the controls to set the
  truncation level and then passed the *original* copy to `select()`:
  ```cpp
  auto controls_trunc_lvl = controls;
  controls_trunc_lvl.set_trunc_lvl(rvine_structure_.get_trunc_lvl());
  select(data, controls);   // <- controls, not controls_trunc_lvl
  ```
  So it never actually respected the object's structure the way its
  documentation claimed.

Those six were the `DEPRECATED` macro's only users, so the macro and its
`#pragma message("WARNING: You need to implement DEPRECATED for this compiler")`
fallback are gone as well.

## Also

- `Vinecop::pdf_full`'s `num_threads` now defaults to `1`, matching `pdf` — an
  API wart 1.0.0 would otherwise freeze. Both overloads.
- `docs/overview-vinecop.dox` taught `select_all()` / `select_families()` as the
  primary API in two places, including a code sample. Rewritten around
  `select()`; the full docs rewrite is a later PR, this just keeps the tree from
  documenting API that no longer exists.

## Downstream

Verified clear, as expected: `pyvinecopulib` uses only `preselect_families` and
`select_families` — the *non-deprecated* `FitControlsBicop`/`FitControlsVinecop`
properties, unrelated to `Vinecop::select_families`. `rvinecopulib` already uses
`set_trunc_lvl` / `set_select_trunc_lvl`. No wrapper patch needed.

## Verification

- 650 tests pass header-only, under `ctest -j32`, and with `VINECOPULIB_PRECOMPILED=ON`.
- Strict build: zero warnings.
- `git grep` finds no remaining reference to any removed name, and no `DEPRECATED` in `include/`.

(650 rather than 648 because this branch is rebased onto main, which now carries
#712's two `inverse_rosenblatt` tests.)