### PR TITLE
feat(bicop): per-row-parameter simulate()

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -396,6 +396,24 @@ For any behavior change:
   see the per-family docs on the `BicopFamily` enum in
   [bicop/family.hpp](include/vinecopulib/bicop/family.hpp) for the house
   style.
+
+  **Write for the caller, not the implementer.** Doxygen text says what a
+  method does, what its arguments mean, and what it returns — never how it is
+  computed internally. The algorithm a method delegates to, which helper it
+  calls, why a branch exists, and what it does or does not allocate are all
+  implementation details: they belong in the code, the commit message, or
+  nowhere. These comments are the downstream Python and R docstrings, so a
+  sentence that only makes sense to someone reading this file is noise to
+  every user who ends up reading it.
+
+  **Do not restate what a sibling overload already documents.** Overloads
+  differing in one argument get a short `@brief` and only the text specific to
+  them; shared semantics live once, in the base overload or in an `@name`
+  group block (see the `//! @name Stats methods with per-row parameters` group
+  in [bicop/implementation/class.ipp](include/vinecopulib/bicop/implementation/class.ipp),
+  where each per-row overload is a one-line `@brief`). Copying the sibling's
+  `@details`, its literature reference, or its edge-case list into a new
+  overload is duplication that will drift.
 - **Parameter passing.** Read-only parameters come in by `const&`. A parameter
   the body needs as a mutable working buffer — `Vinecop::pdf`, `pdf_full`,
   `rosenblatt`, `scores*`, `gradient`, `hessian*`, which pass `u` to

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,21 @@
 
 ### NEW FEATURES
 
+* Add a per-row-parameter overload of `Bicop::simulate`:
+  `simulate(const Eigen::MatrixXd& parameters, bool qrng = false,
+  const std::vector<int>& seeds = {}, size_t num_threads = 1)`. Observation `i`
+  is drawn from the copula carrying row `i` of the `n x p` parameter matrix
+  (the layout of the per-row `pdf`/`hinv1` overloads); the number of
+  observations is `parameters.rows()`, so there is no separate `n` argument,
+  and an empty `parameters` throws. Quasi-random numbers and seeding behave as
+  in the fixed-parameter overload, and the draws are always continuous, even
+  for discrete variable types. Parametric families only; the independence
+  copula takes an `n x 0` matrix. This moves the vectorized-parameter sampling
+  that `rvinecopulib` implemented in its own interface code upstream, so
+  `pyvinecopulib` gets it too. Existing call sites are unaffected, but code
+  taking the address of `&Bicop::simulate` must now disambiguate, e.g. with
+  `py::overload_cast<const size_t&, bool, const std::vector<int>&>(
+  &Bicop::simulate, py::const_)` (#719)
 * Add scores, gradient, and Hessian of the log-likelihood to `Bicop`:
   `scores` (the n x p per-observation score matrix), `gradient` (its
   observation-average), `hessian` and `hessian_full` (the averaged and
@@ -188,6 +203,12 @@
   the pair copulas in the both-endpoints-are-leaves columns change (#702)
 
 ### BUG FIXES
+
+* Reject `n < 1` (and `d < 1`) in `tools_stats::ghalton` and
+  `tools_stats::sobol` instead of writing past the end of the output matrix.
+  Only the pseudo-random branch of `simulate_uniform` validated its arguments,
+  so `simulate_uniform(0, d, true)` reached the quasi-random generators with a
+  zero-column result (#719)
 
 * Fix out-of-bounds parameter indexing in the per-row bivariate evaluation of
   discrete leaves (`pdf_c_d`, `pdf_d_d`, and the discrete branches of `hfunc1` /

--- a/docs/overview-bicop.dox
+++ b/docs/overview-bicop.dox
@@ -195,6 +195,20 @@ auto aic  = bicop.aic(sim_data);
 auto bic  = bicop.bic(sim_data);
 ```
 
+For parametric families, `pdf()`, `cdf()`, `hfunc1()`, `hfunc2()`, `hinv1()`,
+`hinv2()`, `loglik()`, and `simulate()` also have overloads taking one
+parameter set per observation, as in conditional or covariate-dependent
+copula models.
+
+```
+// Simulate 100 observations, each from its own Gauss copula
+Eigen::MatrixXd parameters = Eigen::VectorXd::LinSpaced(100, 0.1, 0.8);
+auto sim_par = bicop.simulate(parameters);
+
+// Evaluate the pdf at the same per-observation parameters
+auto pdf_par = bicop.pdf(sim_par, parameters);
+```
+
 
 Bivariate copula models can also be written to and constructed from JSON or
 CBOR files and

--- a/include/vinecopulib/bicop/class.hpp
+++ b/include/vinecopulib/bicop/class.hpp
@@ -295,6 +295,11 @@ public:
     const bool qrng = false,
     const std::vector<int>& seeds = std::vector<int>()) const;
 
+  Eigen::MatrixXd simulate(const Eigen::MatrixXd& parameters,
+                           const bool qrng = false,
+                           const std::vector<int>& seeds = std::vector<int>(),
+                           const size_t num_threads = 1) const;
+
   // Methods modifying the family/rotation/parameters
   void fit(const Eigen::MatrixXd& data,
            const FitControlsBicop& controls = FitControlsBicop());

--- a/include/vinecopulib/bicop/implementation/class.ipp
+++ b/include/vinecopulib/bicop/implementation/class.ipp
@@ -1498,6 +1498,61 @@ Bicop::simulate(const size_t& n,
   return u;
 }
 
+//! @brief Simulates from a bivariate copula with a different parameter set per
+//! observation.
+//!
+//! @details This is the counterpart of the fixed-parameter `simulate()` for
+//! models whose parameters vary from observation to observation, as in
+//! conditional or covariate-dependent copula models. Observation `i` is drawn
+//! from the copula carrying row `i` of `parameters`, and the number of
+//! observations is the number of rows of `parameters`. The family, rotation,
+//! and variable types are taken from the object, which is left unchanged.
+//!
+//! Sampling uses the inverse Rosenblatt transform: a pair of independent
+//! uniform variables is drawn per observation, and the second one is
+//! transformed by the inverse of the first h-function (see `hinv1()`) at that
+//! observation's parameters. The draws are always continuous, even when the
+//! model has discrete variable types.
+//!
+//! Only parametric families are supported; nonparametric families store an
+//! interpolation grid rather than a per-observation parameter vector.
+//!
+//! If `qrng = TRUE`, generalized Halton sequences are used.
+//! For more information on Generalized Halton sequences, see
+//! Faure, H., Lemieux, C. (2009). Generalized Halton Sequences in 2008:
+//! A Comparative Study. ACM-TOMACS 19(4), Article 15.
+//!
+//! @param parameters An \f$ n \times p \f$ matrix of parameters, where `n` is
+//!   the number of observations to simulate and `p` is the number of family
+//!   parameters (`get_parameters().size()`). Row `i` holds the parameter set
+//!   used for observation `i`, in the family's natural (unrotated)
+//!   parameterization, as for `get_parameters()`. There must be one row per
+//!   simulated observation. The independence copula has no parameters, so `p`
+//!   is zero and only the number of rows matters.
+//! @param qrng Set to true for quasi-random numbers.
+//! @param seeds Seeds of the (quasi-)random number generator; if empty
+//! (default), the (quasi-)random number generator is seeded randomly.
+//! @param num_threads The number of threads to parallelize the inverse
+//!   h-function over observations.
+//! @return An \f$ n \times 2 \f$ matrix of samples from the copula model.
+inline Eigen::MatrixXd
+Bicop::simulate(const Eigen::MatrixXd& parameters,
+                const bool qrng,
+                const std::vector<int>& seeds,
+                const size_t num_threads) const
+{
+  if (parameters.rows() < 1) {
+    throw std::runtime_error("parameters must have at least one row (one "
+                             "parameter set per simulated observation).");
+  }
+  auto u = tools_stats::simulate_uniform(
+    static_cast<size_t>(parameters.rows()), 2, qrng, seeds);
+  // use inverse Rosenblatt transform to generate a sample from the copula
+  // (always simulate continuous data)
+  u.col(1) = this->as_continuous().hinv1(u, parameters, num_threads);
+  return u;
+}
+
 //! @brief Evaluates the log-likelihood.
 //!
 //! @details The log-likelihood is defined as

--- a/include/vinecopulib/bicop/implementation/class.ipp
+++ b/include/vinecopulib/bicop/implementation/class.ipp
@@ -1498,42 +1498,23 @@ Bicop::simulate(const size_t& n,
   return u;
 }
 
-//! @brief Simulates from a bivariate copula with a different parameter set per
-//! observation.
+//! @brief Simulates from a bivariate copula with per-row parameters.
 //!
-//! @details This is the counterpart of the fixed-parameter `simulate()` for
-//! models whose parameters vary from observation to observation, as in
-//! conditional or covariate-dependent copula models. Observation `i` is drawn
-//! from the copula carrying row `i` of `parameters`, and the number of
-//! observations is the number of rows of `parameters`. The family, rotation,
-//! and variable types are taken from the object, which is left unchanged.
-//!
-//! Sampling uses the inverse Rosenblatt transform: a pair of independent
-//! uniform variables is drawn per observation, and the second one is
-//! transformed by the inverse of the first h-function (see `hinv1()`) at that
-//! observation's parameters. The draws are always continuous, even when the
-//! model has discrete variable types.
-//!
-//! Only parametric families are supported; nonparametric families store an
-//! interpolation grid rather than a per-observation parameter vector.
-//!
-//! If `qrng = TRUE`, generalized Halton sequences are used.
-//! For more information on Generalized Halton sequences, see
-//! Faure, H., Lemieux, C. (2009). Generalized Halton Sequences in 2008:
-//! A Comparative Study. ACM-TOMACS 19(4), Article 15.
+//! @details Observation `i` is drawn from the copula carrying row `i` of
+//! `parameters`, without mutating the object's stored parameters. The family,
+//! rotation, and variable types are taken from the object; only the parameter
+//! values vary by observation. Available for parametric families only.
 //!
 //! @param parameters An \f$ n \times p \f$ matrix of parameters, where `n` is
-//!   the number of observations to simulate and `p` is the number of family
-//!   parameters (`get_parameters().size()`). Row `i` holds the parameter set
-//!   used for observation `i`, in the family's natural (unrotated)
-//!   parameterization, as for `get_parameters()`. There must be one row per
-//!   simulated observation. The independence copula has no parameters, so `p`
-//!   is zero and only the number of rows matters.
+//!   the number of observations to simulate, `p` is the number of family
+//!   parameters (`get_parameters().size()`), and row `i` holds the parameter
+//!   set used for observation `i`. Parameters are given in the family's
+//!   natural (unrotated) parameterization, as for `get_parameters()`.
 //! @param qrng Set to true for quasi-random numbers.
 //! @param seeds Seeds of the (quasi-)random number generator; if empty
 //! (default), the (quasi-)random number generator is seeded randomly.
-//! @param num_threads The number of threads to parallelize the inverse
-//!   h-function over observations.
+//! @param num_threads The number of threads to parallelize the simulation over
+//!   observations.
 //! @return An \f$ n \times 2 \f$ matrix of samples from the copula model.
 inline Eigen::MatrixXd
 Bicop::simulate(const Eigen::MatrixXd& parameters,

--- a/include/vinecopulib/misc/implementation/tools_stats.ipp
+++ b/include/vinecopulib/misc/implementation/tools_stats.ipp
@@ -485,6 +485,9 @@ pairwise_mcor(const Eigen::MatrixXd& x, const Eigen::VectorXd& weights)
 inline Eigen::MatrixXd
 ghalton(const size_t& n, const size_t& d, const std::vector<int>& seeds)
 {
+  if ((n < 1) || (d < 1)) {
+    throw std::runtime_error("n and d must be at least 1.");
+  }
 
   Eigen::MatrixXd res(d, n);
 
@@ -547,6 +550,9 @@ ghalton(const size_t& n, const size_t& d, const std::vector<int>& seeds)
 inline Eigen::MatrixXd
 sobol(const size_t& n, const size_t& d, const std::vector<int>& seeds)
 {
+  if ((n < 1) || (d < 1)) {
+    throw std::runtime_error("n and d must be at least 1.");
+  }
 
   // output matrix
   Eigen::MatrixXd output = Eigen::MatrixXd::Zero(n, d);

--- a/test/src_test/include/test_bicop_parametric.hpp
+++ b/test/src_test/include/test_bicop_parametric.hpp
@@ -391,6 +391,114 @@ TEST_P(ParBicopTest, per_row_parameters_match_loop)
   }
 }
 
+// Simulation with one parameter set per observation: the sample is the
+// inverse Rosenblatt transform of the same uniforms the fixed-parameter
+// overload would draw, evaluated at each observation's own parameters.
+TEST_P(ParBicopTest, simulate_per_row_parameters_match_loop)
+{
+  if (!needs_check_)
+    return;
+  if (bicop_.get_parameters().size() == 0)
+    return;
+
+  auto family = bicop_.get_family();
+  auto rotation = bicop_.get_rotation();
+  auto var_types = bicop_.get_var_types();
+  Eigen::Index n = 200;
+  const std::vector<int> seeds = { 7, 8, 9 };
+
+  Eigen::VectorXd lb = bicop_.get_parameters_lower_bounds();
+  Eigen::VectorXd ub = bicop_.get_parameters_upper_bounds();
+  Eigen::Index p = lb.size();
+  Eigen::VectorXd a = lb + 0.2 * (ub - lb);
+  Eigen::VectorXd c = lb + 0.6 * (ub - lb);
+  Eigen::MatrixXd P(n, p);
+  for (Eigen::Index i = 0; i < n; ++i) {
+    double w = static_cast<double>(i % 5) / 4.0;
+    P.row(i) = ((1 - w) * a + w * c).transpose();
+  }
+
+  Eigen::MatrixXd sim = bicop_.simulate(P, false, seeds);
+  ASSERT_EQ(sim.rows(), n);
+  ASSERT_EQ(sim.cols(), 2);
+
+  // the uniforms come from the same stream as in the fixed-parameter overload
+  Eigen::MatrixXd u =
+    tools_stats::simulate_uniform(static_cast<size_t>(n), 2, false, seeds);
+  ASSERT_TRUE(all_close(sim.col(0), u.col(0), 0.0, 0.0)) << bicop_.str();
+
+  // ground truth: loop over single-parameter Bicops
+  Eigen::VectorXd ref(n);
+  for (Eigen::Index i = 0; i < n; ++i) {
+    Bicop bi(family, rotation, P.row(i).transpose().eval(), var_types);
+    ref(i) = bi.hinv1(u.row(i).eval())(0);
+  }
+  ASSERT_TRUE(all_close(sim.col(1), ref)) << bicop_.str();
+  ASSERT_TRUE(all_close(sim.col(1), bicop_.hinv1(u, P), 0.0, 0.0))
+    << bicop_.str();
+
+  // threading parity (results must not depend on num_threads)
+  ASSERT_TRUE(all_close(bicop_.simulate(P, false, seeds, 3), sim, 1e-12, 1e-12))
+    << bicop_.str();
+
+  // broadcasting the stored parameters reproduces the fixed-parameter overload;
+  // the uniforms are identical, the h-inverse only up to floating-point error
+  // (the leaves take a different branch for a single parameter row)
+  {
+    Eigen::MatrixXd Pb = bicop_.get_parameters().transpose().replicate(n, 1);
+    Eigen::MatrixXd s_par = bicop_.simulate(Pb, false, seeds);
+    Eigen::MatrixXd s_fix =
+      bicop_.simulate(static_cast<size_t>(n), false, seeds);
+    ASSERT_TRUE(all_close(s_par.col(0), s_fix.col(0), 0.0, 0.0))
+      << bicop_.str();
+    ASSERT_TRUE(all_close(s_par.col(1), s_fix.col(1), 1e-8, 1e-8))
+      << bicop_.str();
+  }
+
+  // quasi-random numbers take the same path
+  {
+    const std::vector<int> qseeds = { 1, 2, 3 };
+    Eigen::MatrixXd sq = bicop_.simulate(P, true, qseeds);
+    Eigen::MatrixXd uq =
+      tools_stats::simulate_uniform(static_cast<size_t>(n), 2, true, qseeds);
+    ASSERT_TRUE(all_close(sq.col(0), uq.col(0), 0.0, 0.0)) << bicop_.str();
+    ASSERT_TRUE(all_close(sq.col(1), bicop_.hinv1(uq, P), 0.0, 0.0))
+      << bicop_.str();
+  }
+
+  // discrete variable types still yield the latent continuous sample
+  {
+    const std::vector<std::vector<std::string>> var_type_sets = {
+      { "d", "d" }, { "c", "d" }, { "d", "c" }
+    };
+    for (const auto& vt : var_type_sets) {
+      Bicop disc = bicop_;
+      disc.set_var_types(vt);
+      ASSERT_TRUE(all_close(disc.simulate(P, false, seeds), sim, 0.0, 0.0))
+        << disc.str();
+    }
+  }
+
+  // validation errors
+  EXPECT_ANY_THROW(bicop_.simulate(P.topRows(0).eval())); // no rows
+  {
+    Eigen::MatrixXd Pbad(n, p + 1);
+    Pbad.leftCols(p) = P;
+    Pbad.col(p).setConstant(0.5);
+    EXPECT_ANY_THROW(bicop_.simulate(Pbad)); // wrong number of columns
+  }
+  {
+    Eigen::MatrixXd Pnan = P;
+    Pnan(0, 0) = std::numeric_limits<double>::quiet_NaN();
+    EXPECT_ANY_THROW(bicop_.simulate(Pnan)); // NaN parameter
+  }
+  {
+    Eigen::MatrixXd Poob = P;
+    Poob(0, 0) = lb(0) - 1.0;
+    EXPECT_ANY_THROW(bicop_.simulate(Poob)); // out-of-bounds parameter
+  }
+}
+
 // Analytic (or fallback) derivatives must match central finite differences
 // of the public (rotation-aware) pdf/hfunc1/hfunc2. This validates both the
 // derivative formulas and the facade's rotation chain rule; second-order
@@ -1077,6 +1185,35 @@ TEST(BicopPerRowParameters, independence_zero_parameters)
   EXPECT_TRUE(all_close(ind.hfunc2(u, P), ind.hfunc2(u)));
   EXPECT_TRUE(all_close(ind.hinv1(u, P), ind.hinv1(u)));
   EXPECT_TRUE(all_close(ind.hinv2(u, P), ind.hinv2(u)));
+}
+
+// Degenerate families and overload resolution for the per-row simulate().
+TEST(BicopSimulate, per_row_parameters_edge_cases)
+{
+  // nonparametric families have no per-observation parameter vector
+  Bicop tll(BicopFamily::tll);
+  EXPECT_ANY_THROW(tll.simulate(Eigen::MatrixXd::Constant(5, 1, 1.0)));
+
+  // the independence copula takes an n x 0 matrix and leaves column 1 alone
+  Bicop ind(BicopFamily::indep);
+  const Eigen::Index n = 20;
+  Eigen::MatrixXd P(n, 0);
+  Eigen::MatrixXd s = ind.simulate(P, false, { 1, 2, 3 });
+  EXPECT_EQ(s.rows(), n);
+  EXPECT_EQ(s.cols(), 2);
+  EXPECT_TRUE(all_close(
+    s, ind.simulate(static_cast<size_t>(n), false, { 1, 2, 3 }), 0.0, 0.0));
+  EXPECT_ANY_THROW(ind.simulate(Eigen::MatrixXd(0, 0)));
+  EXPECT_ANY_THROW(ind.simulate(Eigen::MatrixXd::Constant(5, 1, 0.5)));
+
+  // an integral first argument must keep resolving to the fixed-parameter
+  // overload, an Eigen one to the per-row overload
+  Bicop g(BicopFamily::gaussian, 0, Eigen::VectorXd::Constant(1, 0.5));
+  EXPECT_EQ(g.simulate(10).rows(), 10);
+  EXPECT_EQ(g.simulate(size_t{ 10 }, true, { 1 }).rows(), 10);
+  Eigen::MatrixXd sv = g.simulate(Eigen::VectorXd::Constant(10, 0.5));
+  EXPECT_EQ(sv.rows(), 10);
+  EXPECT_EQ(sv.cols(), 2);
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/test/src_test/include/test_tools_stats.hpp
+++ b/test/src_test/include/test_tools_stats.hpp
@@ -122,6 +122,16 @@ TEST(test_tools_stats, seed_works)
   ASSERT_TRUE(U2.cwiseEqual(U3).all());
 }
 
+TEST(test_tools_stats, degenerate_dimensions_throw)
+{
+  EXPECT_ANY_THROW(tools_stats::ghalton(0, 2));
+  EXPECT_ANY_THROW(tools_stats::ghalton(2, 0));
+  EXPECT_ANY_THROW(tools_stats::sobol(0, 2));
+  EXPECT_ANY_THROW(tools_stats::sobol(2, 0));
+  EXPECT_ANY_THROW(tools_stats::simulate_uniform(0, 2));
+  EXPECT_ANY_THROW(tools_stats::simulate_uniform(0, 2, true));
+}
+
 TEST(test_tools_stats, dpqnorm_work)
 {
   auto dnorm_boost = [](const Eigen::MatrixXd& x) {


### PR DESCRIPTION
## Summary

Adds `Bicop::simulate(parameters, qrng, seeds, num_threads)`, the counterpart of the fixed-parameter overload for models whose parameters vary from observation to observation (conditional or covariate-dependent copula models).

Motivated by [rvinecopulib#324](https://github.com/vinecopulib/rvinecopulib/pull/324), which implements exactly this in its own Rcpp glue:

```cpp
auto u = tools_stats::simulate_uniform(n, 2, qrng, seeds);
u.col(1) = bicop_cpp.as_continuous().hinv1(u, parameters);
```

Moving it upstream lets `pyvinecopulib` expose the same capability instead of every wrapper re-deriving those two lines.

## API

```cpp
Eigen::MatrixXd simulate(const Eigen::MatrixXd& parameters,
                         const bool qrng = false,
                         const std::vector<int>& seeds = std::vector<int>(),
                         const size_t num_threads = 1) const;
```

- Observation `i` is drawn from the copula carrying row `i` of the `n x p` matrix, the layout already used by the per-row `pdf`/`cdf`/`hfunc*`/`hinv*`/`loglik` overloads (#675).
- **No separate `n` argument** — it is `parameters.rows()`. `format_parameters` already requires an exact row match, so an explicit `n` would only add a second failure mode. An empty `parameters` throws.
- `num_threads` goes **last**, matching every per-row overload on `Bicop`. This deliberately differs from `Vinecop::simulate(n, qrng, num_threads, seeds)`; the intra-class per-row convention is the stronger one, and a swapped `seeds`/`num_threads` argument is a compile error rather than a silent mis-binding.
- Parametric families only. The independence copula takes an `n x 0` matrix.
- The draws are always continuous, even for discrete `var_types` — same as the fixed-parameter overload.

All validation (parametric-only, row/column counts, finiteness, bounds) is inherited from `format_parameters` rather than duplicated.

### Overload resolution

Existing call sites are unaffected. An arithmetic first argument reaches `const Eigen::MatrixXd&` only through a user-defined conversion, which loses to the standard integral/floating conversion to `const size_t&` — and Eigen's single-argument `Matrix` constructors are `explicit` anyway. This is not the ambiguity class of 4810541 (`Vinecop(data)`), which arose from `nlohmann::json`'s *non*-explicit converting constructor sitting between two Eigen-taking overloads. A regression guard test pins this.

**Source break for binding code:** `&Bicop::simulate` is now ambiguous and must be disambiguated, e.g. `py::overload_cast<const size_t&, bool, const std::vector<int>&>(&Bicop::simulate, py::const_)`. Same break `#675` caused for `pdf`/`cdf`. A matching `pyvinecopulib` binding PR is needed.

## Ride-along bug fix

`tools_stats::ghalton` and `tools_stats::sobol` now reject `n < 1` (and `d < 1`). Only the pseudo-random branch of `simulate_uniform` validated its arguments, so `simulate_uniform(0, d, true)` reached the quasi-random generators with a zero-column result: `ghalton` unconditionally writes `res.block(0, 0, d, 1)`, and `sobol` computes `L = ceil(log(0)/log(2))` and writes `C(0) = 1` into a zero-length vector. The new overload's own `n < 1` guard would otherwise merely route around this.

## Note for the pyvinecopulib binding

In C++ a length-`n` `VectorXd` binds as `n x 1`. Through pybind11 a **1-D NumPy array conforms to `Eigen::MatrixXd` as `1 x n`** — so a Gaussian handed `np.array([...])` would throw "expected 1 column", and a Student t handed a 2-element array would silently return *one* observation. The binding should document `parameters` as strictly 2-D (or use `.noconvert()`). The doc comment's "one row per simulated observation" is what makes this unambiguous in both languages.

## Tests

- `ParBicopTest.simulate_per_row_parameters_match_loop` (all parametric families x 4 rotations): column 0 is bitwise the stream `simulate_uniform` would produce; column 1 matches both a row-by-row loop over single-parameter `Bicop`s and `hinv1(u, P)` bitwise; thread parity; qrng; discrete `var_types` return the bitwise-identical latent sample; the four validation throws.
- Broadcasting the stored parameters reproduces the fixed-parameter overload: column 0 exactly, column 1 to `1e-8` — the leaves take an algebraically-equal but textually different branch for a single parameter row (`gaussian`, `student`), and a 1-ulp difference can flip a bisection branch in the numerically inverted families.
- `BicopSimulate.per_row_parameters_edge_cases`: `tll` throws, `indep` with `n x 0`, zero rows, and the overload-resolution guard.
- `test_tools_stats.degenerate_dimensions_throw` for the QRNG fix.

## Validation

- `clang-format` 14 clean; `clang-tidy-14` clean on both the diff and the whole-library `test/test_all.cpp` pass.
- Debug: **696/696** pass.
- `cmake --preset dev` (ASan/UBSan + `-Werror -Wconversion`): new tests pass clean.
- Release `-DVINECOPULIB_PRECOMPILED=ON`: builds, exports the symbol, **696/696** pass.

## Deliberately out of scope

Per-observation-parameter `Vinecop::simulate`/`inverse_rosenblatt`. `inverse_rosenblatt` is a third independent cascade with its own >1 GB recursive halving, and `check_per_obs_params` rejects discrete variables while `inverse_rosenblatt` deliberately calls `set_continuous_var_types()` — a policy conflict that needs a maintainer decision. A proper follow-up would first extract the duplicated `(tree, edge) -> parameter-offset` walk into one helper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)