### PR TITLE
fix(vinecop): evaluate a custom tree criterion serially

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -477,7 +477,8 @@ For any behavior change:
 - **`FitControlsVinecop`**
   ([fit_controls.hpp](include/vinecopulib/vinecop/fit_controls.hpp))
   inherits `FitControlsBicop` and adds the structure knobs: `trunc_lvl`,
-  `tree_criterion` (`"tau"`/`"rho"`/`"hoeffd"`/`"mcor"`), `threshold`,
+  `tree_criterion` (`"tau"`/`"rho"`/`"hoeffd"`/`"mcor"`/`"joe"`/`"custom"`,
+  the last backed by `tree_criterion_function`), `threshold`,
   `tree_algorithm` (`"mst_prim"` default, `"mst_kruskal"`,
   `"random_weighted"`, `"random_unweighted"`), `select_trunc_lvl` /
   `select_threshold` / `select_families`, `show_trace`, and `seeds`.

--- a/NEWS.md
+++ b/NEWS.md
@@ -173,7 +173,7 @@
   be used with any `num_threads`, and the pair-copula fits stay parallel. The
   criterion and the callable may be set in either order, but a fit is now
   rejected up front when only one of the two is given, instead of failing deep
-  inside selection or silently ignoring the callable (#674, #000).
+  inside selection or silently ignoring the callable (#674, #722).
 
 * Add `Vinecop::hfuncs` to return intermediate h-function values (#669)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -167,7 +167,13 @@
   `tree_criterion = "custom"` together with
   `FitControlsVinecop::set_tree_criterion_function` (or
   `FitControlsConfig::tree_criterion_function`), enabling custom dependence
-  criteria during Dissmann's algorithm (#674).
+  criteria during Dissmann's algorithm. The function is always invoked,
+  copied, and destroyed on the thread that starts the fit, never from a worker
+  thread, so it need not be thread safe: an R closure or a Python callable can
+  be used with any `num_threads`, and the pair-copula fits stay parallel. The
+  criterion and the callable may be set in either order, but a fit is now
+  rejected up front when only one of the two is given, instead of failing deep
+  inside selection or silently ignoring the callable (#674, #000).
 
 * Add `Vinecop::hfuncs` to return intermediate h-function values (#669)
 

--- a/docs/overview-vinecop.dox
+++ b/docs/overview-vinecop.dox
@@ -141,7 +141,11 @@ additional data members to control the structure selection:
 minimum spanning tree (see
 [Dissman et al. (2013)](https://mediatum.ub.tum.de/doc/1079277/1079277.pdf)).
 It can take `"tau"` (default) for Kendall's tau, `"rho"` for Spearman's rho,
-or `"hoeffd"` for Hoeffding's D (suited for non-monotonic relationships).
+`"hoeffd"` for Hoeffding's D (suited for non-monotonic relationships),
+`"mcor"` for the maximum correlation, `"joe"` for the Gaussian-copula mutual
+information, or `"custom"` for a user-supplied function (see
+`FitControlsVinecop::set_tree_criterion_function()`, which is always evaluated
+on the calling thread).
 - `double threshold` describes a value (default is 0) of `tree_criterion` under
 which the corresponding pair-copula is set to independence.
 - `bool select_trunc_lvl` can be set to true to select the truncation

--- a/include/vinecopulib/misc/fit_controls.hpp
+++ b/include/vinecopulib/misc/fit_controls.hpp
@@ -18,6 +18,9 @@ namespace vinecopulib {
 //!
 //! Maps a two-column matrix of pair-copula data and a vector of weights to a
 //! scalar dependence value. Used when `tree_criterion` is set to `"custom"`.
+//! The function is always invoked, copied, and destroyed on the calling
+//! thread (the thread that starts the fit), never from a worker thread, so it
+//! need not be thread safe.
 using TreeCriterionFunction =
   std::function<double(const Eigen::MatrixXd&, const Eigen::VectorXd&)>;
 
@@ -71,7 +74,9 @@ struct FitControlsConfig
   std::optional<std::string> tree_criterion;
 
   //! A custom edge-weight function for the spanning tree. Required when
-  //! `tree_criterion` is set to `"custom"`.
+  //! `tree_criterion` is set to `"custom"`, and rejected otherwise. It is
+  //! always called on the thread that starts the fit, so it need not be
+  //! thread safe.
   std::optional<TreeCriterionFunction> tree_criterion_function;
 
   //! Threshold for thresholded vines. Default: 0.

--- a/include/vinecopulib/misc/fit_controls.hpp
+++ b/include/vinecopulib/misc/fit_controls.hpp
@@ -19,9 +19,8 @@ namespace vinecopulib {
 //!
 //! Maps a two-column matrix of pair-copula data and a vector of weights to a
 //! scalar dependence value. Used when `tree_criterion` is set to `"custom"`.
-//! The function is always invoked, copied, and destroyed on the calling
-//! thread (the thread that starts the fit), never from a worker thread, so it
-//! need not be thread safe.
+//! It is always called on the thread that starts the fit, so it need not be
+//! thread safe.
 using TreeCriterionFunction =
   std::function<double(const Eigen::MatrixXd&, const Eigen::VectorXd&)>;
 

--- a/include/vinecopulib/misc/fit_controls.hpp
+++ b/include/vinecopulib/misc/fit_controls.hpp
@@ -11,6 +11,7 @@
 #include <optional>
 #include <string>
 #include <vector>
+#include <vinecopulib/bicop/family.hpp>
 
 namespace vinecopulib {
 

--- a/include/vinecopulib/vinecop/class.hpp
+++ b/include/vinecopulib/vinecop/class.hpp
@@ -420,6 +420,7 @@ protected:
   void finalize_fit(const tools_select::VinecopSelector& selector);
   void check_conditioning_set(const std::vector<size_t>& conditioning_set,
                               const FitControlsVinecop& controls) const;
+  static void check_tree_criterion_function(const FitControlsVinecop& controls);
   void check_weights_size(const Eigen::VectorXd& weights,
                           const Eigen::MatrixXd& data) const;
   void check_enough_data(const Eigen::MatrixXd& data) const;

--- a/include/vinecopulib/vinecop/fit_controls.hpp
+++ b/include/vinecopulib/vinecop/fit_controls.hpp
@@ -75,7 +75,8 @@ public:
   std::string get_tree_criterion() const;
 
   //! @return the custom edge-weight function used when `tree_criterion` is
-  //! `"custom"` (empty otherwise).
+  //! `"custom"` (empty otherwise). It is always called on the thread that
+  //! starts the fit, so it need not be thread safe.
   TreeCriterionFunction get_tree_criterion_function() const;
 
   //! @return the absolute-dependence threshold below which pair copulas
@@ -128,7 +129,10 @@ public:
   void set_tree_criterion(std::string tree_criterion);
 
   //! Sets the custom edge-weight function used when `tree_criterion` is
-  //! `"custom"`.
+  //! `"custom"`. The two can be set in either order, but the fit is rejected
+  //! unless both are set. The function is always called on the thread that
+  //! starts the fit, so it need not be thread safe; the pair-copula fits still
+  //! use `num_threads` threads.
   //! @param tree_criterion_function a callable mapping a two-column matrix of
   //! pair-copula data and a vector of weights to a scalar dependence value.
   void set_tree_criterion_function(

--- a/include/vinecopulib/vinecop/fit_controls.hpp
+++ b/include/vinecopulib/vinecop/fit_controls.hpp
@@ -129,7 +129,7 @@ public:
   void set_tree_criterion(std::string tree_criterion);
 
   //! Sets the custom edge-weight function used when `tree_criterion` is
-  //! `"custom"`. The two can be set in either order, but the fit is rejected
+  //! `"custom"`. The two may be set in either order, but a fit is rejected
   //! unless both are set. The function is always called on the thread that
   //! starts the fit, so it need not be thread safe; the pair-copula fits still
   //! use `num_threads` threads.

--- a/include/vinecopulib/vinecop/implementation/class.ipp
+++ b/include/vinecopulib/vinecop/implementation/class.ipp
@@ -288,8 +288,12 @@ Vinecop::make_pair_copula_store(const size_t d, const size_t trunc_lvl)
 //! 52-69.
 //! The dependence measure used to select trees (default: Kendall's tau) is
 //! corrected for ties (see the [wdm](https://github.com/tnagler/wdm) library).
-//! The dependence measure can be changed using the `controls.tree_criterion`,
-//! which can be set to `"tau"`, `"rho"` or `"hoeffd"`.
+//! The dependence measure can be changed using `controls.tree_criterion`,
+//! which can be set to `"tau"`, `"rho"`, `"hoeffd"`, `"mcor"`, `"joe"`, or
+//! `"custom"`. The last one uses the callable supplied through
+//! `controls.tree_criterion_function`, which is always called on the thread
+//! that starts the fit, so it need not be thread safe; the pair-copula fits
+//! still use `controls.num_threads` threads.
 //! Both Prim's (default: `"mst_prim"`) and Kruskal's (`"mst_kruskal"`)
 //! algorithms are available through `controls.tree_algorithm` for the
 //! maximum spanning tree selection.
@@ -330,6 +334,7 @@ inline void
 Vinecop::select(const Eigen::MatrixXd& data, const FitControlsVinecop& controls)
 {
   if (controls.get_select_families()) {
+    check_tree_criterion_function(controls);
     check_data(data);
     if (d_ == 1) {
       loglik_ = 0;
@@ -394,6 +399,27 @@ Vinecop::check_conditioning_set(const std::vector<size_t>& conditioning_set,
     throw std::runtime_error(
       "conditioning-aware selection does not support truncation "
       "(trunc_lvl / select_trunc_lvl) in this version.");
+  }
+}
+
+//! @brief Validates the custom edge-weight function against the criterion it
+//! belongs to (called from `select()`, the single entry point to structure
+//! selection; the two fields can be set in either order, so the pairing can
+//! only be checked once the fit starts).
+inline void
+Vinecop::check_tree_criterion_function(const FitControlsVinecop& controls)
+{
+  bool is_custom = (controls.get_tree_criterion() == "custom");
+  bool has_function = static_cast<bool>(controls.get_tree_criterion_function());
+  if (is_custom && !has_function) {
+    throw std::runtime_error("tree_criterion = \"custom\" requires a "
+                             "tree_criterion_function callable");
+  }
+  if (has_function && !is_custom) {
+    throw std::runtime_error(
+      "a tree_criterion_function was provided, but tree_criterion is \"" +
+      controls.get_tree_criterion() +
+      "\"; set tree_criterion = \"custom\" to use it");
   }
 }
 

--- a/include/vinecopulib/vinecop/implementation/fit_controls.ipp
+++ b/include/vinecopulib/vinecop/implementation/fit_controls.ipp
@@ -42,8 +42,9 @@ inline FitControlsVinecop::FitControlsVinecop()
 //!     are multiplied.
 //! @param trunc_lvl Truncation level for truncated vines.
 //! @param tree_criterion The criterion for selecting the spanning
-//!     tree (`"tau"`, `"hoeffd"`, `"rho"`, and `"mcor"` implemented so far)
-//!     during the tree-wise structure selection.
+//!     tree (`"tau"`, `"rho"`, `"hoeffd"`, `"mcor"`, `"joe"`, or `"custom"`)
+//!     during the tree-wise structure selection. `"custom"` uses the callable
+//!     set through `set_tree_criterion_function()`.
 //! @param threshold For thresholded vines (0 = no threshold).
 //! @param selection_criterion The selection criterion (`"loglik"`, `"aic"`,
 //!     `"bic"`, `"mbic"`, or `"mbicv"`) for the pair copula families.
@@ -62,7 +63,8 @@ inline FitControlsVinecop::FitControlsVinecop()
 //! @param show_trace Whether to show a trace of the building progress.
 //! @param num_threads Number of concurrent threads to use while fitting
 //!     pair copulas within a tree; never uses more than the number
-//!     of concurrent threads supported by the implementation.
+//!     of concurrent threads supported by the implementation. A custom
+//!     tree criterion is exempt and always runs on the calling thread.
 //! @param tree_algorithm The algorithm for building the spanning
 //!     tree (`"mst_prim"`, `"mst_kruskal"`, `"random_weighted"`, or
 //!     `"random_unweighted"`) during the tree-wise structure selection.
@@ -127,8 +129,9 @@ inline FitControlsVinecop::FitControlsVinecop(
 //! @param controls See `FitControlsBicop()`.
 //! @param trunc_lvl Truncation level for truncated vines.
 //! @param tree_criterion The criterion for selecting the spanning
-//!     tree (`"tau"`, `"hoeffd"`, `"rho"`, and `"mcor"` implemented so far)
-//!     during the tree-wise structure selection.
+//!     tree (`"tau"`, `"rho"`, `"hoeffd"`, `"mcor"`, `"joe"`, or `"custom"`)
+//!     during the tree-wise structure selection. `"custom"` uses the callable
+//!     set through `set_tree_criterion_function()`.
 //! @param threshold For thresholded vines (`0` = no threshold).
 //! @param show_trace Whether to show a trace of the building progress.
 //! @param select_trunc_lvl Whether the truncation shall be selected
@@ -318,6 +321,9 @@ FitControlsVinecop::set_tree_criterion(std::string tree_criterion)
 }
 
 //! @brief Gets the custom criterion function for tree selection.
+//!
+//! @details It is always called on the thread that starts the fit, so it need
+//! not be thread safe.
 inline TreeCriterionFunction
 FitControlsVinecop::get_tree_criterion_function() const
 {
@@ -325,6 +331,10 @@ FitControlsVinecop::get_tree_criterion_function() const
 }
 
 //! @brief Sets the custom criterion function for tree selection.
+//!
+//! @details Required when `tree_criterion` is `"custom"`, and rejected
+//! otherwise; the two can be set in either order. It is always called on the
+//! thread that starts the fit, so it need not be thread safe.
 inline void
 FitControlsVinecop::set_tree_criterion_function(
   TreeCriterionFunction tree_criterion_function)

--- a/include/vinecopulib/vinecop/implementation/fit_controls.ipp
+++ b/include/vinecopulib/vinecop/implementation/fit_controls.ipp
@@ -321,9 +321,6 @@ FitControlsVinecop::set_tree_criterion(std::string tree_criterion)
 }
 
 //! @brief Gets the custom criterion function for tree selection.
-//!
-//! @details It is always called on the thread that starts the fit, so it need
-//! not be thread safe.
 inline TreeCriterionFunction
 FitControlsVinecop::get_tree_criterion_function() const
 {
@@ -331,10 +328,6 @@ FitControlsVinecop::get_tree_criterion_function() const
 }
 
 //! @brief Sets the custom criterion function for tree selection.
-//!
-//! @details Required when `tree_criterion` is `"custom"`, and rejected
-//! otherwise; the two can be set in either order. It is always called on the
-//! thread that starts the fit, so it need not be thread safe.
 inline void
 FitControlsVinecop::set_tree_criterion_function(
   TreeCriterionFunction tree_criterion_function)

--- a/include/vinecopulib/vinecop/implementation/tools_select.ipp
+++ b/include/vinecopulib/vinecop/implementation/tools_select.ipp
@@ -450,7 +450,10 @@ VinecopSelector::add_allowed_edges(VineTree& vine_tree)
 //!
 //! Used when the structure is unknown. The candidate edges are enumerated
 //! single-threaded (insertion order is significant); their weights are then
-//! computed in parallel, with graph writes guarded by a mutex.
+//! computed in parallel, with graph writes guarded by a mutex. A custom
+//! criterion is the exception: it is user code that the library cannot assume
+//! to be thread safe (and that the R and Python bindings may only run on the
+//! thread that entered the library), so those weights are computed serially.
 inline void
 VinecopSelector::add_allowed_edges_proximity(
   VineTree& vine_tree,
@@ -516,8 +519,15 @@ VinecopSelector::add_allowed_edges_proximity(
     }
   };
 
-  pool_.map(process_edge, edge_list);
-  pool_.wait();
+  if (tree_criterion == "custom") {
+    for (const auto& edge : edge_list) {
+      tools_interface::check_user_interrupt();
+      process_edge(edge);
+    }
+  } else {
+    pool_.map(process_edge, edge_list);
+    pool_.wait();
+  }
 }
 
 //! @brief Adds the edges dictated by a fixed vine structure.

--- a/test/src_test/include/test_vinecop_class.hpp
+++ b/test/src_test/include/test_vinecop_class.hpp
@@ -9,7 +9,10 @@
 #include "test_utils.hpp"
 #include "vinecop_test.hpp"
 #include <future>
+#include <mutex>
+#include <set>
 #include <string>
+#include <thread>
 #include <vinecopulib.hpp>
 #include <vinecopulib/misc/tools_stl.hpp>
 
@@ -1794,6 +1797,34 @@ TEST_F(VinecopTest, works_multi_threaded)
   fit2.cdf(u, 100, 2, { 1 });
 }
 
+// Records where a custom tree criterion is evaluated from. The bookkeeping is
+// mutex-guarded so that a regression fails the assertions instead of racing on
+// the recorder itself.
+struct CriterionRecorder
+{
+  std::mutex m;
+  std::set<std::thread::id> ids;
+  size_t num_calls = 0;
+
+  TreeCriterionFunction tau_function()
+  {
+    return [this](const Eigen::MatrixXd& data, const Eigen::VectorXd& weights) {
+      {
+        std::lock_guard<std::mutex> lk(m);
+        ids.insert(std::this_thread::get_id());
+        ++num_calls;
+      }
+      return wdm::wdm(data, "tau", weights)(0, 1);
+    };
+  }
+
+  void reset()
+  {
+    ids.clear();
+    num_calls = 0;
+  }
+};
+
 // check if the same conditioned sets appear for each tree
 inline size_t
 get_pairs_unequal(
@@ -1895,6 +1926,76 @@ TEST_F(VinecopTest, tree_criterion_custom_works)
   bad.set_tree_criterion("custom");
   Vinecop fit_bad(7);
   EXPECT_ANY_THROW(fit_bad.select(u, bad));
+  bad.set_num_threads(4);
+  Vinecop fit_bad_mt(7);
+  EXPECT_ANY_THROW(fit_bad_mt.select(u, bad));
+
+  // a callable that no criterion would ever use must not be silently ignored
+  FitControlsVinecop unused({ BicopFamily::indep });
+  unused.set_tree_criterion_function(tau_fn);
+  Vinecop fit_unused(7);
+  EXPECT_ANY_THROW(fit_unused.select(u, unused));
+
+  // the two fields may be set in either order
+  FitControlsVinecop reversed({ BicopFamily::indep });
+  reversed.set_tree_criterion_function(tau_fn);
+  reversed.set_tree_criterion("custom");
+  Vinecop fit_reversed(7);
+  EXPECT_NO_THROW(fit_reversed.select(u, reversed));
+}
+
+// A custom criterion is arbitrary user code (an R closure or a Python callable
+// in the wrappers), so it must run on the thread that starts the fit no matter
+// how many threads the fit is allowed to use.
+TEST_F(VinecopTest, tree_criterion_custom_is_serial)
+{
+  CriterionRecorder recorder;
+  FitControlsVinecop controls({ BicopFamily::indep });
+  controls.set_tree_criterion("custom");
+  controls.set_tree_criterion_function(recorder.tau_function());
+
+  Vinecop fit1(7);
+  fit1.select(u, controls);
+  size_t num_calls_serial = recorder.num_calls;
+  EXPECT_EQ(recorder.ids.size(), static_cast<size_t>(1));
+  EXPECT_EQ(*recorder.ids.begin(), std::this_thread::get_id());
+  // tree 1 alone enumerates C(7, 2) = 21 candidate edges
+  EXPECT_GT(num_calls_serial, static_cast<size_t>(20));
+
+  recorder.reset();
+  controls.set_num_threads(4);
+  Vinecop fit4(7);
+  fit4.select(u, controls);
+
+  EXPECT_EQ(recorder.ids.size(), static_cast<size_t>(1));
+  EXPECT_EQ(*recorder.ids.begin(), std::this_thread::get_id());
+  // the candidate edges are enumerated serially, so the number of criterion
+  // evaluations cannot depend on the thread count
+  EXPECT_EQ(recorder.num_calls, num_calls_serial);
+  EXPECT_EQ(get_pairs_unequal(fit1.get_matrix(), fit4.get_matrix(), 6), 0);
+  EXPECT_EQ(get_pairs_unequal(vc_matrix, fit4.get_matrix(), 6), 0);
+}
+
+// Sparse selection re-enters add_allowed_edges once per threshold pass; the
+// criterion must stay on the calling thread there too.
+TEST_F(VinecopTest, tree_criterion_custom_is_serial_sparse)
+{
+  u.conservativeResize(200, 7); // above the 10-row floor of the criterion
+
+  CriterionRecorder recorder;
+  FitControlsVinecop controls({ BicopFamily::indep, BicopFamily::gaussian });
+  controls.set_tree_criterion("custom");
+  controls.set_tree_criterion_function(recorder.tau_function());
+  controls.set_select_threshold(true);
+  controls.set_select_trunc_lvl(true);
+  controls.set_num_threads(4);
+
+  Vinecop fit(7);
+  fit.select(u, controls);
+
+  EXPECT_GT(recorder.num_calls, static_cast<size_t>(20));
+  EXPECT_EQ(recorder.ids.size(), static_cast<size_t>(1));
+  EXPECT_EQ(*recorder.ids.begin(), std::this_thread::get_id());
 }
 
 TEST_F(VinecopTest, select_finds_different_structures_random)


### PR DESCRIPTION
## Summary

`VinecopSelector::add_allowed_edges_proximity` weighted candidate edges through the thread pool, so a user-supplied `tree_criterion_function` was invoked **concurrently from worker threads** whenever `num_threads > 1`. That is a data race for any callable holding state, and undefined behavior in the wrappers: an R closure evaluated off the R evaluator thread, or a Python callable invoked without the GIL held.

This is why [rvinecopulib#326](https://github.com/vinecopulib/rvinecopulib/pull/326) has to impose `cores = 1`.

## The fix

```cpp
if (tree_criterion == "custom") {
  for (const auto& edge : edge_list) {
    tools_interface::check_user_interrupt();
    process_edge(edge);
  }
} else {
  pool_.map(process_edge, edge_list);
  pool_.wait();
}
```

Three decisions worth flagging for review:

- **The predicate is the criterion string, not the truthiness of the callable.** `tree_criterion == "custom"` is exactly the set of states in which user code runs. `if (criterion_fun)` would be wrong in both directions: it serializes for nothing when a stale callable is left behind with `tree_criterion = "tau"` (never invoked), and it fails to serialize `"custom"` with an *empty* callable — precisely the path that throws. With the string predicate that error becomes one clean calling-thread throw instead of 21 concurrent worker throws rethrown from `wait()`.
- **The `std::mutex` stays.** It is still required by the parallel branch, and one uncontended lock per edge is unmeasurable next to a call into R or Python. Keeping a single `process_edge` for both branches is what keeps the conditioning-set weight logic single-sourced.
- **Everything else stays parallel.** `select_pair_copulas` cannot reach the criterion, and `Bicop::select` takes `FitControlsBicop` **by value**, so passing `controls_` to it base-slices on the worker — the `std::function` member is never copied or destroyed off-thread either.

### This is the only site

`TreeCriterionFunction` is invoked only in `calculate_criterion_clean`. `calculate_criterion` has exactly two in-library callers: `add_allowed_edges_proximity` (the pool) and `add_allowed_edges_structured` (already serial). Both are reached only via `select_tree` — which has no override — from the plain serial loops in `select_all_trees` and `run_threshold_pass`. `sparse_select_all_trees`, `get_next_threshold`, and `get_thresholded_crits` are criterion-free.

## Eager validation

`Vinecop::select` is the single entry point to selection (the data constructor, `select_all`, and `select_families` all route through it), so the pairing is now checked there:

- `tree_criterion = "custom"` without a callable → previously failed deep inside selection;
- a callable without `tree_criterion = "custom"` → previously **silently ignored**.

The check lives at selection entry rather than in the setters, because `set_tree_criterion_function` before `set_tree_criterion` is a legal ordering; both orders are covered by tests.

## Contract rvinecopulib can rely on

> vinecopulib invokes `FitControlsVinecop`'s `tree_criterion_function` only from the thread that enters the library, and copies and destroys it there too. All remaining parallelism during selection — candidate-edge weighting for the built-in criteria, and pair-copula family/parameter selection — never enters the callable and never touches the R API. `rvinecopulib` may therefore pass a custom tree criterion together with any `cores` value; the `cores = 1` restriction can be dropped.

For pyvinecopulib the trampoline still needs `py::gil_scoped_acquire` if `select` is bound with `py::call_guard<py::gil_scoped_release>`, and the holder's copy/destroy must acquire the GIL too.

## Tests

`VinecopTest.tree_criterion_custom_is_serial` and `..._is_serial_sparse` record `std::this_thread::get_id()` from inside the callable (mutex-guarded, so a regression fails an assertion instead of racing on the recorder) and assert that the set of observed thread ids is exactly `{calling thread}` at `num_threads = 4`, that the number of criterion evaluations is thread-count-independent, and that the structure is unchanged.

Both are positive assertions about where the code runs rather than probabilistic race detection, so they fail deterministically. **Verified against the unfixed code**: with the branch reverted, both report 4 distinct thread ids, none of them the caller.

`tree_criterion_custom_works` is extended with the two validation cases and the reversed setter order.

## Ride-alongs

- `misc/fit_controls.hpp` did not include `bicop/family.hpp` despite using `BicopFamily`; it compiled only because its single include site pulls that in first. Parsing it standalone — as CI's clang-tidy-diff job does for any changed header — fails. One-line fix.
- The admissible-criterion list was stale in four places (`Vinecop::select`, both `FitControlsVinecop` constructors, `docs/overview-vinecop.dox`, AGENTS.md): all listed only a subset, omitting `mcor`, `joe`, and `custom`.

## NEWS

Filed by extending the existing `#674` bullet rather than as a bug fix: `0.8.0` is untagged and the custom criterion itself is unreleased, so no released version can exhibit the race.

## Validation

- `clang-format` 14 clean; `clang-tidy-14` clean on both the diff and the whole-library `test/test_all.cpp` pass.
- Debug: **648/648** pass.

## Out of scope (noted while tracing)

- `Vinecop::select_families` builds `controls_trunc_lvl` and then calls `select(data, controls)` — the adjusted copy is discarded. Real bug, unrelated.
- `FitControlsVinecop::str()` prints `get_select_trunc_lvl()` under the "Select threshold" label, and the `select_threshold`/`select_trunc_lvl` doc comments in `misc/fit_controls.hpp` are swapped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)