### PR TITLE
docs(bicop): state where the Kendall's tau maps apply, and say so when they don't

### DIFF
--- a/include/vinecopulib/bicop/implementation/abstract.ipp
+++ b/include/vinecopulib/bicop/implementation/abstract.ipp
@@ -92,10 +92,17 @@ AbstractBicop::create(BicopFamily family, const Eigen::MatrixXd& parameters)
 
 //!@}
 
+//! Fallback for families that cannot be parametrized by Kendall's tau alone:
+//! everything outside `bicop_families::itau`, plus `student`, whose tau pins
+//! rho but leaves the degrees of freedom free.
 inline Eigen::MatrixXd
 AbstractBicop::no_tau_to_parameters(const double&)
 {
-  throw std::runtime_error("Method not implemented for this family");
+  throw std::runtime_error(
+    "tau_to_parameters() is not available for the " + get_family_name() +
+    " family: its parameters are not determined by Kendall's tau alone. It is "
+    "available for the one-parameter families in bicop_families::itau "
+    "(indep, gaussian, clayton, gumbel, frank, joe).");
 }
 
 //! Default tail dependence: not implemented for this family, so all four

--- a/include/vinecopulib/bicop/implementation/class.ipp
+++ b/include/vinecopulib/bicop/implementation/class.ipp
@@ -1668,17 +1668,32 @@ Bicop::get_npars() const
 
 //! @brief Converts a Kendall's \f$ \tau \f$ into copula parameters
 //! for one-parameter families.
+//!
+//! @details Only available where \f$ \tau \f$ determines the parameters
+//! completely: the one-parameter families in `bicop_families::itau`, i.e.
+//! `indep`, `gaussian`, `clayton`, `gumbel`, `frank` and `joe`. Note that
+//! `student` belongs to `bicop_families::itau` — it can be *fitted* by
+//! inverting \f$ \tau \f$ — but is not invertible here, because \f$ \tau
+//! \f$ pins its correlation and leaves the degrees of freedom free.
+//!
 //! @param tau A value in \f$ (-1, 1) \f$.
+//! @throws std::runtime_error if the family is not one of those listed above.
+//! @see parameters_to_tau(), which is available for every family.
 inline Eigen::MatrixXd
 Bicop::tau_to_parameters(const double& tau) const
 {
   return bicop_->tau_to_parameters(tau);
 }
 
-//! @brief Converts the copula parameters to Kendall's \f$ tau \f$.
+//! @brief Converts the copula parameters to Kendall's \f$ \tau \f$.
+//!
+//! @details Available for every family. For the families whose \f$ \tau \f$
+//! has no closed form (`bb6`, `bb7`, `bb8`, `tawn`) it is computed by
+//! quadrature. The sign is flipped for the 90 and 270 degree rotations.
 //!
 //! @param parameters The parameters (must be a valid parametrization of
 //!     the current family).
+//! @see tau_to_parameters() for the inverse, which only some families admit.
 inline double
 Bicop::parameters_to_tau(const Eigen::MatrixXd& parameters) const
 {

--- a/test/src_test/include/test_bicop_sanity_checks.hpp
+++ b/test/src_test/include/test_bicop_sanity_checks.hpp
@@ -12,6 +12,35 @@
 namespace test_bicop_sanity_checks {
 using namespace vinecopulib;
 
+//! Pins the documented contract of the two tau maps: `parameters_to_tau` is
+//! available for every family, `tau_to_parameters` only where tau determines
+//! the parameters completely.
+TEST(bicop_sanity_checks, tau_maps_are_available_where_documented)
+{
+  const std::vector<BicopFamily> invertible = {
+    BicopFamily::indep,  BicopFamily::gaussian, BicopFamily::clayton,
+    BicopFamily::gumbel, BicopFamily::frank,    BicopFamily::joe
+  };
+  for (auto family : bicop_families::all) {
+    Bicop bicop(family);
+    const bool expected = tools_stl::is_member(family, invertible);
+
+    // parameters_to_tau: every family
+    EXPECT_NO_THROW(bicop.parameters_to_tau(bicop.get_parameters()))
+      << bicop.get_family_name();
+
+    // tau_to_parameters: only the families listed above. Student is in
+    // bicop_families::itau yet is not invertible here, because tau pins its
+    // correlation and leaves the degrees of freedom free.
+    if (expected) {
+      EXPECT_NO_THROW(bicop.tau_to_parameters(0.4)) << bicop.get_family_name();
+    } else {
+      EXPECT_THROW(bicop.tau_to_parameters(0.4), std::runtime_error)
+        << bicop.get_family_name();
+    }
+  }
+}
+
 TEST(bicop_sanity_checks, catches_wrong_parameter_size)
 {
   for (auto family : bicop_families::nonparametric) {


### PR DESCRIPTION
Falls out of writing compiled documentation snippets: an example calling
`tau_to_parameters()` on a BB1 died at runtime with

```
Method not implemented for this family
```

which names neither the family nor what would work, and which nothing in the
documentation predicted.

## What is actually true

Measured across all thirteen families:

| | `parameters_to_tau()` | `tau_to_parameters()` |
|---|---|---|
| `indep`, `gaussian`, `clayton`, `gumbel`, `frank`, `joe` | works | works |
| `student` | works | **throws** |
| `bb1`, `bb6`, `bb7`, `bb8`, `tawn`, `tll` | works | throws |

Two things worth noting:

- **`parameters_to_tau()` is available for every family**, including the
  nonparametric `tll`. The old comment ("must be a valid parametrization of the
  current family") gave no hint of that.
- **`student` is in `bicop_families::itau` but is not invertible here.** It *can*
  be fitted by inverting tau, so membership in that list is the natural thing to
  check — and it gives the wrong answer. tau pins the correlation and leaves the
  degrees of freedom free, so a single-parameter inversion is not well defined.
  That asymmetry is precisely the sort of thing docs owe the reader.

## Changes

- Doxygen on `Bicop::tau_to_parameters` now lists the applicable families,
  calls out the `student` exception explicitly, and carries `@throws`.
- Doxygen on `Bicop::parameters_to_tau` says it is available for every family,
  notes that `bb6`/`bb7`/`bb8`/`tawn` go through quadrature, and records the
  sign flip for the 90/270 rotations.
- The exception message is now actionable:

  ```
  tau_to_parameters() is not available for the Student family: its parameters
  are not determined by Kendall's tau alone. It is available for the
  one-parameter families in bicop_families::itau (indep, gaussian, clayton,
  gumbel, frank, joe).
  ```

- New test `bicop_sanity_checks.tau_maps_are_available_where_documented` asserts
  the table above for all thirteen families, so the documentation and the code
  cannot drift apart.

## Verification

651 tests pass (650 + the new one). No behavior change beyond the message text.

## Note

The other error those snippets caught — `Vinecop::reorient()` rejecting a
conditioning set that is not admissible as a sampling-order tail — needed no fix
here: it is already documented, and its message already points at
`FitControlsVinecop::set_conditioning_set()`. My snippet was simply wrong, and is
fixed in the docs branch.