### PR TITLE
chore: bump the copyright year to 2026

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -344,7 +344,7 @@ jobs:
     name: clang-tidy (diff)
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
-    timeout-minutes: 45
+    timeout-minutes: 75
     steps:
       - uses: actions/checkout@v7
         with:
@@ -352,7 +352,9 @@ jobs:
       - name: Install clang-tidy
         run: |
           sudo apt-get update
-          sudo apt-get install --no-install-recommends -y clang-tidy-14 jq
+          # doxygen: configuring with VINECOPULIB_BUILD_DOC=ON below requires it,
+          # even though only the snippet targets are wanted here.
+          sudo apt-get install --no-install-recommends -y clang-tidy-14 jq doxygen
       - name: Install dependencies
         id: install-dependencies
         uses: ./.github/actions/install-dependencies
@@ -369,21 +371,32 @@ jobs:
       - name: Configure to generate compile_commands.json
         run: |
           mkdir build-tidy && cd build-tidy
-          cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+          # Benchmarks and the documentation snippets are off by default; enable
+          # them so their translation units appear in compile_commands.json,
+          # without which clang-tidy lints them using default flags.
+          cmake .. -DCMAKE_BUILD_TYPE=Debug -DCMAKE_EXPORT_COMPILE_COMMANDS=ON \
+            -DVINECOPULIB_BUILD_BENCHMARKS=ON -DVINECOPULIB_BUILD_DOC=ON
           # Drop FetchContent (googletest) translation units.
           jq '[.[] | select(.file | test("_deps/") | not)]' compile_commands.json > filtered.json
           mv filtered.json compile_commands.json
+      # Only translation units: headers have no compile_commands.json entry, so
+      # clang-tidy would lint them with default flags and report the resulting
+      # clang-diagnostic-errors as findings. The repo-wide pass below covers
+      # them, transitively and with the right flags.
       - name: Run clang-tidy on the diff
         run: |
           git diff -U0 "origin/${{ github.base_ref }}...HEAD" \
-            -- '*.hpp' '*.ipp' '*.cpp' '*.cc' '*.h' \
+            -- '*.cpp' '*.cc' \
             ':(exclude)include/vinecopulib/misc/nlohmann_json.hpp' \
             ':(exclude)include/vinecopulib/misc/tools_stats_sobol.hpp' \
             | /usr/lib/llvm-14/share/clang/clang-tidy-diff.py \
                 -p1 -path build-tidy -clang-tidy-binary clang-tidy-14 -use-color
 
-      # test_all.cpp includes every test header, and so transitively the whole
-      # library: one translation unit covers the tree. Keeps the backlog at zero
-      # rather than only gating new code.
+      # The per-area test translation units include the whole library between
+      # them, so this keeps the backlog at zero rather than only gating new
+      # code. (test_all.cpp is just main() and covers nothing.) Each one takes
+      # minutes, so run them in parallel.
       - name: Run clang-tidy over the whole library
-        run: clang-tidy-14 -p build-tidy --quiet test/test_all.cpp
+        run: |
+          run-clang-tidy-14 -p build-tidy -quiet -j "$(nproc)" \
+            'test/src_test/test_.*[.]cpp'

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the “Software”), to deal in

--- a/benchmarks/src/bench_bicop_families.cpp
+++ b/benchmarks/src/bench_bicop_families.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/benchmarks/src/bench_bicop_tll.cpp
+++ b/benchmarks/src/bench_bicop_tll.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/benchmarks/src/bench_interpolation.cpp
+++ b/benchmarks/src/bench_interpolation.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/benchmarks/src/bench_main.cpp
+++ b/benchmarks/src/bench_main.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/benchmarks/src/bench_tools_stats.cpp
+++ b/benchmarks/src/bench_tools_stats.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/benchmarks/src/bench_vinecop.cpp
+++ b/benchmarks/src/bench_vinecop.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/benchmarks/src/helpers.hpp
+++ b/benchmarks/src/helpers.hpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/benchmarks/src/parity_dump.cpp
+++ b/benchmarks/src/parity_dump.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/benchmarks/src/quadrature_study.cpp
+++ b/benchmarks/src/quadrature_study.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/cmake/findHeaders.cmake
+++ b/cmake/findHeaders.cmake
@@ -4,7 +4,7 @@ if(VINECOPULIB_PRECOMPILED)
     set(vinecopulib_generated_sources ${CMAKE_BINARY_DIR}/generated/src)
     set(vinecopulib_generated_includes ${CMAKE_BINARY_DIR}/generated/include)
 
-    string(CONCAT license "// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter \n"
+    string(CONCAT license "// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter \n"
             "// \n"
             "// This file is part of the vinecopulib library and licensed under the terms of \n"
             "// the MIT license. For a copy, see the LICENSE file in the root directory of \n"

--- a/cmake/templates/rscript.hpp.in
+++ b/cmake/templates/rscript.hpp.in
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/docs/license.dox
+++ b/docs/license.dox
@@ -2,7 +2,7 @@
 
 The MIT License (MIT)
 
-Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of
 this software and associated documentation files (the “Software”), to deal in

--- a/docs/snippets/bicop.cpp
+++ b/docs/snippets/bicop.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/docs/snippets/conditional.cpp
+++ b/docs/snippets/conditional.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/docs/snippets/discrete.cpp
+++ b/docs/snippets/discrete.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/docs/snippets/inference.cpp
+++ b/docs/snippets/inference.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/docs/snippets/vinecop.cpp
+++ b/docs/snippets/vinecop.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/examples/vinecop/src/main.cpp
+++ b/examples/vinecop/src/main.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib.hpp
+++ b/include/vinecopulib.hpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/bicop/abstract.hpp
+++ b/include/vinecopulib/bicop/abstract.hpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/bicop/archimedean.hpp
+++ b/include/vinecopulib/bicop/archimedean.hpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/bicop/bb1.hpp
+++ b/include/vinecopulib/bicop/bb1.hpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/bicop/bb6.hpp
+++ b/include/vinecopulib/bicop/bb6.hpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/bicop/bb7.hpp
+++ b/include/vinecopulib/bicop/bb7.hpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/bicop/bb8.hpp
+++ b/include/vinecopulib/bicop/bb8.hpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/bicop/class.hpp
+++ b/include/vinecopulib/bicop/class.hpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/bicop/clayton.hpp
+++ b/include/vinecopulib/bicop/clayton.hpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/bicop/elliptical.hpp
+++ b/include/vinecopulib/bicop/elliptical.hpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/bicop/extreme_value.hpp
+++ b/include/vinecopulib/bicop/extreme_value.hpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/bicop/family.hpp
+++ b/include/vinecopulib/bicop/family.hpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/bicop/fit_controls.hpp
+++ b/include/vinecopulib/bicop/fit_controls.hpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/bicop/frank.hpp
+++ b/include/vinecopulib/bicop/frank.hpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/bicop/gaussian.hpp
+++ b/include/vinecopulib/bicop/gaussian.hpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/bicop/gumbel.hpp
+++ b/include/vinecopulib/bicop/gumbel.hpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/bicop/implementation/abstract.ipp
+++ b/include/vinecopulib/bicop/implementation/abstract.ipp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/bicop/implementation/archimedean.ipp
+++ b/include/vinecopulib/bicop/implementation/archimedean.ipp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/bicop/implementation/bb1.ipp
+++ b/include/vinecopulib/bicop/implementation/bb1.ipp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/bicop/implementation/bb6.ipp
+++ b/include/vinecopulib/bicop/implementation/bb6.ipp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/bicop/implementation/bb7.ipp
+++ b/include/vinecopulib/bicop/implementation/bb7.ipp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/bicop/implementation/bb8.ipp
+++ b/include/vinecopulib/bicop/implementation/bb8.ipp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/bicop/implementation/class.ipp
+++ b/include/vinecopulib/bicop/implementation/class.ipp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/bicop/implementation/clayton.ipp
+++ b/include/vinecopulib/bicop/implementation/clayton.ipp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/bicop/implementation/elliptical.ipp
+++ b/include/vinecopulib/bicop/implementation/elliptical.ipp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/bicop/implementation/extreme_value.ipp
+++ b/include/vinecopulib/bicop/implementation/extreme_value.ipp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/bicop/implementation/family.ipp
+++ b/include/vinecopulib/bicop/implementation/family.ipp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/bicop/implementation/fit_controls.ipp
+++ b/include/vinecopulib/bicop/implementation/fit_controls.ipp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/bicop/implementation/frank.ipp
+++ b/include/vinecopulib/bicop/implementation/frank.ipp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/bicop/implementation/gaussian.ipp
+++ b/include/vinecopulib/bicop/implementation/gaussian.ipp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/bicop/implementation/gumbel.ipp
+++ b/include/vinecopulib/bicop/implementation/gumbel.ipp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/bicop/implementation/indep.ipp
+++ b/include/vinecopulib/bicop/implementation/indep.ipp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/bicop/implementation/joe.ipp
+++ b/include/vinecopulib/bicop/implementation/joe.ipp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/bicop/implementation/kernel.ipp
+++ b/include/vinecopulib/bicop/implementation/kernel.ipp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/bicop/implementation/parametric.ipp
+++ b/include/vinecopulib/bicop/implementation/parametric.ipp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/bicop/implementation/student.ipp
+++ b/include/vinecopulib/bicop/implementation/student.ipp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/bicop/implementation/tawn.ipp
+++ b/include/vinecopulib/bicop/implementation/tawn.ipp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/bicop/implementation/tll.ipp
+++ b/include/vinecopulib/bicop/implementation/tll.ipp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/bicop/implementation/tools_select.ipp
+++ b/include/vinecopulib/bicop/implementation/tools_select.ipp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/bicop/indep.hpp
+++ b/include/vinecopulib/bicop/indep.hpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/bicop/joe.hpp
+++ b/include/vinecopulib/bicop/joe.hpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/bicop/kernel.hpp
+++ b/include/vinecopulib/bicop/kernel.hpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/bicop/parametric.hpp
+++ b/include/vinecopulib/bicop/parametric.hpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/bicop/student.hpp
+++ b/include/vinecopulib/bicop/student.hpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/bicop/tawn.hpp
+++ b/include/vinecopulib/bicop/tawn.hpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/bicop/tll.hpp
+++ b/include/vinecopulib/bicop/tll.hpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/bicop/tools_select.hpp
+++ b/include/vinecopulib/bicop/tools_select.hpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/misc/fit_controls.hpp
+++ b/include/vinecopulib/misc/fit_controls.hpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/misc/implementation/tools_eigen.ipp
+++ b/include/vinecopulib/misc/implementation/tools_eigen.ipp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/misc/implementation/tools_interpolation.ipp
+++ b/include/vinecopulib/misc/implementation/tools_interpolation.ipp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/misc/implementation/tools_optimization.ipp
+++ b/include/vinecopulib/misc/implementation/tools_optimization.ipp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/misc/implementation/tools_stats.ipp
+++ b/include/vinecopulib/misc/implementation/tools_stats.ipp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/misc/implementation/tools_transforms.ipp
+++ b/include/vinecopulib/misc/implementation/tools_transforms.ipp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/misc/tools_batch.hpp
+++ b/include/vinecopulib/misc/tools_batch.hpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/misc/tools_constants.hpp
+++ b/include/vinecopulib/misc/tools_constants.hpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/misc/tools_eigen.hpp
+++ b/include/vinecopulib/misc/tools_eigen.hpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/misc/tools_integration.hpp
+++ b/include/vinecopulib/misc/tools_integration.hpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/misc/tools_interface.hpp
+++ b/include/vinecopulib/misc/tools_interface.hpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/misc/tools_interpolation.hpp
+++ b/include/vinecopulib/misc/tools_interpolation.hpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/misc/tools_optimization.hpp
+++ b/include/vinecopulib/misc/tools_optimization.hpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/misc/tools_serialization.hpp
+++ b/include/vinecopulib/misc/tools_serialization.hpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/misc/tools_stats.hpp
+++ b/include/vinecopulib/misc/tools_stats.hpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/misc/tools_stats_ghalton.hpp
+++ b/include/vinecopulib/misc/tools_stats_ghalton.hpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/misc/tools_stats_sobol.hpp
+++ b/include/vinecopulib/misc/tools_stats_sobol.hpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/misc/tools_stl.hpp
+++ b/include/vinecopulib/misc/tools_stl.hpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/misc/tools_thread.hpp
+++ b/include/vinecopulib/misc/tools_thread.hpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/misc/tools_transforms.hpp
+++ b/include/vinecopulib/misc/tools_transforms.hpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/misc/triangular_array.hpp
+++ b/include/vinecopulib/misc/triangular_array.hpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/version.hpp
+++ b/include/vinecopulib/version.hpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/vinecop/class.hpp
+++ b/include/vinecopulib/vinecop/class.hpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/vinecop/fit_controls.hpp
+++ b/include/vinecopulib/vinecop/fit_controls.hpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/vinecop/implementation/class.ipp
+++ b/include/vinecopulib/vinecop/implementation/class.ipp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/vinecop/implementation/fit_controls.ipp
+++ b/include/vinecopulib/vinecop/implementation/fit_controls.ipp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/vinecop/implementation/rvine_structure.ipp
+++ b/include/vinecopulib/vinecop/implementation/rvine_structure.ipp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/vinecop/implementation/rvine_trees.ipp
+++ b/include/vinecopulib/vinecop/implementation/rvine_trees.ipp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/vinecop/implementation/tools_select.ipp
+++ b/include/vinecopulib/vinecop/implementation/tools_select.ipp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/vinecop/rvine_structure.hpp
+++ b/include/vinecopulib/vinecop/rvine_structure.hpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/vinecop/rvine_trees.hpp
+++ b/include/vinecopulib/vinecop/rvine_trees.hpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/include/vinecopulib/vinecop/tools_select.hpp
+++ b/include/vinecopulib/vinecop/tools_select.hpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/test/src_test/include/kernel_test.hpp
+++ b/test/src_test/include/kernel_test.hpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/test/src_test/include/parbicop_test.hpp
+++ b/test/src_test/include/parbicop_test.hpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/test/src_test/include/r_parity.hpp
+++ b/test/src_test/include/r_parity.hpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/test/src_test/include/test_utils.hpp
+++ b/test/src_test/include/test_utils.hpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/test/src_test/include/vinecop_test.hpp
+++ b/test/src_test/include/vinecop_test.hpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/test/src_test/kernel_test.cpp
+++ b/test/src_test/kernel_test.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/test/src_test/parbicop_test.cpp
+++ b/test/src_test/parbicop_test.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/test/src_test/test_bicop_kernel.cpp
+++ b/test/src_test/test_bicop_kernel.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/test/src_test/test_bicop_parametric.cpp
+++ b/test/src_test/test_bicop_parametric.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/test/src_test/test_bicop_sanity_checks.cpp
+++ b/test/src_test/test_bicop_sanity_checks.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/test/src_test/test_bicop_select.cpp
+++ b/test/src_test/test_bicop_select.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/test/src_test/test_bicop_taildep.cpp
+++ b/test/src_test/test_bicop_taildep.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/test/src_test/test_discrete.cpp
+++ b/test/src_test/test_discrete.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/test/src_test/test_rvine_structure.cpp
+++ b/test/src_test/test_rvine_structure.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/test/src_test/test_serialization.cpp
+++ b/test/src_test/test_serialization.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/test/src_test/test_tools_optimization.cpp
+++ b/test/src_test/test_tools_optimization.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/test/src_test/test_tools_stats.cpp
+++ b/test/src_test/test_tools_stats.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/test/src_test/test_vinecop_class.cpp
+++ b/test/src_test/test_vinecop_class.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/test/src_test/test_vinecop_sanity_checks.cpp
+++ b/test/src_test/test_vinecop_sanity_checks.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/test/src_test/test_weights.cpp
+++ b/test/src_test/test_weights.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/test/src_test/vinecop_test.cpp
+++ b/test/src_test/vinecop_test.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of

--- a/test/test_all.cpp
+++ b/test/test_all.cpp
@@ -1,4 +1,4 @@
-// Copyright © 2016-2025 Thomas Nagler and Thibault Vatter
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
 //
 // This file is part of the vinecopulib library and licensed under the terms of
 // the MIT license. For a copy, see the LICENSE file in the root directory of


### PR DESCRIPTION
Stacked on #725.

Year only — `2016-2025` → `2016-2026` — across the 120 owned files that carry the
banner, plus `LICENSE`, `docs/license.dox`, and the license string that
`cmake/findHeaders.cmake` prepends to the generated translation units.
`cmake/templates/rscript.hpp.in` said only `2018` and is brought into line.

`include/vinecopulib/misc/nlohmann_json.hpp` and `cmake/codeCoverage.cmake` are
third-party and untouched.

SPDX identifiers are deliberately **not** part of this. A year-only sweep is
reviewable by a single assertion:

```
$ git diff --stat                     # 120 files, one changed line each
$ git diff -U0 | grep '^[+-]' | grep -v -- '---\|+++' | grep -cv '2016-202[56]'
0
$ git grep -l 'Copyright © 2016-2025' | grep -v nlohmann | wc -l
0
```

A length-changing edit would not be, and it would mean simultaneously trusting
the generated-source banner handling across ~28 files.

## Verification

Configured `VINECOPULIB_PRECOMPILED=ON` and confirmed the generated `.cpp` files
still begin with a well-formed banner followed by their `#include`, and that the
library builds.
