### PR TITLE
docs: document the benchmark and parity tooling, and add the missing repo files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,30 @@
+# Mirrors .clang-format (Mozilla) for the editors that read this instead.
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.{hpp,ipp,cpp,h,cc}]
+indent_style = space
+indent_size = 2
+max_line_length = 80
+
+[*.{cmake,txt,yml,yaml,json}]
+indent_style = space
+indent_size = 2
+
+[*.py]
+indent_style = space
+indent_size = 4
+
+[*.md]
+# Trailing whitespace is a hard line break in Markdown.
+trim_trailing_whitespace = false
+
+[include/vinecopulib/misc/nlohmann_json.hpp]
+# Vendored verbatim.
+indent_size = unset
+max_line_length = unset

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @tnagler @tvatter

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,24 @@
+---
+name: Bug report
+about: Something behaves incorrectly
+labels: bug
+---
+
+**What happened, and what you expected instead**
+
+**Minimal reproducer**
+
+```cpp
+```
+
+**Environment**
+
+- vinecopulib version / commit:
+- compiler and version:
+- platform:
+- header-only or `VINECOPULIB_PRECOMPILED=ON`:
+
+**Anything else**
+
+For a numerical discrepancy, please include the parameters and the values you
+get against the values you expect.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,15 @@
+---
+name: Feature request
+about: Suggest a capability
+labels: enhancement
+---
+
+**What you are trying to do**
+
+**What the library would need to provide**
+
+**Alternatives you considered**
+
+Note that some things are deliberately out of scope — 1-d marginal estimation,
+binding code, and higher-level estimators live in the R and Python wrappers.
+See the Scope section of AGENTS.md.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+<!-- The squashed commit message is what lands on main; make the description
+     read as that summary. See CONTRIBUTING.md. -->
+
+## What this changes
+
+## Why
+
+## Checklist
+
+- [ ] Formatted with clang-format 14
+- [ ] `ctest` passes locally
+- [ ] `NEWS.md` updated under the unreleased heading, if user-visible
+- [ ] Doxygen comments updated on any changed declaration
+- [ ] Numerical changes checked with the parity harness (`scripts/README.md`)

--- a/.gitignore
+++ b/.gitignore
@@ -45,7 +45,6 @@ cmake-build/
 examples/*/build/
 examples/*/bin/
 compile_commands.json
-.vscode/
 
 # Ctags
 src/tags
@@ -80,7 +79,8 @@ Temporary Items
 debug/
 release/
 
-.claude/
+.claude/settings.local.json
+.claude/*.local.json
 build*/
 
 # generated benchmark & parity-comparison artifacts (see scripts/bench_baseline.sh
@@ -102,3 +102,12 @@ myvine.cbor
 docs/html/
 docs/xml/
 docs/search/
+CMakeUserPresets.json
+.cache/
+*.orig
+*.rej
+*.gcda
+*.gcno
+*.info
+Testing/
+cmake-build-*

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,12 +1,13 @@
 {
     "title": "vinecopulib",
-    "description": "<p><a href=\"https://vinecopulib.github.io/vinecopulib/\">vinecopulib</a> is a header-only C++ library for vine copula models based on Eigen. It provides high-performance implementations of the core features of the popular VineCopula R library, in particular inference algorithms for both vine copula and bivariate copula models</p>",
+    "description": "<p><a href=\"https://vinecopulib.github.io/vinecopulib/\">vinecopulib</a> is a header-only C++17 library for vine copula models, built on Eigen. It provides high-performance implementations of the core features of the VineCopula R package, in particular inference algorithms for both vine copula and bivariate copula models, with nonparametric and multi-parameter families, lower runtimes and lower memory consumption in high dimensions.</p>",
     "keywords": [
-        "dependence",
         "copula",
-        "vine",
+        "vine copula",
         "pair copula construction",
-        "simulation"
+        "dependence modeling",
+        "simulation",
+        "C++"
     ],
     "upload_type": "software",
     "access_right": "open",
@@ -19,6 +20,19 @@
         {
             "orcid": "0000-0001-9212-0218",
             "name": "Vatter, Thibault"
+        }
+    ],
+    "version": "0.8.0",
+    "related_identifiers": [
+        {
+            "identifier": "https://github.com/vinecopulib/rvinecopulib",
+            "relation": "isSupplementTo",
+            "scheme": "url"
+        },
+        {
+            "identifier": "https://github.com/vinecopulib/pyvinecopulib",
+            "relation": "isSupplementTo",
+            "scheme": "url"
         }
     ]
 }

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -79,7 +79,7 @@ Three design principles inform the rest of this file:
   `ghalton`, behind `simulate_uniform`.
 - **Pseudo-observations** — `to_pseudo_obs` (rank-normalize to the unit
   hypercube), the canonical input transform for copula fitting.
-- **Numerics infrastructure** — bound-constrained MLE (Powell's BOBYQA),
+- **Numerics infrastructure** — bound-constrained MLE (Brent and BFGS),
   bilinear interpolation grids for TLL, 1-d numerical integration, a
   thread pool, and JSON (de)serialization.
 
@@ -102,9 +102,11 @@ Three design principles inform the rest of this file:
 
 ## API stability & releases
 
-`vinecopulib` follows **semantic versioning** (`MAJOR.MINOR.PATCH`;
-currently 0.8.0). Because the R and Python interfaces pin a tag of this
-repo, public-API changes are real breaks for downstream users.
+`vinecopulib` follows **semantic versioning** (`MAJOR.MINOR.PATCH`). The
+authoritative version lives in `CMakeLists.txt` and
+[version.hpp](include/vinecopulib/version.hpp) — deliberately not repeated here,
+so this file cannot go stale. Because the R and Python interfaces pin a tag of
+this repo, public-API changes are real breaks for downstream users.
 
 - **Record every change in [NEWS.md](NEWS.md).** Each release has
   `### BREAKING API CHANGES`, `### NEW FEATURES`, and `### BUG FIXES`
@@ -115,17 +117,14 @@ repo, public-API changes are real breaks for downstream users.
   `VINECOPULIB_VERSION` (encoded integer, `800` for 0.8.0 —
   `major*100000 + minor*100 + patch`) and `VINECOPULIB_LIB_VERSION`
   (string, `"x_y[_z]"` — currently `"0_8"`).
-- **Prefer deprecation over a hard break.** The `DEPRECATED` macro
-  (defined in
-  [vinecop/fit_controls.hpp](include/vinecopulib/vinecop/fit_controls.hpp))
-  marks superseded API while keeping it callable — e.g.
-  `Vinecop::select_all` / `select_families` (use `select`),
-  `FitControlsVinecop::get_truncation_level` (use `get_trunc_lvl`). When
-  a rename is unavoidable, ship both for a cycle and document the
-  migration. Recent examples: `mst_algorithm` → `tree_algorithm` and the
-  `"prim"`/`"kruskal"` → `"mst_prim"`/`"mst_kruskal"` value renames
-  (#637); the CMake option `VINECOPULIB_BUILD_SHARED_LIBS` →
-  `VINECOPULIB_PRECOMPILED` (#641).
+- **Prefer deprecation over a hard break.** When a rename is unavoidable, ship
+  both spellings for a cycle and document the migration; the 1.0.0 removals
+  had been deprecated since 0.3.1. Recent examples: `mst_algorithm` →
+  `tree_algorithm` and the `"prim"`/`"kruskal"` → `"mst_prim"`/`"mst_kruskal"`
+  value renames (#637); the CMake option `VINECOPULIB_BUILD_SHARED_LIBS` →
+  `VINECOPULIB_PRECOMPILED` (#641). There is no `DEPRECATED` macro at present —
+  1.0.0 removed its last users along with the macro. Reintroduce one when it is
+  next needed rather than leaving a macro with no callers.
 
 ## Project layout
 
@@ -135,7 +134,7 @@ vinecopulib/
   README.md, NEWS.md, LICENSE, .zenodo.json
   CMakeLists.txt                 # 24-line entry point; includes the cmake/ modules
   .clang-format, .clang-tidy     # Mozilla style; advisory tidy checks
-  codecov.yml, .codacy.yml       # coverage / static-analysis service config
+  codecov.yml                    # coverage service config
 
   include/
     vinecopulib.hpp              # umbrella header — the canonical user include
@@ -161,7 +160,7 @@ vinecopulib/
         tools_stats.hpp          # pseudo-obs, QRNG, distributions, dep. measures
         tools_stats_sobol.hpp, tools_stats_ghalton.hpp
         tools_eigen.hpp, tools_stl.hpp
-        tools_optimization.hpp, tools_bobyqa.hpp   # BOBYQA MLE
+        tools_optimization.hpp, tools_transforms.hpp  # Brent/BFGS MLE
         tools_interpolation.hpp  # InterpolationGrid (TLL)
         tools_serialization.hpp, nlohmann_json.hpp # JSON
         tools_thread.hpp, tools_interface.hpp, tools_batch.hpp  # parallelism
@@ -175,11 +174,19 @@ vinecopulib/
     compilerDefOpt.cmake, buildTargets.cmake, codeCoverage.cmake,
     findR.cmake, printInfo.cmake
     templates/                   # Config.cmake.in, rscript.hpp.in, *.R parity tests
-  test/                          # GoogleTest; thin test_*.cpp + src_test/ logic
+  test/                          # GoogleTest; test_all.cpp + one TU per area in src_test/
   examples/                      # bicop/, vinecop/, benchmark/ — standalone projects
-  docs/                          # Doxyfile(.in), Doxyfile-mcss, *.dox, create-docs.md
-  .github/workflows/             # continuous_integration.yml
+                                 # (benchmark/ is an old chrono harness, unrelated to benchmarks/)
+  benchmarks/                    # google/benchmark suite, parity_dump, quadrature_study
+  scripts/                       # parity comparison, benchmark baselines, version check
+  tools/derivs/                  # the derivative-generation tooling
+  bench_results/                 # benchmark and parity output (gitignored)
+  docs/                          # Doxyfile.in, Doxyfile-mcss.in, *.dox, snippets/
+  .github/workflows/             # continuous_integration, release, release-drift, codeql, docs
 ```
+
+The listing above is the orientation, not an inventory: directories come and go,
+so check the tree rather than trusting it to be exhaustive.
 
 There is **no** `src/` of library `.cpp` files, **no** `lib/` /
 `contrib/` vendored tree, **no** git submodules, and **no**
@@ -517,9 +524,10 @@ Infrastructure shared across both modules:
   densities·CDFs·quantiles, bivariate normal/t CDFs, dependence-measure
   matrices (via `wdm`), and the `BoxCovering` machinery for discrete-ties
   latent-sample recovery.
-- **`tools_optimization` + `tools_bobyqa`** — Powell's BOBYQA
-  bound-constrained optimizer behind an `Optimizer` wrapper; the engine
-  for parametric MLE.
+- **`tools_optimization` + `tools_transforms`** — Brent's bracketing search
+  in one dimension and BFGS above it, behind an `Optimizer` wrapper; the engine
+  for parametric MLE. Bound constraints are handled by transforming the
+  parameters (`tools_transforms`) rather than by the optimizer.
 - **`tools_interpolation`** — `InterpolationGrid`, the bilinear unit-square
   grid backing the `tll` family, with Sinkhorn margin normalization and
   `integrate_1d` / `integrate_2d`.
@@ -558,25 +566,32 @@ headers (`vinecopulib/bicop/class.hpp`, etc.).
 
 ## Tests
 
-GoogleTest, under [test/](test/). The layout is split: thin
-`test/test_<topic>.cpp` translation units register the suites, while the
-actual logic lives in `test/src_test/*.cpp` with fixtures in
-`test/src_test/include/*.hpp`. The executable list (13 binaries, including
-the aggregate `test_all`) is in
-[cmake/buildTargets.cmake](cmake/buildTargets.cmake); each links
-`gtest vinecopulib … src_test`.
+GoogleTest, under [test/](test/). `test/test_all.cpp` is just `main()`; the
+tests live one translation unit per area in `test/src_test/test_*.cpp`, with
+fixtures and helpers in `test/src_test/include/`. Each area is its own **OBJECT**
+library — a test's only visible effect is the static initializer that registers
+it, so a static library would drop it at link time and the suite would run zero
+tests while exiting 0. `test/CheckTestCount.cmake` guards against exactly that.
 
 Conventions:
 
-- **Run** `bin/test_all` (or `ctest`) from the build directory after
-  `make`.
+- **Run** `bin/test_all`, or `ctest -j` (the R fixtures are parallel-safe: each
+  test gets its own exchange directory). Neither depends on the working
+  directory.
+- **Iterate on one area** with `make test_<area>_only`, which compiles and runs
+  only that area; the objects are shared with `test_all`, so nothing is compiled
+  twice. `--gtest_filter` selects a subset without rebuilding.
 - **Coverage** is collected on the Ubuntu/GNU Debug CI build
   (`-DVINECOPULIB_CODE_COVERAGE=ON`, target `vinecopulib_coverage`) and
   uploaded to Codecov; [codecov.yml](codecov.yml) ignores `test/` and the
   vendored `nlohmann_json.hpp`.
-- **R parity tests** are optional: with Rscript available, the
-  `cmake/templates/*.R` scripts cross-check parametric bicop / vinecop
-  results against the VineCopula R package.
+- **R parity tests** are optional, behind `VINECOPULIB_R_PARITY_TESTS`
+  (default ON iff Rscript is found). The `cmake/templates/*.R` scripts
+  cross-check parametric bicop / vinecop results against **VineCopula >= 2.6.2
+  from GitHub, not CRAN**; with the option off the tests skip rather than fail.
+- **Golden values and parity**: the golden-value tests are the CI-enforced part;
+  the before/after `parity_dump` comparison is a manual tool for numerical
+  changes. Both are documented in [scripts/README.md](scripts/README.md).
 - **Round-trip / parity invariants to preserve** when touching numerics:
   JSON `to_file` → constructor round-trips for `Bicop`, `Vinecop`, and
   `RVineStructure`; copula identities (h-function ↔ inverse, Rosenblatt ↔

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,36 @@
+cff-version: 1.2.0
+title: vinecopulib
+message: If you use this software, please cite it as below.
+type: software
+authors:
+  - family-names: Nagler
+    given-names: Thomas
+    orcid: https://orcid.org/0000-0003-1855-0046
+  - family-names: Vatter
+    given-names: Thibault
+    orcid: https://orcid.org/0000-0001-9212-0218
+abstract: >-
+  A header-only C++ library for vine copula models, built on Eigen. It provides
+  high-performance implementations of the core features of the VineCopula R
+  package, in particular inference algorithms for both vine copula and bivariate
+  copula models, with nonparametric and multi-parameter families, lower runtimes
+  and lower memory consumption in high dimensions.
+keywords:
+  - copula
+  - vine copula
+  - pair copula construction
+  - dependence modeling
+  - simulation
+  - C++
+license: MIT
+repository-code: https://github.com/vinecopulib/vinecopulib
+url: https://vinecopulib.github.io/vinecopulib/
+# Zenodo reads this file in preference to .zenodo.json. Keep `version` and
+# `date-released` in step with CMakeLists.txt at release time;
+# scripts/check_version.py enforces it.
+version: 0.8.0
+date-released: '2026-06-12'
+identifiers:
+  - type: doi
+    value: 10.5281/zenodo.1401557
+    description: Concept DOI, resolving to the latest release.

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,9 @@
+# Code of conduct
+
+This project follows the
+[Contributor Covenant](https://www.contributor-covenant.org/version/2/1/code_of_conduct/),
+version 2.1.
+
+In short: be respectful, assume good faith, and keep discussion technical.
+Report unacceptable behavior to the maintainers, Thomas Nagler and
+Thibault Vatter, through GitHub. Reports are handled confidentially.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,86 @@
+# Contributing to vinecopulib
+
+Thanks for taking the time. This file covers the mechanics; the engineering
+invariants — module boundaries, API-stability policy, conventions — are in
+[AGENTS.md](AGENTS.md), which is worth reading before a first change.
+
+## Pull requests
+
+Pull requests go to `main`. Releases are tags on `main`; there is no long-lived
+development branch.
+
+**One pull request, one commit on `main`.** Pull requests are squash-merged, so
+the squashed message — not the intermediate commits — is what explains the change
+to a future reader. Write it as a summary of the whole pull request: what
+changed, why, and anything someone will need later (behavior changes,
+follow-ups). Iterations taken to reach a working state are review history, not
+project history.
+
+Commit subjects follow the convention already visible in `git log`:
+
+```
+feat(vinecop): support conditioning sets in Rosenblatt transforms
+refactor(bicop)!: remove members deprecated since 0.3.1
+fix(vinecop): evaluate a custom tree criterion serially
+docs: rewrite the user documentation for 1.0.0
+```
+
+A `!` marks a breaking change. Scopes are the module directories: `bicop`,
+`vinecop`, `misc`.
+
+For work that builds on work still in review, prefer
+[stacked pull requests](https://docs.github.com/en/pull-requests/how-tos/stacked-pull-requests)
+over one large branch: each gets its own review and its own CI run.
+
+## Before you push
+
+```bash
+# format (exactly clang-format 14; other versions produce a different result)
+pip install clang-format==14.0.6
+clang-format --version    # must print 14.0.6
+git ls-files '*.hpp' '*.ipp' '*.cpp' | grep -v nlohmann_json | xargs clang-format -i
+
+# build and test
+cmake --preset dev        # Debug + sanitizers + strict warnings
+cmake --build build-dev -j
+cd build-dev && ctest -j$(nproc)
+```
+
+While iterating on one area, `make test_<area>_only` builds and runs just that
+area, and `--gtest_filter` selects a subset without rebuilding.
+
+The R parity tests need R with **VineCopula >= 2.6.2 from GitHub, not CRAN**.
+Without R they skip: configure with `-DVINECOPULIB_R_PARITY_TESTS=OFF` to make
+that explicit.
+
+Anything touching numerics should also be checked with the parity harness — see
+[scripts/README.md](scripts/README.md).
+
+## Changelog
+
+Every user-visible change adds a bullet to [NEWS.md](NEWS.md) under the
+unreleased heading, in the section that fits: `BREAKING API CHANGES`,
+`BEHAVIOR CHANGES`, `NEW FEATURES`, `PERFORMANCE`, `BUG FIXES`,
+`BUILD SYSTEM AND DEPENDENCIES`, or `DOCUMENTATION AND TOOLING`.
+
+Style, which the existing entries follow:
+
+- one `* ` bullet per change, one blank line between bullets;
+- wrapped at 80 columns, continuations indented two spaces;
+- **1-3 lines, hard cap 4** — anything longer belongs in the migration guide,
+  which the bullet links;
+- imperative present tense, identifiers in backticks, no bold;
+- a trailing `(#NNN)` with no period after it; several as `(#659, #667)`.
+
+## Documentation
+
+Code examples on the `docs/*.dox` pages are `\snippet`s of compiled sources under
+`docs/snippets/`, and CI compiles *and runs* them. Add an example by adding it
+there and referencing it — do not paste code into the prose, or it will rot.
+
+Doxygen runs with `WARN_AS_ERROR`, so an undocumented parameter or a broken
+reference fails the build. See [docs/create-docs.md](docs/create-docs.md).
+
+## Releasing
+
+See [docs/releasing.md](docs/releasing.md).

--- a/README.md
+++ b/README.md
@@ -3,36 +3,96 @@
 [![Build Status](https://github.com/vinecopulib/vinecopulib/actions/workflows/continuous_integration.yml/badge.svg?branch=main)](https://github.com/vinecopulib/vinecopulib/actions/workflows/continuous_integration.yml)
 [![Coverage Status](https://img.shields.io/codecov/c/github/vinecopulib/vinecopulib/main.svg)](https://codecov.io/github/vinecopulib/vinecopulib?branch=main)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
-[![Documentation](https://img.shields.io/website/http/vinecopulib.github.io/vinecopulib.svg)](https://vinecopulib.github.io/vinecopulib/)
+[![Documentation](https://img.shields.io/badge/docs-website-blue.svg)](https://vinecopulib.github.io/vinecopulib/)
 [![DOI](https://zenodo.org/badge/76354683.svg)](https://zenodo.org/badge/latestdoi/76354683)
 
-#### What is vinecopulib?
+A header-only C++ library for **vine copula models**, built on
+[Eigen](https://eigen.tuxfamily.org/). It provides high-performance
+implementations of the core features of the
+[VineCopula R package](https://github.com/tnagler/VineCopula) — inference
+algorithms for both vine copula and bivariate copula models — with
 
-[vinecopulib](https://vinecopulib.github.io/vinecopulib/) is a header-only C++ library for vine copula models based on
-[Eigen](http://eigen.tuxfamily.org/index.php?title=Main_Page). It provides
-high-performance implementations of the core features of the popular
-[VineCopula R library](https://github.com/tnagler/VineCopula), in particular
-inference algorithms for both vine copula and bivariate copula models.
-Advantages over VineCopula are  
-
-- a stand-alone C++ library with interfaces to both R and Python,
-- a sleaker and more modern API,
+- nonparametric and multi-parameter families,
 - shorter runtimes and lower memory consumption, especially in high dimensions,
-- nonparametric and multiparameter families.
+- a sleeker, more modern API,
+- interfaces for [R](https://github.com/vinecopulib/rvinecopulib) and
+  [Python](https://github.com/vinecopulib/pyvinecopulib).
 
-The library also has interfaces for
-[R](https://github.com/vinecopulib/rvinecopulib) and
-[Python](https://github.com/vinecopulib/pyvinecopulib).
+## Requirements
 
-#### Contact
+| | |
+| --- | --- |
+| Compiler | anything with **C++17** |
+| CMake | **3.14** or later |
+| [Eigen](https://eigen.tuxfamily.org/) | 3.3 or later |
+| [Boost](https://www.boost.org/) | **1.75** or later (headers only) |
+| [wdm](https://github.com/tnagler/wdm) | 0.2.6 — found via `find_package`, otherwise fetched at configure time |
+| R (optional) | only for the parity tests, with VineCopula >= 2.6.2 |
 
-If you have any questions regarding the library, feel free to
-[open an issue](https://github.com/vinecopulib/vinecopulib/issues/new) or
-send a mail to [info@vinecopulib.org](mailto:info@vinecopulib.org).
+## Quickstart
 
-#### Documentation
+```bash
+git clone https://github.com/vinecopulib/vinecopulib.git
+cd vinecopulib
+cmake -S . -B build -DCMAKE_BUILD_TYPE=Release -DBUILD_TESTING=OFF
+cmake --build build -j
+sudo cmake --install build
+```
 
-For documentation of the library's functionality and
-instructions how to use it, check out our
-[website](https://vinecopulib.github.io/vinecopulib/) or the `docs/` folder
-in this repository.
+Then, from your own project:
+
+```cmake
+find_package(vinecopulib REQUIRED)
+target_link_libraries(my_target PRIVATE vinecopulib::vinecopulib)
+```
+
+```cpp
+#include <vinecopulib.hpp>
+
+using namespace vinecopulib;
+
+int main() {
+  auto data = tools_stats::simulate_uniform(500, 5);
+
+  // select the structure, the families, and the parameters
+  Vinecop model(data);
+  std::cout << model.str() << std::endl;
+
+  auto pdf = model.pdf(data);
+  auto sim = model.simulate(100);
+}
+```
+
+The library is header-only by default; `-DVINECOPULIB_PRECOMPILED=ON` compiles it
+into a real library instead.
+
+## Documentation
+
+The [website](https://vinecopulib.github.io/vinecopulib/) is the reference:
+
+- [Setup](https://vinecopulib.github.io/vinecopulib/setup.html) — building, installing, and every CMake option
+- [Bivariate copulas](https://vinecopulib.github.io/vinecopulib/overview-bicop.html) and [vine copulas](https://vinecopulib.github.io/vinecopulib/overview-vinecop.html)
+- [Discrete variables](https://vinecopulib.github.io/vinecopulib/discrete.html), [conditional simulation](https://vinecopulib.github.io/vinecopulib/conditional.html), [scores and Hessians](https://vinecopulib.github.io/vinecopulib/inference.html)
+
+Every code example on those pages is compiled and run in CI, from the sources
+under [`docs/snippets/`](docs/snippets).
+
+## Contributing
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for the workflow and
+[AGENTS.md](AGENTS.md) for the engineering invariants. The benchmark and
+numerical-parity tooling is documented in
+[benchmarks/README.md](benchmarks/README.md) and
+[scripts/README.md](scripts/README.md); releases in
+[docs/releasing.md](docs/releasing.md).
+
+## Citation
+
+If you use vinecopulib in your work, please cite it. [CITATION.cff](CITATION.cff)
+carries the machine-readable metadata, which GitHub renders as a citation in the
+sidebar.
+
+## Contact
+
+[Open an issue](https://github.com/vinecopulib/vinecopulib/issues/new) or write to
+[info@vinecopulib.org](mailto:info@vinecopulib.org).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,19 @@
+# Security policy
+
+## Supported versions
+
+Fixes go into the next release from `main`. Older tags are not patched.
+
+## Reporting a vulnerability
+
+Please report privately through GitHub's
+[security advisories](https://github.com/vinecopulib/vinecopulib/security/advisories/new)
+rather than a public issue.
+
+vinecopulib is a numerical library: it parses model files (JSON and CBOR) and
+otherwise operates on in-memory numeric data. The most plausible reports are
+crashes or memory errors from malformed model files, or from data whose shape
+violates a documented precondition. Both are worth reporting.
+
+Please include the vinecopulib version, compiler and platform, and the smallest
+input that reproduces the problem.

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,21 +1,7 @@
-# Benchmark suite (google/benchmark) + numerical parity harness.
-#
-# Not built by default and never installed. Enable with:
-#   cmake -S . -B build-bench -DCMAKE_BUILD_TYPE=Release \
-#         -DVINECOPULIB_BUILD_BENCHMARKS=ON -DBUILD_TESTING=OFF
-#   cmake --build build-bench -j
-#
-# Baseline capture (reference machine, performance governor pinned):
-#   build-bench/bin/bench_all --benchmark_repetitions=10 \
-#     --benchmark_report_aggregates_only=true \
-#     --benchmark_out=baseline.json --benchmark_out_format=json
-# Then after changes, write contender.json the same way and compare with
-#   _deps/googlebenchmark-src/tools/compare.py benchmarks baseline.json contender.json
-#
-# Numerical parity:
-#   build-bench/bin/parity_dump parity_master.json     (on master)
-#   build-bench/bin/parity_dump parity_branch.json     (on the branch)
-#   python3 scripts/compare_parity.py parity_master.json parity_branch.json
+# Benchmark suite (google/benchmark), numerical parity harness, and the
+# quadrature study. Not built by default and never installed:
+#   cmake --preset bench && cmake --build build-bench -j
+# See benchmarks/README.md and scripts/README.md.
 
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_BINARY_DIR}/bin)
 

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,96 @@
+# Benchmarks
+
+A [google/benchmark](https://github.com/google/benchmark) suite (`bench_all`)
+and a numerical parity harness (`parity_dump`), plus the quadrature study that
+chose the Kendall's-tau integration rule (`quadrature_study`).
+
+> **Not** `examples/benchmark/`. That is an unrelated, pre-existing `chrono`
+> harness and has nothing to do with this suite.
+
+## Building and running
+
+```bash
+cmake --preset bench          # Release + VINECOPULIB_BUILD_BENCHMARKS + native arch
+cmake --build build-bench -j
+build-bench/bin/bench_all
+```
+
+Or spelled out:
+
+```bash
+cmake -S . -B build-bench -DCMAKE_BUILD_TYPE=Release \
+      -DVINECOPULIB_BUILD_BENCHMARKS=ON -DBUILD_TESTING=OFF
+cmake --build build-bench -j
+```
+
+Useful flags:
+
+| flag | effect |
+| --- | --- |
+| `--benchmark_filter=<regex>` | run a subset, e.g. `--benchmark_filter='bicop/pdf/Clayton'` |
+| `--benchmark_repetitions=10` | repeat, for the aggregate statistics |
+| `--benchmark_report_aggregates_only=true` | print only mean/median/stddev |
+| `--benchmark_out=x.json --benchmark_out_format=json` | machine-readable output |
+
+## Layout
+
+| file | covers |
+| --- | --- |
+| `src/bench_bicop_families.cpp` | per-family evaluation, fitting, discrete dispatch |
+| `src/bench_bicop_tll.cpp` | the nonparametric `tll` family |
+| `src/bench_interpolation.cpp` | `InterpolationGrid` |
+| `src/bench_tools_stats.cpp` | pseudo-observations, QRNG, distributions, dependence measures |
+| `src/bench_vinecop.cpp` | vine selection, evaluation, simulation, Rosenblatt |
+| `src/bench_main.cpp` | hand-rolled `main` |
+| `src/helpers.hpp` | seeded fixtures shared by all of the above |
+
+`bench_main.cpp` is hand-written rather than `BENCHMARK_MAIN()` only so that the
+file stays a normal translation unit; it does exactly what the macro does.
+
+## Adding a case
+
+Cases are registered at static-initialization time from a file-local
+`Registrar`, not with the `BENCHMARK()` macro, because the names are built at
+runtime from the family list:
+
+```cpp
+struct Registrar
+{
+  Registrar()
+  {
+    for (auto family : families) {
+      register_eval_benchmarks(family);
+    }
+  }
+};
+const Registrar registrar;   // registers when the TU is loaded
+```
+
+Follow the slash-namespaced naming convention — `bicop/pdf/Clayton/n=1000` — so
+that `--benchmark_filter` can select by surface, family or size. Use the seeded
+fixtures in `helpers.hpp`: every input must be deterministic, or run-to-run
+comparisons mean nothing.
+
+## Comparing two runs
+
+`scripts/bench_baseline.sh` is the one-command driver; see
+[`../scripts/README.md`](../scripts/README.md) for the whole workflow, including
+the numerical parity harness that guards against a "speedup" that quietly
+changes results.
+
+## The quadrature study
+
+`src/quadrature_study.cpp` measures accuracy *and* time for several quadrature
+rules on the four `parameters_to_tau` integrands (BB6, BB7, BB8, Tawn), against
+50-digit references computed in the same harness with
+`boost::multiprecision`. It cross-checks its restated integrands against
+`Bicop::get_tau()` first, so a mismatch means the study is wrong rather than the
+library.
+
+It is a study, not a regression test: run it when changing an integrand or the
+integration rule.
+
+```bash
+cmake --build build-bench -j --target quadrature_study
+build-bench/bin/quadrature_study
+```

--- a/benchmarks/src/parity_dump.cpp
+++ b/benchmarks/src/parity_dump.cpp
@@ -4,12 +4,11 @@
 // the MIT license. For a copy, see the LICENSE file in the root directory of
 // vinecopulib or https://vinecopulib.github.io/vinecopulib/.
 
-// Dumps a JSON file of numerical outputs across the surfaces touched by the
-// performance work, for before/after comparison via
-// scripts/compare_parity.py. Fully deterministic (fixed seeds everywhere).
+// Dumps a JSON file of numerical outputs across the surfaces the optimization
+// work touches, for before/after comparison via scripts/compare_parity.py.
+// Fully deterministic (fixed seeds everywhere). See scripts/README.md.
 //
 // Usage: parity_dump [output.json]  (default: bench_results/parity.json)
-// Keep generated dumps under bench_results/ so they stay gitignored.
 
 #include "helpers.hpp"
 #include <fstream>

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,52 @@
+# Releasing
+
+Releases are tags on `main`. The steady state is a `NEWS.md` whose top heading
+says `(unreleased)`; a dated heading means a release is in flight, and a dated
+heading with no tag is a bug — which is what `release-drift.yml` looks for
+weekly. That is how 0.8.0 ended up fully written up and never released.
+
+## Steps
+
+1. Confirm `main` is green and every intended pull request has merged.
+2. Open a release pull request that retitles the top `NEWS.md` heading from
+   `(unreleased)` to the release date and — if the version was not already
+   bumped along with the changelog — sets it in the places that must agree:
+   - `CMakeLists.txt` — `project(vinecopulib VERSION X.Y.Z ...)`
+   - `include/vinecopulib/version.hpp` — `VINECOPULIB_VERSION` (a **plain
+     decimal** literal: `000800` is octal and does not mean what it looks like)
+     and `VINECOPULIB_LIB_VERSION`
+   - `CITATION.cff` — `version` and `date-released`
+   - `.zenodo.json` — `version`
+
+   Bumping the version with the changelog and dating the heading here is the
+   usual split: `check_version.py` compares the `NEWS.md` heading against the
+   project version, so doing both at once keeps every intermediate pull
+   request green.
+3. Wait for the `version` CI job. `scripts/check_version.py` fails if any of
+   those disagree with each other or with `NEWS.md`.
+4. Merge, then tag:
+   ```bash
+   git tag -a vX.Y.Z -m "vinecopulib X.Y.Z"
+   git push origin vX.Y.Z
+   ```
+5. Confirm `release.yml` created the GitHub release from the `NEWS.md` section,
+   and `docs.yml` deployed the website.
+6. Confirm the Zenodo deposition; update the DOI badge if the concept DOI
+   changed.
+7. **Open the next cycle immediately**: add a `## vinecopulib X.Y+1.0
+   (unreleased)` heading to `NEWS.md`. This is the step that prevents a repeat —
+   without it, a dated heading is ambiguous.
+8. File pin-bump issues in
+   [rvinecopulib](https://github.com/vinecopulib/rvinecopulib) and
+   [pyvinecopulib](https://github.com/vinecopulib/pyvinecopulib). Both pin a tag
+   of this repository, so every public-API or behavior change here is a real
+   change for their users.
+
+## What the automation covers
+
+| workflow | trigger | does |
+| --- | --- | --- |
+| `continuous_integration.yml` (`version` job) | every pull request | `check_version.py`, i.e. internal consistency |
+| `release.yml` | `v*` tag | `check_version.py --released --tag`, re-runs the matrix, extracts the `NEWS.md` section, creates the release |
+| `docs.yml` | `v*` tag | builds and publishes the m.css website |
+| `release-drift.yml` | weekly | fails if `CMakeLists.txt`'s version has no matching tag |

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,94 @@
+# Scripts
+
+Tooling for the two things that are easy to break silently: numerical results
+and the release version.
+
+## Numerical parity
+
+A performance change is only acceptable if it does not move the numbers. The
+parity harness makes that checkable.
+
+`benchmarks/src/parity_dump.cpp` writes one JSON file of outputs across the
+surfaces the optimization work touches — bivariate evaluation and fitting, TLL,
+`tools_stats`, vine evaluation and selection, and the Kendall's-tau sweeps — on a
+fixed 21x21 lattice with fixed seeds. It is fully deterministic, so two dumps
+differ only where the code does.
+
+```bash
+# on the baseline
+git checkout main
+cmake -S . -B build-bench -DCMAKE_BUILD_TYPE=Release \
+      -DVINECOPULIB_BUILD_BENCHMARKS=ON -DBUILD_TESTING=OFF
+cmake --build build-bench -j --target parity_dump
+build-bench/bin/parity_dump bench_results/parity_main.json
+
+# on the branch
+git checkout my-branch
+cmake --build build-bench -j --target parity_dump
+build-bench/bin/parity_dump bench_results/parity_branch.json
+
+python3 scripts/compare_parity.py \
+    bench_results/parity_main.json bench_results/parity_branch.json
+```
+
+`compare_parity.py` flattens both files to slash-joined paths
+(`bicop_eval/Clayton/rot0/pdf`) and compares elementwise, choosing a tolerance by
+**longest matching prefix** from `parity_gates.json`. Anything unmatched must be
+bit-identical. `--strict` demands that everywhere, which is the right setting for
+a change that claims to be a pure refactor.
+
+### Re-baselining a gate
+
+When a change is *meant* to move numbers, relax the gate and say why. The
+`_comment*` keys exist for that and are skipped when the gates are read:
+
+```json
+"_comment_tau": "tau integrands reformulated and integrated with tanh-sinh ...",
+"tau/": 1e-07,
+```
+
+A gate without a recorded reason is indistinguishable from a regression someone
+gave up on. Keep the relaxation as narrow as the affected keys.
+
+Note that the lattice covers interiors. Near-boundary corners live in separate
+`*_edge` keys, added after a round of τ bugs that the interior sweeps missed
+entirely — if a change affects extreme parameters, check that those moved as
+intended.
+
+The golden-value tests in the suite
+(`test/src_test/test_tools_stats.cpp`, `test_bicop_kernel.cpp`,
+`test_bicop_sanity_checks.cpp`) are the part of this that CI enforces on every
+run; the dump comparison is a manual, before/after tool.
+
+## Benchmark baselines
+
+`bench_baseline.sh` builds the suite and captures one run:
+
+```bash
+scripts/bench_baseline.sh bench_results/baseline.json --benchmark_repetitions=10
+# ... make the change ...
+scripts/bench_baseline.sh bench_results/contender.json --benchmark_repetitions=10
+python3 build-bench/_deps/googlebenchmark-src/tools/compare.py \
+    benchmarks bench_results/baseline.json bench_results/contender.json
+```
+
+Output goes to `bench_results/` (gitignored). Pin the CPU governor and use
+repetitions if you intend to trust small differences. See
+[`../benchmarks/README.md`](../benchmarks/README.md) for the suite itself.
+
+## Version consistency
+
+`check_version.py` cross-checks the project version everywhere it appears —
+`CMakeLists.txt`, both macros in `version.hpp`, `CITATION.cff`, `.zenodo.json`,
+and the top heading of `NEWS.md`:
+
+```bash
+python3 scripts/check_version.py            # every PR (CI runs this)
+python3 scripts/check_version.py --released # also requires a dated NEWS heading
+python3 scripts/check_version.py --tag v1.0.0
+```
+
+`--released` is what `release.yml` runs against a tag. The weekly
+`release-drift.yml` catches the opposite failure: a version dated in `NEWS.md`
+with no tag pushed, which is exactly how 0.8.0 ended up written up but never
+released.

--- a/scripts/compare_parity.py
+++ b/scripts/compare_parity.py
@@ -22,20 +22,14 @@ replace the built-in table (use as gates are relaxed per phase).
 import argparse
 import json
 import math
+import pathlib
 import sys
 
-# Built-in gate table; update as optimization phases land (see plan).
-# Ordered by specificity: first match wins.
-DEFAULT_GATES = [
-    # Phase 2.6: integration tolerance 1e-12 -> 1e-9 on tau
-    # ("tau/", 1e-7),
-    # Phase 2: log-pdf pathway + vectorized leaves (fp reassociation)
-    # ("bicop_eval/", 1e-12),
-    # ("bicop_fit/", 1e-8),
-    # Phase 3: tll overhaul
-    # ("tll/", 1e-6),
-    # ("vinecop/", 1e-9),
-]
+# The accepted gates live in parity_gates.json next to this script, which is the
+# default for --tol-config. There is deliberately no built-in table: an empty one
+# silently demands bit-identical results everywhere, which no real comparison
+# meets.
+DEFAULT_TOL_CONFIG = pathlib.Path(__file__).with_name("parity_gates.json")
 
 
 def flatten(obj, prefix=""):
@@ -85,8 +79,9 @@ def main():
     ap.add_argument("branch")
     ap.add_argument("--strict", action="store_true",
                     help="require bit-identical everywhere")
-    ap.add_argument("--tol-config", default=None,
-                    help="JSON file: {prefix: tol} overriding the gate table")
+    ap.add_argument("--tol-config", default=str(DEFAULT_TOL_CONFIG),
+                    help="JSON file of {prefix: tolerance} gates "
+                         "(default: %(default)s)")
     args = ap.parse_args()
 
     with open(args.master) as f:
@@ -94,11 +89,14 @@ def main():
     with open(args.branch) as f:
         branch = flatten(json.load(f))
 
-    gates = [] if args.strict else list(DEFAULT_GATES)
-    if args.tol_config and not args.strict:
+    gates = []
+    if not args.strict:
         with open(args.tol_config) as f:
-            gates = sorted(json.load(f).items(),
-                           key=lambda kv: -len(kv[0]))
+            # _comment* keys document why a gate was relaxed; they are prose,
+            # not prefixes, and their string values would break the comparison.
+            entries = {k: v for k, v in json.load(f).items()
+                       if not k.startswith("_comment")}
+        gates = sorted(entries.items(), key=lambda kv: -len(kv[0]))
 
     missing = sorted(set(master) - set(branch))
     added = sorted(set(branch) - set(master))


### PR DESCRIPTION
Stacked on #726.

`benchmarks/` and `scripts/` were new this cycle and undocumented outside four
comment blocks that contradicted each other — they disagreed about whether output
goes to the working directory or `bench_results/`, and one omitted the
then-mandatory `--tol-config`. They now have READMEs, and the comment blocks are
one-line pointers at them.

## Two footguns found while documenting the parity harness

- **`compare_parity.py`'s built-in gate table was entirely commented out**, so a
  bare invocation silently demanded bit-identical results everywhere — which no
  real comparison meets. `--tol-config` now defaults to
  `scripts/parity_gates.json`.
- **`_comment*` keys were loaded as gate prefixes.** Their values are prose, so
  had one ever matched a key, the comparison would have raised `TypeError` rather
  than reporting a difference. They are now skipped.

## New files

| file | purpose |
| --- | --- |
| `benchmarks/README.md` | the suite, the `Registrar` pattern, the naming convention, the quadrature study, and an explicit warning that `examples/benchmark/` is an unrelated pre-existing harness |
| `scripts/README.md` | the parity workflow end to end, how to re-baseline a gate *with a recorded reason*, and the version tooling |
| `CONTRIBUTING.md` | workflow, commit convention, the NEWS.md style rules verbatim, stacked PRs |
| `CITATION.cff` | Zenodo reads this in preference to `.zenodo.json`; `check_version.py` already expected it |
| `SECURITY.md`, `CODE_OF_CONDUCT.md` | were missing |
| `docs/releasing.md` | the runbook, including the step that prevents another written-up-but-never-tagged release |
| `.github/` templates, `CODEOWNERS`, `.editorconfig` | were missing |

## README

Rewritten from a 2017 feature list into a requirements table, a quickstart using
`vinecopulib::vinecopulib`, and links to the pages. The 404ing Codacy badge is
gone, as is the deprecated `img.shields.io/website/http/...` form.

## AGENTS.md truth pass

Claims that had gone stale:

- BOBYQA and `tools_bobyqa.hpp` — replaced by Brent and BFGS in #685;
- the `DEPRECATED` macro — removed in #718 along with its last users;
- the test layout — now one translation unit per area;
- the project layout — `benchmarks/`, `scripts/`, `tools/` were missing, and the
  listing implied it was exhaustive;
- **the hardcoded version** — removed in favor of pointing at `CMakeLists.txt`,
  so this particular drift cannot recur.

## .gitignore

`.claude/` was ignored wholesale while `.claude/agents/ponytail.md` is tracked
(force-added), so any new shared file there was silently unaddable. Narrowed to
the local settings files, and the duplicated entries are collapsed.
