### PR TITLE
Support custom conditioning sets and unified discrete layouts

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -100,6 +100,10 @@ wrong thing.
   reorient the vine through non-owning views rather than copying pair copulas
   (#715)
 
+* Accept and document both the expanded `2d` and compact `d + k` data layouts
+  consistently across bivariate and vine copula operations, including the
+  Rosenblatt transforms and conditional simulation
+
 * Evaluate copulas with one parameter set per observation: `pdf`, `cdf`,
   h-functions, `loglik`, `simulate` and the derivative methods on `Bicop`, and
   the corresponding `Vinecop` surfaces (#675, #699, #719)

--- a/NEWS.md
+++ b/NEWS.md
@@ -146,6 +146,10 @@ wrong thing.
 
 ### BUG FIXES
 
+* Treat omitted pair-copulas as implicit independence during evaluation of a
+  `Vinecop` constructed from a full structure, preventing conditional
+  simulation from accessing an empty pair-copula store (#729)
+
 * Fix four numerical defects in `parameters_to_tau`: Tawn's `A''` evaluated to
   `inf * 0` for small psi and cancelled to a negative value elsewhere, its
   integrand peaks away from 1/2 for asymmetric parameters, and the BB7 and BB8

--- a/NEWS.md
+++ b/NEWS.md
@@ -102,7 +102,7 @@ wrong thing.
 
 * Accept and document both the expanded `2d` and compact `d + k` data layouts
   consistently across bivariate and vine copula operations, including the
-  Rosenblatt transforms and conditional simulation
+  Rosenblatt transforms and conditional simulation (#729)
 
 * Evaluate copulas with one parameter set per observation: `pdf`, `cdf`,
   h-functions, `loglik`, `simulate` and the derivative methods on `Bicop`, and

--- a/docs/conditional.dox
+++ b/docs/conditional.dox
@@ -32,12 +32,12 @@ columns of `u_cond` correspond to `conditioning_set` in the supplied order.
 `u_cond` has one row per output sample; to draw many samples at a single
 conditioning point, repeat that point over the rows.
 
-With an explicit `conditioning_set`, `u_cond` can use either layout described
-in @ref discrete: the preferred expanded layout has `2k` columns, while the
-compact layout has `k + k_d` columns, where `k_d` is the number of discrete
-conditioning variables. The overload without `conditioning_set` infers `k`
-from the column count and retains the compact interpretation when the two
-layouts are ambiguous.
+With an explicit `conditioning_set`, `u_cond` can use either layout from the
+@ref discrete "discrete-data documentation". The preferred expanded layout has
+`2k` columns, while the compact layout has `k + k_d` columns, where `k_d` is the
+number of discrete conditioning variables. The overload without
+`conditioning_set` infers `k` from the column count and retains the compact
+interpretation when the two layouts are ambiguous.
 
 The result is an \f$ n \times d \f$ matrix in which the conditioning columns
 reproduce `u_cond` and the remaining ones are draws from the conditional

--- a/docs/conditional.dox
+++ b/docs/conditional.dox
@@ -32,6 +32,13 @@ columns of `u_cond` correspond to `conditioning_set` in the supplied order.
 `u_cond` has one row per output sample; to draw many samples at a single
 conditioning point, repeat that point over the rows.
 
+With an explicit `conditioning_set`, `u_cond` can use either layout described
+in @ref discrete: the preferred expanded layout has `2k` columns, while the
+compact layout has `k + k_d` columns, where `k_d` is the number of discrete
+conditioning variables. The overload without `conditioning_set` infers `k`
+from the column count and retains the compact interpretation when the two
+layouts are ambiguous.
+
 The result is an \f$ n \times d \f$ matrix in which the conditioning columns
 reproduce `u_cond` and the remaining ones are draws from the conditional
 distribution. Discrete conditioning variables are supported and need their

--- a/docs/conditional.dox
+++ b/docs/conditional.dox
@@ -23,9 +23,14 @@ the vine order.
 @section conditional-simulate Simulating conditionally
 
 `simulate_conditional(u_cond, ...)` draws the remaining variables given the
-conditioning values. `u_cond` has one row per output sample, and its columns
-correspond, left to right, to the **last `k` entries of the vine order**. To draw
-many samples at a single conditioning point, repeat that point over the rows.
+conditioning values. By default, the conditioning variables are the last `k`
+entries of the vine order. The overload
+`simulate_conditional(u_cond, conditioning_set, ...)` accepts any conditioning
+set that is admissible as a sampling-order tail and evaluates the model in that
+orientation without modifying it. Indices are 1-based, and the first `k`
+columns of `u_cond` correspond to `conditioning_set` in the supplied order.
+`u_cond` has one row per output sample; to draw many samples at a single
+conditioning point, repeat that point over the rows.
 
 The result is an \f$ n \times d \f$ matrix in which the conditioning columns
 reproduce `u_cond` and the remaining ones are draws from the conditional

--- a/docs/discrete.dox
+++ b/docs/discrete.dox
@@ -13,17 +13,22 @@ that scale has atoms: the model needs both \f$ F(x) \f$ and the left limit
 
 @section discrete-layout The data layout
 
-Every data-taking method uses the same convention. For `d` variables of which
-`k` are discrete, the data matrix has \f$ d + k \f$ columns:
+Every data-taking method accepts two equivalent conventions. The preferred
+expanded layout has \f$ 2d \f$ columns:
 
 - the first `d` columns hold \f$ F(x) \f$ for every variable, in the model's
   variable order;
-- the next `k` columns hold \f$ F(x^-) \f$ for the discrete variables only, in
-  the order in which those variables appear among the first `d`.
+- the next `d` columns hold \f$ F(x^-) \f$ in the same order.
 
-For an all-discrete model this is the \f$ n \times 2d \f$ case. Continuous
-variables need no second column, since for them the left limit and the
-distribution function coincide.
+For continuous variables \f$ F(x^-) = F(x) \f$, so their columns in the second
+block duplicate the corresponding columns in the first block. These duplicate
+columns may be omitted: if `k` of the `d` variables are discrete, the compact
+layout has \f$ d + k \f$ columns, with the `k` left-limits ordered by the
+positions of the discrete variables in the first block.
+
+Both layouts are accepted throughout the library. The expanded layout is often
+more convenient for interfaces because its shape does not depend on
+`var_types`; the compact layout avoids storing duplicate continuous columns.
 
 @section discrete-bicop Bivariate copulas
 
@@ -35,7 +40,7 @@ mixed-discrete expressions (`pdf_c_d`, `pdf_d_d` internally).
 
 @section discrete-vinecop Vine copulas
 
-The same convention applies to `Vinecop`, whose `var_types` has one entry per
+The same conventions apply to `Vinecop`, whose `var_types` has one entry per
 variable. `simulate()` returns the `d` \f$ F(x) \f$ columns only.
 
 `set_var_types()` on an existing model re-types the pair copulas according to

--- a/docs/snippets/conditional.cpp
+++ b/docs/snippets/conditional.cpp
@@ -38,15 +38,10 @@ void
 snippet_simulate_conditional()
 {
   //! [simulate]
-  size_t d = 4;
-  auto data = tools_stats::simulate_uniform(500, d, false, { 2 });
+  Vinecop model(DVineStructure({ 1, 2, 3, 4 }));
+  std::vector<size_t> conditioning_set{ 1, 2 };
 
-  FitControlsVinecop controls;
-  controls.set_conditioning_set({ 3, 4 });
-  Vinecop model(data, RVineStructure(), {}, controls);
-
-  // One conditioning point per output row; the columns correspond, left to
-  // right, to the last k entries of the vine order -- here variables 3 and 4.
+  // One conditioning point per output row; columns follow conditioning_set.
   size_t n = 100;
   Eigen::MatrixXd u_cond(n, 2);
   u_cond.col(0).setConstant(0.3);
@@ -54,7 +49,8 @@ snippet_simulate_conditional()
 
   // n x d: the conditioning columns reproduce u_cond, the rest are draws from
   // the conditional distribution.
-  Eigen::MatrixXd sim = model.simulate_conditional(u_cond, false, 1, { 7 });
+  Eigen::MatrixXd sim =
+    model.simulate_conditional(u_cond, conditioning_set, false, 1, { 7 });
   std::cout << "conditional draws: " << sim.rows() << " x " << sim.cols()
             << std::endl;
   //! [simulate]

--- a/docs/snippets/discrete.cpp
+++ b/docs/snippets/discrete.cpp
@@ -29,16 +29,15 @@ void
 snippet_bicop_discrete()
 {
   //! [bicop]
-  // A discrete variable needs two columns: F(x) and the left limit F(x-). The
-  // data matrix therefore carries one extra column per discrete variable, all
-  // the left limits following the d ordinary columns.
+  // The preferred layout has two full blocks: F(x), followed by F(x-).
   auto continuous = tools_stats::simulate_uniform(500, 2, false, { 1 });
   auto disc = discretize(continuous.col(0), 5);
 
-  Eigen::MatrixXd data(500, 3);
+  Eigen::MatrixXd data(500, 4);
   data.col(0) = disc.first; // F(x) of the discrete variable
   data.col(1) = continuous.col(1);
   data.col(2) = disc.second; // F(x-) of the discrete variable
+  data.col(3) = data.col(1); // F(x-) = F(x) for a continuous variable
 
   // Declare the types, then fit as usual.
   FitControlsBicop controls({ BicopFamily::gaussian, BicopFamily::clayton });
@@ -58,20 +57,20 @@ void
 snippet_vinecop_discrete()
 {
   //! [vinecop]
-  // Same convention for vines: n x (d + k) columns, where k is the number of
-  // discrete variables.
+  // Same convention for vines: the expanded layout has 2d columns.
   size_t d = 4;
   auto continuous = tools_stats::simulate_uniform(500, d, false, { 2 });
   auto disc0 = discretize(continuous.col(0), 4);
   auto disc2 = discretize(continuous.col(2), 6);
 
-  Eigen::MatrixXd data(500, d + 2);
+  Eigen::MatrixXd data(500, 2 * d);
   data.col(0) = disc0.first;
   data.col(1) = continuous.col(1);
   data.col(2) = disc2.first;
   data.col(3) = continuous.col(3);
-  data.col(4) = disc0.second; // left limits, in the order the discrete
-  data.col(5) = disc2.second; // variables appear among the first d columns
+  data.rightCols(d) = data.leftCols(d);
+  data.col(d) = disc0.second;
+  data.col(d + 2) = disc2.second;
 
   Vinecop model(data, RVineStructure(), { "d", "c", "d", "c" });
 

--- a/include/vinecopulib/bicop/class.hpp
+++ b/include/vinecopulib/bicop/class.hpp
@@ -45,7 +45,9 @@ using BicopPtr = std::shared_ptr<AbstractBicop>;
 //!
 class Bicop
 {
+  //! @cond INTERNAL
   friend class BicopView;
+  //! @endcond
 
 public:
   // Constructors

--- a/include/vinecopulib/bicop/implementation/class.ipp
+++ b/include/vinecopulib/bicop/implementation/class.ipp
@@ -184,8 +184,9 @@ Bicop::to_file(const std::string& filename) const
 //! variables the left limit and the cdf itself coincide. Respective columns can
 //! be omitted in the second block.
 //!
-//! @param u An \f$ n \times (2 + k) \f$ matrix of observations contained in
-//!   \f$(0, 1) \f$, where \f$ k \f$ is the number of discrete variables.
+//! @param u An \f$ n \times 4 \f$ or \f$ n \times (2 + k) \f$ matrix of
+//!   observations contained in \f$(0, 1) \f$, where \f$ k \f$ is the number
+//!   of discrete variables.
 //! @return A length n vector of copula densities evaluated at \c u.
 inline Eigen::VectorXd
 Bicop::pdf(const Eigen::MatrixXd& u) const
@@ -206,8 +207,9 @@ Bicop::pdf(const Eigen::MatrixXd& u) const
 //! variables the left limit and the cdf itself coincide. Respective columns can
 //! be omitted in the second block.
 //!
-//! @param u An \f$ n \times (2 + k) \f$ matrix of observations contained in
-//!   \f$(0, 1) \f$, where \f$ k \f$ is the number of discrete variables.
+//! @param u An \f$ n \times 4 \f$ or \f$ n \times (2 + k) \f$ matrix of
+//!   observations contained in \f$(0, 1) \f$, where \f$ k \f$ is the number
+//!   of discrete variables.
 //! @return A length n vector of copula probabilities evaluated at \c u.
 inline Eigen::VectorXd
 Bicop::cdf(const Eigen::MatrixXd& u) const
@@ -244,8 +246,9 @@ Bicop::cdf(const Eigen::MatrixXd& u) const
 //! variables the left limit and the cdf itself coincide. Respective columns can
 //! be omitted in the second block.
 //!
-//! @param u An \f$ n \times (2 + k) \f$ matrix of observations contained in
-//!   \f$(0, 1) \f$, where \f$ k \f$ is the number of discrete variables.
+//! @param u An \f$ n \times 4 \f$ or \f$ n \times (2 + k) \f$ matrix of
+//!   observations contained in \f$(0, 1) \f$, where \f$ k \f$ is the number
+//!   of discrete variables.
 //! @return A length n vector of the first h-function evaluated at \c u.
 inline Eigen::VectorXd
 Bicop::hfunc1(const Eigen::MatrixXd& u) const
@@ -271,8 +274,9 @@ Bicop::hfunc1(const Eigen::MatrixXd& u) const
 //! variables the left limit and the cdf itself coincide. Respective columns can
 //! be omitted in the second block.
 //!
-//! @param u An \f$ n \times (2 + k) \f$ matrix of observations contained in
-//!   \f$(0, 1) \f$, where \f$ k \f$ is the number of discrete variables.
+//! @param u An \f$ n \times 4 \f$ or \f$ n \times (2 + k) \f$ matrix of
+//!   observations contained in \f$(0, 1) \f$, where \f$ k \f$ is the number
+//!   of discrete variables.
 //! @return A length n vector of the second h-function evaluated at \c u.
 inline Eigen::VectorXd
 Bicop::hfunc2(const Eigen::MatrixXd& u) const
@@ -299,8 +303,9 @@ Bicop::hfunc2(const Eigen::MatrixXd& u) const
 //! variables the left limit and the cdf itself coincide. Respective columns can
 //! be omitted in the second block.
 //!
-//! @param u An \f$ n \times (2 + k) \f$ matrix of observations contained in
-//!   \f$(0, 1) \f$, where \f$ k \f$ is the number of discrete variables.
+//! @param u An \f$ n \times 4 \f$ or \f$ n \times (2 + k) \f$ matrix of
+//!   observations contained in \f$(0, 1) \f$, where \f$ k \f$ is the number
+//!   of discrete variables.
 //! @return A length n vector of the inverse of the first h-function evaluated
 //! at \c u.
 inline Eigen::VectorXd
@@ -328,8 +333,9 @@ Bicop::hinv1(const Eigen::MatrixXd& u) const
 //! variables the left limit and the cdf itself coincide. Respective columns can
 //! be omitted in the second block.
 //!
-//! @param u An \f$ n \times (2 + k) \f$ matrix of observations contained in
-//!   \f$(0, 1) \f$, where \f$ k \f$ is the number of discrete variables.
+//! @param u An \f$ n \times 4 \f$ or \f$ n \times (2 + k) \f$ matrix of
+//!   observations contained in \f$(0, 1) \f$, where \f$ k \f$ is the number
+//!   of discrete variables.
 //! @return A length n vector of the inverse of the second h-function evaluated
 //! at \c u.
 inline Eigen::VectorXd
@@ -469,8 +475,9 @@ BicopView::swap_arguments(const Eigen::MatrixXd& u)
 //!
 //! Common arguments:
 //!
-//! - `u`: an \f$ n \times (2 + k) \f$ matrix of observations (see the
-//!   single-argument overloads for the layout with discrete variables).
+//! - `u`: an \f$ n \times 4 \f$ or \f$ n \times (2 + k) \f$ matrix of
+//!   observations (see the single-argument overloads for the layout with
+//!   discrete variables).
 //! - `parameters`: an \f$ n \times p \f$ matrix, where `p` is the number of
 //!   family parameters (`get_parameters().size()`) and row `i` holds the
 //!   parameter set used for row `i` of `u`. Parameters are given in the
@@ -1557,8 +1564,9 @@ Bicop::simulate(const Eigen::MatrixXd& parameters,
 //! variables the left limit and the cdf itself coincide. Respective columns can
 //! be omitted in the second block.
 //!
-//! @param u An \f$ n \times (2 + k) \f$ matrix of observations contained in
-//!   \f$(0, 1) \f$, where \f$ k \f$ is the number of discrete variables.
+//! @param u An \f$ n \times 4 \f$ or \f$ n \times (2 + k) \f$ matrix of
+//!   observations contained in \f$(0, 1) \f$, where \f$ k \f$ is the number
+//!   of discrete variables.
 //! @return The log-likelihood evaluated at \c u.
 inline double
 Bicop::loglik(const Eigen::MatrixXd& u) const
@@ -1566,7 +1574,7 @@ Bicop::loglik(const Eigen::MatrixXd& u) const
   if (u.rows() < 1) {
     return get_loglik();
   } else {
-    tools_eigen::check_if_in_unit_cube(u);
+    check_data(u);
     return bicop_->loglik(prep_for_abstract(u));
   }
 }
@@ -1580,8 +1588,9 @@ Bicop::loglik(const Eigen::MatrixXd& u) const
 //! The AIC is a consistent model selection criterion even
 //! for nonparametric models.
 //!
-//! @param u An \f$ n \times (2 + k) \f$ matrix of observations contained in
-//!   \f$(0, 1) \f$, where \f$ k \f$ is the number of discrete variables.
+//! @param u An \f$ n \times 4 \f$ or \f$ n \times (2 + k) \f$ matrix of
+//!   observations contained in \f$(0, 1) \f$, where \f$ k \f$ is the number
+//!   of discrete variables.
 //! @return The AIC evaluated at \c u.
 inline double
 Bicop::aic(const Eigen::MatrixXd& u) const
@@ -1598,8 +1607,9 @@ Bicop::aic(const Eigen::MatrixXd& u) const
 //! The BIC is a consistent model selection criterion
 //! for parametric models.
 //!
-//! @param u An \f$ n \times (2 + k) \f$ matrix of observations contained in
-//!   \f$(0, 1) \f$, where \f$ k \f$ is the number of discrete variables.
+//! @param u An \f$ n \times 4 \f$ or \f$ n \times (2 + k) \f$ matrix of
+//!   observations contained in \f$(0, 1) \f$, where \f$ k \f$ is the number
+//!   of discrete variables.
 //! @return The BIC evaluated at \c u.
 inline double
 Bicop::bic(const Eigen::MatrixXd& u) const
@@ -1624,8 +1634,9 @@ Bicop::bic(const Eigen::MatrixXd& u) const
 //! non-independence copula and \f$ I \f$ is an indicator for the family being
 //! non-independence.
 //!
-//! @param u An \f$ n \times (2 + k) \f$ matrix of observations contained in
-//!   \f$(0, 1) \f$, where \f$ k \f$ is the number of discrete variables.
+//! @param u An \f$ n \times 4 \f$ or \f$ n \times (2 + k) \f$ matrix of
+//!   observations contained in \f$(0, 1) \f$, where \f$ k \f$ is the number
+//!   of discrete variables.
 //! @param psi0 Prior probability of a non-independence copula.
 //! @return The mBIC evaluated at \c u.
 // clang-format on
@@ -1904,7 +1915,7 @@ Bicop::check_data_dim(const Eigen::MatrixXd& u) const
   if ((n_cols != n_cols_exp) & (n_cols != 4)) {
     std::stringstream msg;
     msg << "data has wrong number of columns; "
-        << "expected: " << n_cols_exp << " or 4, actual: " << n_cols
+        << "expected: 4 or " << n_cols_exp << ", actual: " << n_cols
         << " (model contains ";
     if (n_disc == 0) {
       msg << "no discrete variables)." << std::endl;
@@ -2054,16 +2065,18 @@ Bicop::as_continuous() const
 //! When at least one variable is discrete, two types of "observations"
 //! are required: the first \f$ n \times 2 \f$ block contains realizations of
 //! \f$ F_{X_1}(X_1), F_{X_2}(X_2) \f$. Let \f$ k \f$ denote the number of
-//! discrete variables (either one or two). Then the second \f$ n \times k \f$
-//! block contains realizations of \f$ F_{X_k}(X_k^-) \f$. The minus indicates a
+//! discrete variables (either one or two). The second \f$ n \times 2 \f$ block
+//! contains realizations of \f$ F_{X_j}(X_j^-) \f$. The minus indicates a
 //! left-sided limit of the cdf. For continuous variables the left limit and the
-//! cdf itself coincide. For, e.g., an integer-valued variable, it holds \f$
-//! F_{X_k}(X_k^-) = F_{X_k}(X_k - 1) \f$.
+//! cdf itself coincide, and their columns can be omitted from the second block.
+//! For, e.g., an integer-valued variable, it holds
+//! \f$ F_{X_j}(X_j^-) = F_{X_j}(X_j - 1) \f$.
 //!
 //! Incomplete observations (i.e., ones with a NaN value) are discarded.
 //!
-//! @param data An \f$ n \times (2 + k) \f$ matrix of observations contained in
-//!   \f$(0, 1) \f$, where \f$ k \f$ is the number of discrete variables.
+//! @param data An \f$ n \times 4 \f$ or \f$ n \times (2 + k) \f$ matrix of
+//!   observations contained in \f$(0, 1) \f$, where \f$ k \f$ is the number
+//!   of discrete variables.
 //! @param controls The controls (see `FitControlsBicop`).
 inline void
 Bicop::fit(const Eigen::MatrixXd& data, const FitControlsBicop& controls)
@@ -2074,6 +2087,7 @@ Bicop::fit(const Eigen::MatrixXd& data, const FitControlsBicop& controls)
   } else {
     method = controls.get_nonparametric_method();
   }
+  check_data_dim(data);
   tools_eigen::check_if_in_unit_cube(data);
 
   auto w = controls.get_weights();
@@ -2100,16 +2114,18 @@ Bicop::fit(const Eigen::MatrixXd& data, const FitControlsBicop& controls)
 //! When at least one variable is discrete, two types of "observations"
 //! are required: the first \f$ n \times 2 \f$ block contains realizations of
 //! \f$ F_{X_1}(X_1), F_{X_2}(X_2) \f$. Let \f$ k \f$ denote the number of
-//! discrete variables (either one or two). Then the second \f$ n \times k \f$
-//! block contains realizations of \f$ F_{X_k}(X_k^-) \f$. The minus indicates a
+//! discrete variables (either one or two). The second \f$ n \times 2 \f$ block
+//! contains realizations of \f$ F_{X_j}(X_j^-) \f$. The minus indicates a
 //! left-sided limit of the cdf. For continuous variables the left limit and the
-//! cdf itself coincide. For, e.g., an integer-valued variable, it holds \f$
-//! F_{X_k}(X_k^-) = F_{X_k}(X_k - 1) \f$.
+//! cdf itself coincide, and their columns can be omitted from the second block.
+//! For, e.g., an integer-valued variable, it holds
+//! \f$ F_{X_j}(X_j^-) = F_{X_j}(X_j - 1) \f$.
 //!
 //! Incomplete observations (i.e., ones with a NaN value) are discarded.
 //!
-//! @param data An \f$ n \times (2 + k) \f$ matrix of observations contained in
-//!   \f$(0, 1) \f$, where \f$ k \f$ is the number of discrete variables.
+//! @param data An \f$ n \times 4 \f$ or \f$ n \times (2 + k) \f$ matrix of
+//!   observations contained in \f$(0, 1) \f$, where \f$ k \f$ is the number
+//!   of discrete variables.
 //! @param controls The controls (see `FitControlsBicop`).
 inline void
 Bicop::select(const Eigen::MatrixXd& data, FitControlsBicop controls)

--- a/include/vinecopulib/vinecop/class.hpp
+++ b/include/vinecopulib/vinecop/class.hpp
@@ -367,6 +367,7 @@ private:
     VinecopView(const Vinecop& vinecop, const ReorientationMap& reorientation);
 
     const RVineStructure& get_structure() const;
+    size_t get_trunc_lvl() const;
     BicopView get_pair_copula(size_t tree, size_t edge) const;
 
   private:
@@ -461,6 +462,7 @@ private:
   // overloads: rejects discrete variables and checks the n x npars shape.
   void check_per_obs_params(const Eigen::MatrixXd& u,
                             const Eigen::MatrixXd& per_obs_params) const;
+  size_t get_effective_trunc_lvl() const;
 
 protected:
   size_t d_{ 1 };

--- a/include/vinecopulib/vinecop/class.hpp
+++ b/include/vinecopulib/vinecop/class.hpp
@@ -208,6 +208,12 @@ public:
     const bool qrng = false,
     const size_t num_threads = 1,
     const std::vector<int>& seeds = std::vector<int>()) const;
+  Eigen::MatrixXd simulate_conditional(
+    const Eigen::MatrixXd& u_cond,
+    const std::vector<size_t>& conditioning_set,
+    const bool qrng = false,
+    const size_t num_threads = 1,
+    const std::vector<int>& seeds = std::vector<int>()) const;
 
   void reorient(const std::vector<size_t>& conditioning_set);
 
@@ -370,6 +376,13 @@ private:
 
   ReorientationMap make_reorientation_map(
     const std::vector<size_t>& conditioning_set) const;
+  Eigen::MatrixXd simulate_conditional_impl(
+    const Eigen::MatrixXd& u_cond,
+    const std::vector<size_t>& conditioning_set,
+    const VinecopView& view,
+    bool qrng,
+    size_t num_threads,
+    const std::vector<int>& seeds) const;
   Eigen::MatrixXd rosenblatt_impl(Eigen::MatrixXd u,
                                   const VinecopView& view,
                                   size_t num_threads,

--- a/include/vinecopulib/vinecop/implementation/class.ipp
+++ b/include/vinecopulib/vinecop/implementation/class.ipp
@@ -27,7 +27,8 @@ inline Vinecop::Vinecop(const size_t d)
 //! @param structure An `RVineStructure` object specifying the vine structure.
 //! @param pair_copulas `Bicop` objects specifying the pair-copulas, namely
 //!     a nested list such that `pc_store[t][e]` contains a `Bicop`
-//!     object for the pair copula corresponding to tree `t` and edge `e`.
+//!     object for the pair copula corresponding to tree `t` and edge `e`. If
+//!     empty, all pair-copulas are treated as independence.
 //! @param var_types Strings specifying the types of the variables,
 //!   e.g., `("c", "d")` means first variable continuous, second discrete.
 //!   If empty, then all variables are set as continuous.
@@ -53,7 +54,8 @@ inline Vinecop::Vinecop(const RVineStructure& structure,
 //! @param matrix An R-vine matrix specifying the vine structure.
 //! @param pair_copulas `Bicop` objects specifying the pair-copulas, namely
 //!     a nested list such that `pc_store[t][e]` contains a `Bicop`
-//!     object for the pair copula corresponding to tree `t` and edge `e`.
+//!     object for the pair copula corresponding to tree `t` and edge `e`. If
+//!     empty, all pair-copulas are treated as independence.
 //! @param var_types Strings specifying the types of the variables,
 //!   e.g., `("c", "d")` means first variable continuous, second discrete.
 //!   If empty, then all variables are set as continuous.
@@ -443,6 +445,12 @@ Vinecop::VinecopView::get_structure() const
                         : vinecop_->rvine_structure_;
 }
 
+inline size_t
+Vinecop::VinecopView::get_trunc_lvl() const
+{
+  return vinecop_->get_effective_trunc_lvl();
+}
+
 inline BicopView
 Vinecop::VinecopView::get_pair_copula(size_t tree, size_t edge) const
 {
@@ -592,7 +600,7 @@ Vinecop::fit(const Eigen::MatrixXd& data,
   auto u = collapse_data(data);
 
   // info about the vine structure (reverse rows (!) for more natural indexing)
-  size_t trunc_lvl = rvine_structure_.get_trunc_lvl();
+  size_t trunc_lvl = get_effective_trunc_lvl();
   if (trunc_lvl == 0)
     return;
 
@@ -813,6 +821,12 @@ inline size_t
 Vinecop::get_trunc_lvl() const
 {
   return rvine_structure_.get_trunc_lvl();
+}
+
+inline size_t
+Vinecop::get_effective_trunc_lvl() const
+{
+  return std::min(rvine_structure_.get_trunc_lvl(), pair_copulas_.size());
 }
 
 //! @brief Gets the parameters of all pair copulas.
@@ -1149,7 +1163,7 @@ Vinecop::pdf_full(Eigen::MatrixXd u,
   }
 
   // info about the vine structure (reverse rows (!) for more natural indexing)
-  size_t trunc_lvl = rvine_structure_.get_trunc_lvl();
+  size_t trunc_lvl = get_effective_trunc_lvl();
   auto order = rvine_structure_.get_order();
   auto disc_cols = tools_select::get_disc_cols(var_types_);
   const bool discrete = is_discrete();
@@ -1361,7 +1375,7 @@ Vinecop::pdf(Eigen::MatrixXd u,
 inline void
 Vinecop::check_parametric(const char* fn) const
 {
-  size_t trunc_lvl = rvine_structure_.get_trunc_lvl();
+  size_t trunc_lvl = get_effective_trunc_lvl();
   for (size_t t = 0; t < trunc_lvl; t++) {
     for (size_t e = 0; e < d_ - 1 - t; e++) {
       if (!tools_stl::is_member(pair_copulas_[t][e].get_family(),
@@ -1427,7 +1441,7 @@ Vinecop::build_deriv_cache(const Eigen::MatrixXd& u,
                            bool second_order,
                            const Eigen::MatrixXd& per_obs_params) const
 {
-  size_t trunc_lvl = rvine_structure_.get_trunc_lvl();
+  size_t trunc_lvl = get_effective_trunc_lvl();
   auto order = rvine_structure_.get_order();
   const size_t m = size;
   TriangularArray<DerivCache> cache(d_, trunc_lvl);
@@ -1688,7 +1702,7 @@ Vinecop::scores_full(Eigen::MatrixXd u,
   u = collapse_data(u);
 
   // info about the vine structure (reverse rows (!) for more natural indexing)
-  size_t trunc_lvl = rvine_structure_.get_trunc_lvl();
+  size_t trunc_lvl = get_effective_trunc_lvl();
   auto order = rvine_structure_.get_order();
   auto disc_cols = tools_select::get_disc_cols(var_types_);
   const size_t n = static_cast<size_t>(u.rows());
@@ -2212,7 +2226,7 @@ Vinecop::hessian_full(Eigen::MatrixXd u,
   check_data(u);
   u = collapse_data(u);
 
-  size_t trunc_lvl = rvine_structure_.get_trunc_lvl();
+  size_t trunc_lvl = get_effective_trunc_lvl();
 
   check_parametric("hessian()");
 
@@ -2550,7 +2564,7 @@ Vinecop::hessian(Eigen::MatrixXd u,
   if (n == 0 || npars == 0) {
     return H;
   }
-  size_t trunc_lvl = rvine_structure_.get_trunc_lvl();
+  size_t trunc_lvl = get_effective_trunc_lvl();
 
   // ponytail: process observations in row-chunks so peak memory is
   // O(chunk * npars^2) rather than O(n * npars^2) -- hessian_full()
@@ -3105,7 +3119,7 @@ Vinecop::rosenblatt_impl(Eigen::MatrixXd u,
 
   // info about the vine structure
   const auto& structure = view.get_structure();
-  size_t trunc_lvl = structure.get_trunc_lvl();
+  size_t trunc_lvl = view.get_trunc_lvl();
   auto order = structure.get_order();
   auto inverse_order = tools_stl::invert_permutation(order);
   auto disc_cols = tools_select::get_disc_cols(var_types_);
@@ -3315,7 +3329,7 @@ Vinecop::inverse_rosenblatt_impl(const Eigen::MatrixXd& u,
 
   // info about the vine structure (in upper triangular matrix notation)
   const auto& structure = view.get_structure();
-  size_t trunc_lvl = structure.get_trunc_lvl();
+  size_t trunc_lvl = view.get_trunc_lvl();
   auto order = structure.get_order();
   auto inverse_order = tools_stl::invert_permutation(order);
 

--- a/include/vinecopulib/vinecop/implementation/class.ipp
+++ b/include/vinecopulib/vinecop/implementation/class.ipp
@@ -2719,10 +2719,7 @@ Vinecop::simulate(const size_t n,
 //! order (they are drawn first by the vine and form a self-contained sub-vine).
 //! Each row of `u_cond` is one
 //! conditioning point; the corresponding output row is drawn from the
-//! remaining variables' distribution conditional on that point. It is
-//! implemented as a Rosenblatt transform of the conditioning variables
-//! followed by an inverse Rosenblatt transform (see `rosenblatt()` /
-//! `inverse_rosenblatt()`).
+//! remaining variables' distribution conditional on that point.
 //!
 //! Discrete conditioning variables are supported. As for the other data-taking
 //! methods, a discrete variable requires its left-limit CDF \f$ F(x^-) \f$ in
@@ -2763,81 +2760,106 @@ Vinecop::simulate_conditional(const Eigen::MatrixXd& u_cond,
                               const size_t num_threads,
                               const std::vector<int>& seeds) const
 {
-  size_t n = static_cast<size_t>(u_cond.rows());
   size_t n_cols = static_cast<size_t>(u_cond.cols());
   auto order = rvine_structure_.get_order();
 
-  // ---- recover the number of conditioning variables `k` from the column
-  //      count. `u_cond` has `k` value columns plus one left-limit column
-  //      F(x^-) per discrete conditioning variable, i.e.
-  //      `n_cols = k + #discrete(order[d-k..d-1])`. This is strictly increasing
-  //      in `k`, so the match is unique. The conditioning variables are the
-  //      last `k` of the vine order (drawn first, a self-contained sub-vine).
   size_t k = 0;
-  bool found = false;
-  for (size_t kk = 1; (kk <= d_ - 1) && !found; ++kk) {
+  for (size_t kk = 1; kk <= d_ - 1; ++kk) {
     size_t kd = 0;
     for (size_t i = 0; i < kk; ++i)
       if (var_types_[order[d_ - kk + i] - 1] == "d")
         ++kd;
     if (n_cols == kk + kd) {
       k = kk;
-      found = true;
+      break;
     }
   }
-  if (!found) {
+  if (k == 0) {
     throw std::runtime_error(
       "u_cond has an invalid number of columns; expected k + (number of "
       "discrete conditioning variables) columns for some number of "
       "conditioning variables k in 1, ..., d - 1.");
   }
+
+  std::vector<size_t> conditioning_set(k);
+  for (size_t i = 0; i < k; ++i)
+    conditioning_set[i] = order[d_ - k + i];
+  return simulate_conditional_impl(
+    u_cond, conditioning_set, VinecopView(*this), qrng, num_threads, seeds);
+}
+
+//! @brief Simulates conditionally on a specified set of variables.
+//!
+//! @param conditioning_set The 1-based conditioning-variable indices. The
+//!   first `k` columns of `u_cond` correspond to these variables in the given
+//!   order; left-limit columns follow in the same order among the discrete
+//!   variables.
+inline Eigen::MatrixXd
+Vinecop::simulate_conditional(const Eigen::MatrixXd& u_cond,
+                              const std::vector<size_t>& conditioning_set,
+                              const bool qrng,
+                              const size_t num_threads,
+                              const std::vector<int>& seeds) const
+{
+  auto reorientation = make_reorientation_map(conditioning_set);
+  return simulate_conditional_impl(u_cond,
+                                   conditioning_set,
+                                   VinecopView(*this, reorientation),
+                                   qrng,
+                                   num_threads,
+                                   seeds);
+}
+
+inline Eigen::MatrixXd
+Vinecop::simulate_conditional_impl(const Eigen::MatrixXd& u_cond,
+                                   const std::vector<size_t>& conditioning_set,
+                                   const VinecopView& view,
+                                   bool qrng,
+                                   size_t num_threads,
+                                   const std::vector<int>& seeds) const
+{
+  const size_t n = static_cast<size_t>(u_cond.rows());
+  const size_t k = conditioning_set.size();
+  const size_t kd = static_cast<size_t>(std::count_if(
+    conditioning_set.begin(), conditioning_set.end(), [&](size_t var) {
+      return var_types_[var - 1] == "d";
+    }));
+  if (static_cast<size_t>(u_cond.cols()) != k + kd) {
+    throw std::runtime_error(
+      "u_cond must have one column per conditioning variable plus one "
+      "left-limit column per discrete conditioning variable.");
+  }
   if (!tools_eigen::check_if_in_unit_cube(u_cond)) {
     throw std::runtime_error("all elements of u_cond must be in (0, 1).");
   }
 
-  // ---- algorithm (reuse the tested Rosenblatt primitives) ----
-  // 1. Embed the conditioning values into a full data matrix in the collapsed
-  //    `n x (d + n_discrete)` layout: value columns F(x), plus a left-limit
-  //    column F(x^-) for each discrete conditioning variable. The fillers are
-  //    irrelevant: the conditioning block is self-contained, so its Rosenblatt
-  //    transform depends only on the conditioning values.
   auto disc_cols = tools_select::get_disc_cols(var_types_);
   Eigen::MatrixXd u_completed =
     Eigen::MatrixXd::Constant(n, d_ + get_n_discrete(), 0.5);
   size_t kd_seen = 0;
   for (size_t i = 0; i < k; ++i) {
-    size_t var = order[d_ - k + i] - 1;
-    u_completed.col(var) = u_cond.col(i); // F(x)
+    size_t var = conditioning_set[i] - 1;
+    u_completed.col(var) = u_cond.col(i);
     if (var_types_[var] == "d") {
       if ((u_cond.col(k + kd_seen).array() > u_cond.col(i).array()).any()) {
         throw std::runtime_error(
           "for discrete conditioning variables, the left-limit columns of "
           "u_cond (F(x^-)) must not exceed the value columns (F(x)).");
       }
-      u_completed.col(d_ + disc_cols[var]) = u_cond.col(k + kd_seen); // F(x^-)
+      u_completed.col(d_ + disc_cols[var]) = u_cond.col(k + kd_seen);
       ++kd_seen;
     }
   }
 
-  // 2. Recover the independent-uniform seeds of the conditioning block.
-  //    `randomize_discrete = true` is required: for a discrete conditioning
-  //    value the seed is drawn across the atom's [F(x^-), F(x)] interval
-  //    (Brockwell), so the conditioned draws are unbiased. It is a no-op for
-  //    continuous models.
-  Eigen::MatrixXd w = rosenblatt(u_completed, num_threads, true, seeds);
+  Eigen::MatrixXd w =
+    rosenblatt_impl(std::move(u_completed), view, num_threads, true, seeds);
 
-  // 3. Assemble the seed matrix: conditioning seeds + fresh uniforms for the
-  //    conditioned variables.
   Eigen::MatrixXd u = tools_stats::simulate_uniform(n, d_, qrng, seeds);
-  for (size_t i = 0; i < k; ++i) {
-    size_t col = order[d_ - k + i] - 1;
-    u.col(col) = w.col(col);
+  for (auto var : conditioning_set) {
+    u.col(var - 1) = w.col(var - 1);
   }
 
-  // 4. Inverse Rosenblatt: reproduces the conditioning values (exactly for
-  //    continuous variables, up to the atom for discrete ones) and draws the
-  //    remaining variables from their conditional distribution.
-  return inverse_rosenblatt(u, num_threads);
+  return inverse_rosenblatt_impl(u, view, num_threads);
 }
 
 //! @brief Evaluates the log-likelihood.

--- a/include/vinecopulib/vinecop/implementation/class.ipp
+++ b/include/vinecopulib/vinecop/implementation/class.ipp
@@ -2808,11 +2808,22 @@ Vinecop::simulate_conditional(const Eigen::MatrixXd& u_cond,
 
 //! @brief Simulates conditionally on a specified set of variables.
 //!
+//! @param u_cond An \f$ n \times (k + k_d) \f$ compact or \f$ n \times 2k
+//!   \f$ expanded matrix of conditioning values, with one conditioning point
+//!   per row. The first `k` columns follow `conditioning_set`; left-limits
+//!   follow in the same order for the expanded layout and only for discrete
+//!   variables in the compact layout.
 //! @param conditioning_set The 1-based conditioning-variable indices. The
 //!   first `k` columns of `u_cond` correspond to these variables in the given
 //!   order. In the expanded layout, the next `k` columns contain their
 //!   left-limits in the same order; in the compact layout, only left-limits of
 //!   discrete variables follow.
+//! @param qrng Set to true for quasi-random numbers (over the conditioned
+//!   variables).
+//! @param num_threads The number of threads to use for computations.
+//! @param seeds Seeds of the random number generator; if empty (default),
+//!   the random number generator is seeded randomly.
+//! @return An \f$ n \times d \f$ matrix of conditional samples.
 inline Eigen::MatrixXd
 Vinecop::simulate_conditional(const Eigen::MatrixXd& u_cond,
                               const std::vector<size_t>& conditioning_set,

--- a/include/vinecopulib/vinecop/implementation/class.ipp
+++ b/include/vinecopulib/vinecop/implementation/class.ipp
@@ -327,7 +327,7 @@ Vinecop::make_pair_copula_store(const size_t d, const size_t trunc_lvl)
 //! so that the maximal available information is used.
 //!
 //!
-//! @param data \f$ n \times (d + k) \f$ or \f$ n \times 2d \f$ matrix of
+//! @param data \f$ n \times 2d \f$ or \f$ n \times (d + k) \f$ matrix of
 //!   observations, where \f$ k \f$ is the number of discrete variables.
 //! @param controls The controls to the algorithm (see `FitControlsVinecop()`).
 inline void
@@ -578,7 +578,7 @@ Vinecop::reorient(const std::vector<size_t>& conditioning_set)
 //! and a `FitControlsVinecop` object instantiated
 //! with `select_families = false`.
 //!
-//! @param data \f$ n \times (d + k) \f$ or \f$ n \times 2d \f$ matrix of
+//! @param data \f$ n \times 2d \f$ or \f$ n \times (d + k) \f$ matrix of
 //!   observations, where \f$ k \f$ is the number of discrete variables.
 //! @param controls The controls for each bivariate fit (see
 //! `FitControlsBicop()`).
@@ -1095,7 +1095,7 @@ Vinecop::get_var_types() const
 //! limit and the cdf itself coincide. Respective columns can be omitted in the
 //! second block.
 //!
-//! @param u An \f$ n \times (d + k) \f$ or \f$ n \times 2d \f$ matrix of
+//! @param u An \f$ n \times 2d \f$ or \f$ n \times (d + k) \f$ matrix of
 //!   evaluation points, where \f$ k \f$ is the number of discrete variables
 //!   (see `Vinecop::select()`).
 //! @param num_threads The number of threads to use for computations; if greater
@@ -1332,7 +1332,7 @@ Vinecop::pdf_full(Eigen::MatrixXd u,
 //! limit and the cdf itself coincide. Respective columns can be omitted in the
 //! second block.
 //!
-//! @param u An \f$ n \times (d + k) \f$ or \f$ n \times 2d \f$ matrix of
+//! @param u An \f$ n \times 2d \f$ or \f$ n \times (d + k) \f$ matrix of
 //!   evaluation points, where \f$ k \f$ is the number of discrete variables
 //!   (see `Vinecop::select()`).
 //! @param num_threads The number of threads to use for computations; if greater
@@ -1628,7 +1628,7 @@ Vinecop::build_deriv_cache(const Eigen::MatrixXd& u,
 //! the caches below stay empty). Models with nonparametric pair copulas are
 //! rejected (differentiating w.r.t. the interpolation grid is meaningless).
 //!
-//! @param u An \f$ n \times (d + k) \f$ or \f$ n \times 2d \f$ matrix of
+//! @param u An \f$ n \times 2d \f$ or \f$ n \times (d + k) \f$ matrix of
 //!   evaluation points, where \f$ k \f$ is the number of discrete variables
 //!   (see `select()`).
 //! @param step_wise if `false`, full gradient of the log-likelihood; if `true`,
@@ -2097,7 +2097,7 @@ Vinecop::scores_full(Eigen::MatrixXd u,
 //! with respect to the parameters. This is a thin wrapper around
 //! `scores_full()`; see there for the computational details.
 //!
-//! @param u An \f$ n \times (d + k) \f$ or \f$ n \times 2d \f$ matrix of
+//! @param u An \f$ n \times 2d \f$ or \f$ n \times (d + k) \f$ matrix of
 //!   evaluation points, where \f$ k \f$ is the number of discrete variables
 //!   (see `select()`).
 //! @param step_wise if `false`, full gradient of the log-likelihood; if `true`,
@@ -2131,7 +2131,7 @@ Vinecop::scores(Eigen::MatrixXd u,
 //! Returns the observation-average of `scores()` as a vector of length
 //! `npars`, mirroring how `hessian()` averages `hessian_full()`.
 //!
-//! @param u An \f$ n \times (d + k) \f$ or \f$ n \times 2d \f$ matrix of
+//! @param u An \f$ n \times 2d \f$ or \f$ n \times (d + k) \f$ matrix of
 //!   evaluation points, where \f$ k \f$ is the number of discrete variables
 //!   (see `select()`).
 //! @param step_wise if `false`, full gradient of the log-likelihood; if `true`,
@@ -2178,7 +2178,7 @@ Vinecop::gradient(Eigen::MatrixXd u,
 //! Models with discrete variables use central finite differences of
 //! `scores()` instead; models with nonparametric pair copulas are rejected.
 //!
-//! @param u An \f$ n \times (d + k) \f$ or \f$ n \times 2d \f$ matrix of
+//! @param u An \f$ n \times 2d \f$ or \f$ n \times (d + k) \f$ matrix of
 //!   evaluation points, where \f$ k \f$ is the number of discrete variables
 //!   (see `select()`).
 //! @param step_wise if `false`, full gradient of the log-likelihood; if `true`,
@@ -2513,7 +2513,7 @@ Vinecop::hessian_full(Eigen::MatrixXd u,
 //! \f$ \mathrm{npars} \times \mathrm{npars} \f$ matrix (use `hessian_full()`
 //! for the per-observation decomposition).
 //!
-//! @param u An \f$ n \times (d + k) \f$ or \f$ n \times 2d \f$ matrix of
+//! @param u An \f$ n \times 2d \f$ or \f$ n \times (d + k) \f$ matrix of
 //!   evaluation points, where \f$ k \f$ is the number of discrete variables
 //!   (see `select()`).
 //! @param step_wise if `false`, full gradient of the log-likelihood; if `true`,
@@ -2589,7 +2589,7 @@ Vinecop::hessian(Eigen::MatrixXd u,
 //! matrix. Together with `hessian()` this forms the sandwich estimator of the
 //! asymptotic covariance.
 //!
-//! @param u An \f$ n \times (d + k) \f$ or \f$ n \times 2d \f$ matrix of
+//! @param u An \f$ n \times 2d \f$ or \f$ n \times (d + k) \f$ matrix of
 //!   evaluation points, where \f$ k \f$ is the number of discrete variables
 //!   (see `select()`).
 //! @param step_wise if `false`, full gradient of the log-likelihood; if `true`,
@@ -2639,7 +2639,7 @@ Vinecop::scores_cov(Eigen::MatrixXd u,
 //! limit and the cdf itself coincide. Respective columns can be omitted in the
 //! second block.
 //!
-//! @param u An \f$ n \times (d + k) \f$ or \f$ n \times 2d \f$ matrix of
+//! @param u An \f$ n \times 2d \f$ or \f$ n \times (d + k) \f$ matrix of
 //!   evaluation points, where \f$ k \f$ is the number of discrete variables
 //!   (see `Vinecop::select()`).
 //! @param N Integer for the number of quasi-random numbers to draw
@@ -2742,6 +2742,10 @@ Vinecop::simulate(const size_t n,
 //!   supplying only `k` columns when a conditioning variable is discrete may be
 //!   silently reinterpreted as a different `k`. To draw many samples at a
 //!   single conditioning point, pass that point repeated over `n` rows.
+//!   The overload taking `conditioning_set` also accepts the expanded
+//!   \f$ n \times 2k \f$ layout, with one left-limit column per conditioning
+//!   variable. Use that overload whenever the expanded layout is ambiguous
+//!   with a compact layout for a different number of conditioning variables.
 //! @param qrng Set to true for quasi-random numbers (over the conditioned
 //!   variables).
 //! @param num_threads The number of threads to use for computations.
@@ -2792,8 +2796,9 @@ Vinecop::simulate_conditional(const Eigen::MatrixXd& u_cond,
 //!
 //! @param conditioning_set The 1-based conditioning-variable indices. The
 //!   first `k` columns of `u_cond` correspond to these variables in the given
-//!   order; left-limit columns follow in the same order among the discrete
-//!   variables.
+//!   order. In the expanded layout, the next `k` columns contain their
+//!   left-limits in the same order; in the compact layout, only left-limits of
+//!   discrete variables follow.
 inline Eigen::MatrixXd
 Vinecop::simulate_conditional(const Eigen::MatrixXd& u_cond,
                               const std::vector<size_t>& conditioning_set,
@@ -2824,10 +2829,12 @@ Vinecop::simulate_conditional_impl(const Eigen::MatrixXd& u_cond,
     conditioning_set.begin(), conditioning_set.end(), [&](size_t var) {
       return var_types_[var - 1] == "d";
     }));
-  if (static_cast<size_t>(u_cond.cols()) != k + kd) {
+  const size_t n_cols = static_cast<size_t>(u_cond.cols());
+  const bool expanded = n_cols == 2 * k;
+  if (!expanded && (n_cols != k + kd)) {
     throw std::runtime_error(
-      "u_cond must have one column per conditioning variable plus one "
-      "left-limit column per discrete conditioning variable.");
+      "u_cond must have 2 * k columns or one column per conditioning variable "
+      "plus one left-limit column per discrete conditioning variable.");
   }
   if (!tools_eigen::check_if_in_unit_cube(u_cond)) {
     throw std::runtime_error("all elements of u_cond must be in (0, 1).");
@@ -2841,12 +2848,13 @@ Vinecop::simulate_conditional_impl(const Eigen::MatrixXd& u_cond,
     size_t var = conditioning_set[i] - 1;
     u_completed.col(var) = u_cond.col(i);
     if (var_types_[var] == "d") {
-      if ((u_cond.col(k + kd_seen).array() > u_cond.col(i).array()).any()) {
+      size_t left_col = expanded ? k + i : k + kd_seen;
+      if ((u_cond.col(left_col).array() > u_cond.col(i).array()).any()) {
         throw std::runtime_error(
           "for discrete conditioning variables, the left-limit columns of "
           "u_cond (F(x^-)) must not exceed the value columns (F(x)).");
       }
-      u_completed.col(d_ + disc_cols[var]) = u_cond.col(k + kd_seen);
+      u_completed.col(d_ + disc_cols[var]) = u_cond.col(left_col);
       ++kd_seen;
     }
   }
@@ -2868,7 +2876,7 @@ Vinecop::simulate_conditional_impl(const Eigen::MatrixXd& u_cond,
 //! \f[ \mathrm{loglik} = \sum_{i = 1}^n \log c(U_{1, i}, ..., U_{d, i}), \f]
 //! where \f$ c \f$ is the copula density, see `Vinecop::pdf()`.
 //!
-//! @param u An \f$ n \times (d + k) \f$ or \f$ n \times 2d \f$ matrix of
+//! @param u An \f$ n \times 2d \f$ or \f$ n \times (d + k) \f$ matrix of
 //!   evaluation points, where \f$ k \f$ is the number of discrete variables
 //!   (see `select()` or `Vinecop::pdf()`).
 //! @param num_threads The number of threads to use for computations; if greater
@@ -2908,7 +2916,7 @@ Vinecop::loglik(const Eigen::MatrixXd& u,
 //! The AIC is a consistent model selection criterion even
 //! for nonparametric models.
 //!
-//! @param u An \f$ n \times (d + k) \f$ or \f$ n \times 2d \f$ matrix of
+//! @param u An \f$ n \times 2d \f$ or \f$ n \times (d + k) \f$ matrix of
 //!   evaluation points, where \f$ k \f$ is the number of discrete variables
 //!   (see `select()` or `Vinecop::pdf()`).
 //! @param num_threads The number of threads to use for computations; if greater
@@ -2930,7 +2938,7 @@ Vinecop::aic(const Eigen::MatrixXd& u, const size_t num_threads) const
 //! The BIC is a consistent model selection criterion
 //! for nonparametric models.
 //!
-//! @param u An \f$ n \times (d + k) \f$ or \f$ n \times 2d \f$ matrix of
+//! @param u An \f$ n \times 2d \f$ or \f$ n \times (d + k) \f$ matrix of
 //!   evaluation points, where \f$ k \f$ is the number of discrete variables
 //!   (see `Vinecop::select()` or `Vinecop::pdf()`).
 //! @param num_threads The number of threads to use for computations; if greater
@@ -2958,7 +2966,7 @@ Vinecop::bic(const Eigen::MatrixXd& u, const size_t num_threads) const
 //! selection criterion for parametric sparse vine copula models when
 //! \f$ d = o(\sqrt{n \log n})\f$.
 //!
-//! @param u An \f$ n \times (d + k) \f$ or \f$ n \times 2d \f$ matrix of
+//! @param u An \f$ n \times 2d \f$ or \f$ n \times (d + k) \f$ matrix of
 //!   evaluation points, where \f$ k \f$ is the number of discrete variables
 //!   (see `Vinecop::select()` or `Vinecop::pdf()`).
 //! @param psi0 Baseline prior probability of a non-independence copula.
@@ -3029,7 +3037,8 @@ Vinecop::get_npars() const
 //! \f[ F(V_{M[d - j, j]} | V_{M[d - j - 1, j - 1]}, \dots, V_{M[0, 0]}), \f]
 //! set `randomize_discrete = FALSE`.
 //!
-//! @param u An \f$ n \times d \f$ matrix of evaluation points.
+//! @param u An \f$ n \times 2d \f$ or \f$ n \times (d + k) \f$ matrix of
+//!   evaluation points, where \f$ k \f$ is the number of discrete variables.
 //! @param num_threads The number of threads to use for computations; if greater
 //!   than 1, the function will be applied concurrently to `num_threads` batches
 //!   of `u`.
@@ -3058,7 +3067,8 @@ Vinecop::rosenblatt(Eigen::MatrixXd u,
 //! @details The vine is evaluated in an admissible sampling order whose tail
 //! contains exactly `conditioning_set`. The model itself is not modified.
 //!
-//! @param u An \f$ n \times d \f$ matrix of evaluation points.
+//! @param u An \f$ n \times 2d \f$ or \f$ n \times (d + k) \f$ matrix of
+//!   evaluation points, where \f$ k \f$ is the number of discrete variables.
 //! @param conditioning_set The 1-based indices of the conditioning variables.
 //! @param num_threads The number of threads to use for computations.
 //! @param randomize_discrete Whether to randomize the transform for discrete
@@ -3229,7 +3239,10 @@ Vinecop::rosenblatt_impl(Eigen::MatrixXd u,
 //! `Vinecop::inverse_rosenblatt()` computes \f[ V_{M[d - j, j]}= F^{-1}(U_{M[d
 //! - j, j]} | U_{M[d - j - 1, j - 1]}, \dots, U_{M[0, 0]}). \f]
 //!
-//! @param u An \f$ n \times d \f$ matrix of evaluation points.
+//! @param u An \f$ n \times 2d \f$, \f$ n \times (d + k) \f$, or
+//!   \f$ n \times d \f$ matrix of independent uniform variates, where \f$ k \f$
+//!   is the number of discrete variables. Only the first \f$ d \f$ columns are
+//!   used.
 //! @param num_threads The number of threads to use for computations; if greater
 //!   than 1, the function will be applied concurrently to `num_threads` batches
 //!   of `u`.
@@ -3246,7 +3259,10 @@ Vinecop::inverse_rosenblatt(const Eigen::MatrixXd& u,
 //! @details The vine is evaluated in an admissible sampling order whose tail
 //! contains exactly `conditioning_set`. The model itself is not modified.
 //!
-//! @param u An \f$ n \times d \f$ matrix of independent uniform variates.
+//! @param u An \f$ n \times 2d \f$, \f$ n \times (d + k) \f$, or
+//!   \f$ n \times d \f$ matrix of independent uniform variates, where \f$ k \f$
+//!   is the number of discrete variables. Only the first \f$ d \f$ columns are
+//!   used.
 //! @param conditioning_set The 1-based indices of the conditioning variables.
 //! @param num_threads The number of threads to use for computations.
 //! @return An \f$ n \times d \f$ matrix of transformed values.
@@ -3266,11 +3282,12 @@ Vinecop::inverse_rosenblatt_impl(const Eigen::MatrixXd& u,
                                  size_t num_threads) const
 {
   const size_t n_cols = static_cast<size_t>(u.cols());
-  if ((n_cols != d_) && (n_cols != 2 * d_)) {
+  const size_t compact_cols = d_ + get_n_discrete();
+  if ((n_cols != d_) && (n_cols != compact_cols) && (n_cols != 2 * d_)) {
     throw std::runtime_error(
-      "data has wrong number of columns; expected: " + std::to_string(d_) +
-      " or " + std::to_string(2 * d_) + ", actual: " + std::to_string(n_cols) +
-      ".");
+      "data has wrong number of columns; expected: " + std::to_string(2 * d_) +
+      ", " + std::to_string(compact_cols) + ", or " + std::to_string(d_) +
+      ", actual: " + std::to_string(n_cols) + ".");
   }
   if (u.rows() < 1) {
     throw std::runtime_error("data must have at least one row");
@@ -3370,7 +3387,7 @@ Vinecop::check_data_dim(const Eigen::MatrixXd& data) const
   if ((d_data != d_exp) & (d_data != 2 * d_)) {
     std::stringstream msg;
     msg << "data has wrong number of columns; "
-        << "expected: " << d_exp << " or " << 2 * d_ << ", actual: " << d_data
+        << "expected: " << 2 * d_ << " or " << d_exp << ", actual: " << d_data
         << " (model contains ";
     if (n_disc == 0) {
       msg << "no discrete variables)." << std::endl;

--- a/test/src_test/test_discrete.cpp
+++ b/test/src_test/test_discrete.cpp
@@ -172,6 +172,7 @@ TEST(discrete, vinecop)
 
   u.col(3) = (utmp.col(3).array() * 10).ceil() / 10;
   u.col(5 + 2) = (utmp.col(3).array() * 10).floor() / 10;
+  auto u_compact = u;
 
   // fit vine
   auto controls = FitControlsVinecop({ BicopFamily::clayton });
@@ -207,6 +208,11 @@ TEST(discrete, vinecop)
   u.col(7) = (utmp.col(2).array() * 10).floor() / 10;
   u.col(3) = (utmp.col(3).array() * 10).ceil() / 10;
   u.col(8) = (utmp.col(3).array() * 10).floor() / 10;
+  EXPECT_TRUE(
+    vc.pdf(u_compact.topRows(100)).isApprox(vc.pdf(u.topRows(100)), 1e-12));
+  EXPECT_TRUE(
+    vc.rosenblatt(u_compact.topRows(100), 1, true, { 5 })
+      .isApprox(vc.rosenblatt(u.topRows(100), 1, true, { 5 }), 1e-12));
   vc2.select(u, controls);
   vc2.pdf(u);
   pcs = vc2.get_all_pair_copulas();

--- a/test/src_test/test_vinecop_class.cpp
+++ b/test/src_test/test_vinecop_class.cpp
@@ -396,6 +396,7 @@ TEST_F(VinecopTest, simulate_is_correct)
 TEST_F(VinecopTest, inverse_rosenblatt_does_not_mutate_discrete_model)
 {
   const size_t d = 5;
+  const size_t n_discrete = 3;
   auto pair_copulas = Vinecop::make_pair_copula_store(d);
   auto par = Eigen::VectorXd::Constant(1, 2.0);
   for (size_t tree = 0; tree < pair_copulas.size(); ++tree) {
@@ -409,10 +410,20 @@ TEST_F(VinecopTest, inverse_rosenblatt_does_not_mutate_discrete_model)
   Vinecop continuous(structure, pair_copulas);
   auto w = tools_stats::simulate_uniform(100, d, false, { 17 });
 
-  EXPECT_TRUE(all_close(discrete.inverse_rosenblatt(w),
-                        continuous.inverse_rosenblatt(w),
-                        1e-12,
-                        1e-12));
+  auto expected = discrete.inverse_rosenblatt(w);
+  EXPECT_TRUE(
+    all_close(expected, continuous.inverse_rosenblatt(w), 1e-12, 1e-12));
+
+  Eigen::MatrixXd w_compact(w.rows(), d + n_discrete);
+  w_compact.leftCols(d) = w;
+  w_compact.rightCols(n_discrete) = w.leftCols(n_discrete);
+  Eigen::MatrixXd w_expanded(w.rows(), 2 * d);
+  w_expanded.leftCols(d) = w;
+  w_expanded.rightCols(d) = w;
+  EXPECT_TRUE(
+    all_close(discrete.inverse_rosenblatt(w_compact), expected, 1e-12, 1e-12));
+  EXPECT_TRUE(
+    all_close(discrete.inverse_rosenblatt(w_expanded), expected, 1e-12, 1e-12));
   EXPECT_EQ(discrete.get_var_types(), var_types);
 
   auto pair_copulas_before = discrete.get_all_pair_copulas();
@@ -765,6 +776,11 @@ TEST(VinecopConditionalSimulation, accepts_custom_conditioning_set)
   u_cond.col(1).setConstant(0.7);
   auto actual =
     model.simulate_conditional(u_cond, conditioning_set, true, 2, { 71 });
+  Eigen::MatrixXd u_cond_expanded(u_cond.rows(), 2 * u_cond.cols());
+  u_cond_expanded.leftCols(u_cond.cols()) = u_cond;
+  u_cond_expanded.rightCols(u_cond.cols()) = u_cond;
+  auto actual_expanded = model.simulate_conditional(
+    u_cond_expanded, conditioning_set, true, 2, { 71 });
 
   auto materialized = model;
   materialized.reorient(conditioning_set);
@@ -779,6 +795,7 @@ TEST(VinecopConditionalSimulation, accepts_custom_conditioning_set)
     materialized.simulate_conditional(u_cond_tail, true, 2, { 71 });
 
   EXPECT_TRUE(all_close(actual, expected, 1e-12, 1e-12));
+  EXPECT_TRUE(all_close(actual_expanded, actual, 1e-12, 1e-12));
   EXPECT_TRUE(all_close(actual.col(1), u_cond.col(0), 1e-12, 1e-12));
   EXPECT_TRUE(all_close(actual.col(0), u_cond.col(1), 1e-12, 1e-12));
   EXPECT_EQ(model.get_order(), original_order);
@@ -788,18 +805,25 @@ TEST(VinecopConditionalSimulation, custom_set_handles_discrete_variables)
 {
   auto model = make_clayton_dvine(4, 2.0, 270);
   model.set_var_types({ "d", "c", "d", "c" });
-  const std::vector<size_t> conditioning_set{ 1 };
+  const std::vector<size_t> conditioning_set{ 2, 1 };
 
-  Eigen::MatrixXd u_cond(100, 2);
-  u_cond.col(0).setConstant(0.8);
-  u_cond.col(1).setConstant(0.6);
+  Eigen::MatrixXd u_cond(100, 3);
+  u_cond.col(0).setConstant(0.4);
+  u_cond.col(1).setConstant(0.8);
+  u_cond.col(2).setConstant(0.6);
   auto actual =
     model.simulate_conditional(u_cond, conditioning_set, false, 2, { 73 });
 
-  auto materialized = model;
-  materialized.reorient(conditioning_set);
-  auto expected = materialized.simulate_conditional(u_cond, false, 2, { 73 });
-  EXPECT_TRUE(all_close(actual, expected, 1e-12, 1e-12));
+  Eigen::MatrixXd u_cond_expanded(100, 4);
+  u_cond_expanded.col(0) = u_cond.col(0);
+  u_cond_expanded.col(1) = u_cond.col(1);
+  u_cond_expanded.col(2) = u_cond.col(0);
+  u_cond_expanded.col(3) = u_cond.col(2);
+  auto actual_expanded = model.simulate_conditional(
+    u_cond_expanded, conditioning_set, false, 2, { 73 });
+
+  EXPECT_TRUE(all_close(actual_expanded, actual, 1e-12, 1e-12));
+  EXPECT_TRUE(all_close(actual.col(1), u_cond.col(0), 1e-12, 1e-12));
   EXPECT_TRUE((actual.col(0).array() >= 0.6 - 1e-12).all());
   EXPECT_TRUE((actual.col(0).array() <= 0.8 + 1e-12).all());
 }

--- a/test/src_test/test_vinecop_class.cpp
+++ b/test/src_test/test_vinecop_class.cpp
@@ -663,6 +663,13 @@ TEST_F(VinecopTest, reoriented_transforms_handle_tll_without_materializing_grid)
               materialized.rosenblatt(expected_inverse, 1, false),
               1e-8,
               1e-8));
+
+  auto u_cond = Eigen::MatrixXd::Constant(20, 1, 0.4);
+  EXPECT_TRUE(all_close(
+    model.simulate_conditional(u_cond, conditioning_set, false, 1, { 63 }),
+    materialized.simulate_conditional(u_cond, false, 1, { 63 }),
+    1e-8,
+    1e-8));
 }
 
 TEST_F(VinecopTest, reoriented_transforms_validate_conditioning_set)
@@ -744,6 +751,76 @@ TEST_F(VinecopTest, simulate_conditional_is_correct)
   double ref_mean = sum / cnt;
   EXPECT_NEAR(cond_mean, ref_mean, 0.02);
   EXPECT_GT(std::abs(cond_mean - big.col(freevar).mean()), 0.1);
+}
+
+TEST(VinecopConditionalSimulation, accepts_custom_conditioning_set)
+{
+  const size_t d = 4;
+  auto model = make_clayton_dvine(d, 2.0, 90);
+  const auto original_order = model.get_order();
+  const std::vector<size_t> conditioning_set{ 2, 1 };
+
+  Eigen::MatrixXd u_cond(200, conditioning_set.size());
+  u_cond.col(0).setConstant(0.3);
+  u_cond.col(1).setConstant(0.7);
+  auto actual =
+    model.simulate_conditional(u_cond, conditioning_set, true, 2, { 71 });
+
+  auto materialized = model;
+  materialized.reorient(conditioning_set);
+  auto order = materialized.get_order();
+  Eigen::MatrixXd u_cond_tail(u_cond.rows(), u_cond.cols());
+  for (size_t i = 0; i < conditioning_set.size(); ++i) {
+    size_t var = order[d - conditioning_set.size() + i];
+    auto it = std::find(conditioning_set.begin(), conditioning_set.end(), var);
+    u_cond_tail.col(i) = u_cond.col(it - conditioning_set.begin());
+  }
+  auto expected =
+    materialized.simulate_conditional(u_cond_tail, true, 2, { 71 });
+
+  EXPECT_TRUE(all_close(actual, expected, 1e-12, 1e-12));
+  EXPECT_TRUE(all_close(actual.col(1), u_cond.col(0), 1e-12, 1e-12));
+  EXPECT_TRUE(all_close(actual.col(0), u_cond.col(1), 1e-12, 1e-12));
+  EXPECT_EQ(model.get_order(), original_order);
+}
+
+TEST(VinecopConditionalSimulation, custom_set_handles_discrete_variables)
+{
+  auto model = make_clayton_dvine(4, 2.0, 270);
+  model.set_var_types({ "d", "c", "d", "c" });
+  const std::vector<size_t> conditioning_set{ 1 };
+
+  Eigen::MatrixXd u_cond(100, 2);
+  u_cond.col(0).setConstant(0.8);
+  u_cond.col(1).setConstant(0.6);
+  auto actual =
+    model.simulate_conditional(u_cond, conditioning_set, false, 2, { 73 });
+
+  auto materialized = model;
+  materialized.reorient(conditioning_set);
+  auto expected = materialized.simulate_conditional(u_cond, false, 2, { 73 });
+  EXPECT_TRUE(all_close(actual, expected, 1e-12, 1e-12));
+  EXPECT_TRUE((actual.col(0).array() >= 0.6 - 1e-12).all());
+  EXPECT_TRUE((actual.col(0).array() <= 0.8 + 1e-12).all());
+}
+
+TEST(VinecopConditionalSimulation, custom_set_validates_inputs)
+{
+  auto model = make_clayton_dvine(4, 2.0);
+  auto u_cond = Eigen::MatrixXd::Constant(3, 2, 0.5);
+
+  EXPECT_ANY_THROW(
+    model.simulate_conditional(u_cond, std::vector<size_t>{}, false, 1, { 1 }));
+  EXPECT_ANY_THROW(model.simulate_conditional(
+    u_cond, std::vector<size_t>{ 1, 1 }, false, 1, { 1 }));
+  EXPECT_ANY_THROW(model.simulate_conditional(
+    u_cond, std::vector<size_t>{ 1, 3 }, false, 1, { 1 }));
+  EXPECT_ANY_THROW(
+    model.simulate_conditional(Eigen::MatrixXd::Constant(3, 1, 0.5),
+                               std::vector<size_t>{ 1, 2 },
+                               false,
+                               1,
+                               { 1 }));
 }
 
 TEST_F(VinecopTest, simulate_conditional_throws)

--- a/test/src_test/test_vinecop_class.cpp
+++ b/test/src_test/test_vinecop_class.cpp
@@ -33,6 +33,25 @@ TEST_F(VinecopTest, constructors_without_error)
   Vinecop vinecop_parametrized(model_matrix, pair_copulas);
 }
 
+TEST(VinecopConstructor, omitted_pair_copulas_are_independence)
+{
+  const size_t d = 4;
+  Vinecop model(DVineStructure({ 1, 2, 3, 4 }));
+
+  ASSERT_TRUE(model.get_all_pair_copulas().empty());
+  auto data = tools_stats::simulate_uniform(20, d, false, { 1 });
+  EXPECT_TRUE(all_close(model.pdf(data), Eigen::VectorXd::Ones(data.rows())));
+
+  std::vector<size_t> conditioning_set{ 1, 2 };
+  Eigen::MatrixXd u_cond(20, conditioning_set.size());
+  u_cond.col(0).setConstant(0.3);
+  u_cond.col(1).setConstant(0.8);
+  auto simulated =
+    model.simulate_conditional(u_cond, conditioning_set, false, 1, { 2 });
+  EXPECT_TRUE(all_close(simulated.col(0), u_cond.col(0)));
+  EXPECT_TRUE(all_close(simulated.col(1), u_cond.col(1)));
+}
+
 TEST_F(VinecopTest, copy)
 {
   auto pair_copulas = Vinecop::make_pair_copula_store(7);


### PR DESCRIPTION
Summary

- add a conditional-simulation overload that accepts an explicit conditioning set and evaluates through the reoriented vine view
- accept both expanded and compact left-limit layouts for explicit conditional inputs, and both 2d and d + k inputs consistently across bivariate and vine operations
- document the expanded 2d layout as the preferred interface convention while retaining the compact d + k layout
- add compact/expanded parity coverage for Rosenblatt transforms, inverse Rosenblatt, and conditional simulation

Testing

- clang-format-14
- strict Debug build with -Werror, -Wconversion, and -Wnoexcept
- debug/bin/test_all: 711 tests passed
- precompiled Release library target built successfully (Release tests skipped as requested)

This PR is intentionally stacked on docs/news-1.0.