### PR TITLE
ci: lint the library through two translation units instead of thirteen

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -392,11 +392,11 @@ jobs:
             | /usr/lib/llvm-14/share/clang/clang-tidy-diff.py \
                 -p1 -path build-tidy -clang-tidy-binary clang-tidy-14 -use-color
 
-      # The per-area test translation units include the whole library between
-      # them, so this keeps the backlog at zero rather than only gating new
-      # code. (test_all.cpp is just main() and covers nothing.) Each one takes
-      # minutes, so run them in parallel.
+      # Keeps the backlog at zero rather than only gating new code. Two
+      # translation units suffice: one including <vinecopulib.hpp> reaches every
+      # library header bar version.hpp, and one parametric-bicop unit reaches the
+      # shared test fixtures. (test_all.cpp is just main() and covers nothing.)
       - name: Run clang-tidy over the whole library
         run: |
-          run-clang-tidy-14 -p build-tidy -quiet -j "$(nproc)" \
-            'test/src_test/test_.*[.]cpp'
+          clang-tidy-14 -p build-tidy --quiet \
+            docs/snippets/vinecop.cpp test/src_test/test_bicop_parametric.cpp


### PR DESCRIPTION
The repo-wide clang-tidy pass was consuming **~65 minutes of the job's 75-minute
budget** on a runner. #717 gave every test area its own translation unit, and the
pass linted all thirteen — each instantiating the whole header-only library. #726
sat behind exactly this for over an hour.

## Two units, same coverage

| | TUs | wall (this machine) |
|---|---|---|
| before | 13 | ~26 min serial (4.5 min at `-j8`, unavailable on a 2-core runner) |
| after | 2 | **4:04** |

- `docs/snippets/vinecop.cpp` includes `<vinecopulib.hpp>` and so reaches **78 of
  the 78 library headers**. The one exception is `version.hpp` — two `#define`s,
  nothing to lint.
- `test/src_test/test_bicop_parametric.cpp` reaches the shared test fixtures
  (`parbicop_test.hpp`, `test_utils.hpp`, `r_parity.hpp`).

Changed test units are still linted individually by the diff pass in the same
job, so per-PR feedback on test code is unaffected.

## Verified, not assumed

Coverage was measured with `g++ -MM` against the full header list, and the gate
was checked with a negative control — injecting a `typedef` into
`vinecop/rvine_structure.hpp`, which the umbrella unit only sees transitively:

```
include/vinecopulib/vinecop/rvine_structure.hpp:16:1: error: use 'using' instead
of 'typedef' [modernize-use-using,-warnings-as-errors]
```

Caught. Probe reverted. Zero findings on the tree as it stands.