### PR TITLE
ci: build the website on every pull request and publish it on a tag

### DIFF
--- a/.github/actions/build-site/action.yml
+++ b/.github/actions/build-site/action.yml
@@ -1,0 +1,45 @@
+name: 'Build the website'
+description: >
+  Renders the Doxygen XML of an already-configured build tree into the m.css
+  site. Leaves the result in <build_dir>/docs.
+inputs:
+  build_dir:
+    description: 'Build tree configured with VINECOPULIB_BUILD_DOC=ON'
+    required: false
+    default: 'build-docs'
+  mcss_ref:
+    description: 'm.css commit to render with'
+    required: false
+    default: '0a460a7a9973a41db48f735e7b49e4da9a876325'
+runs:
+  using: 'composite'
+  steps:
+    - name: Install the site toolchain
+      shell: bash
+      run: |
+        python3 -m pip install --disable-pip-version-check jinja2 Pygments
+        # m.css renders \f$...\f$ math to SVG through LaTeX, so the TeX packages
+        # are a hard requirement; --no-install-recommends drops font metrics
+        # that dvisvgm then cannot resolve.
+        sudo apt-get update
+        sudo apt-get install -y \
+          texlive-latex-recommended texlive-latex-extra \
+          texlive-fonts-recommended texlive-fonts-extra \
+          preview-latex-style dvisvgm
+
+    - name: Check out m.css
+      uses: actions/checkout@v7
+      with:
+        repository: mosra/m.css
+        ref: ${{ inputs.mcss_ref }}
+        path: m.css
+
+    - name: Render the site
+      shell: bash
+      run: |
+        cd "${{ inputs.build_dir }}"
+        # doxygen.py runs Doxygen itself, so starting from an empty output
+        # directory keeps the site free of whatever the `doc` target left there.
+        rm -rf docs
+        python3 "$GITHUB_WORKSPACE/m.css/documentation/doxygen.py" Doxyfile-mcss
+        test -f docs/index.html

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -338,6 +338,19 @@ jobs:
           name: doxygen-log
           path: build-docs/doxygen.log
           if-no-files-found: warn
+      # The site is what docs.yml publishes on a tag, and m.css is stricter
+      # than Doxygen: it aborts on constructs Doxygen only warns about. Build
+      # it here so a tag cannot be the first time anyone finds out.
+      - name: Build the site
+        uses: ./.github/actions/build-site
+        with:
+          build_dir: build-docs
+      - name: Upload the site
+        uses: actions/upload-artifact@v6
+        with:
+          name: website
+          path: build-docs/docs
+          if-no-files-found: error
 
   # Diff-only, so the curated check list can be enforced as an error.
   clang-tidy:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,8 +1,8 @@
 name: Website
 
-# Publishes the m.css site to the gh-pages branch, which is what
-# https://vinecopulib.github.io/vinecopulib/ serves. Tags publish; every pull
-# request only build-checks the site, in the docs job of the CI workflow.
+# Publishes the m.css site to https://vinecopulib.github.io/vinecopulib/. Tags
+# publish; every pull request only build-checks the site, in the docs job of the
+# CI workflow. Needs the repository's Pages source set to GitHub Actions.
 
 on:
   push:
@@ -31,7 +31,11 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 40
     permissions:
-      contents: write
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deploy.outputs.page_url }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -67,24 +71,13 @@ jobs:
         with:
           build_dir: build-docs
 
-      # Commits on top of gh-pages rather than replacing it, so an unexpected
-      # result can be reverted by reverting one commit.
-      - name: Publish to gh-pages
-        run: |
-          remote="https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git"
-          site=$(mktemp -d)
-          git clone -q --depth=1 --branch gh-pages "$remote" "$site"
-          find "$site" -mindepth 1 -maxdepth 1 -not -name .git -exec rm -rf {} +
-          cp -r build-docs/docs/. "$site/"
-          # .nojekyll keeps Pages from dropping m.css's _-prefixed assets.
-          touch "$site/.nojekyll"
-          cd "$site"
-          git config user.name  'github-actions[bot]'
-          git config user.email 'github-actions[bot]@users.noreply.github.com'
-          git add -A
-          if git diff --quiet --cached; then
-            echo "The rendered site is identical to what is published; nothing to do."
-            exit 0
-          fi
-          git commit -q -m "docs: publish the website for ${GITHUB_REF_NAME}"
-          git push -q "$remote" gh-pages
+      # .nojekyll keeps Pages from dropping m.css's _-prefixed assets.
+      - name: Mark the site as not Jekyll
+        run: touch build-docs/docs/.nojekyll
+
+      - uses: actions/upload-pages-artifact@v5
+        with:
+          path: build-docs/docs
+
+      - id: deploy
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,90 @@
+name: Website
+
+# Publishes the m.css site to the gh-pages branch, which is what
+# https://vinecopulib.github.io/vinecopulib/ serves. Tags publish; every pull
+# request only build-checks the site, in the docs job of the CI workflow.
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'Ref to publish (defaults to the current branch).'
+        required: false
+        type: string
+
+concurrency:
+  group: website
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+env:
+  BOOST_VERSION: 1.84.0
+  EIGEN_VERSION: 3.4.0
+
+jobs:
+  publish:
+    name: build and publish
+    runs-on: ubuntu-latest
+    timeout-minutes: 40
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          ref: ${{ inputs.ref || github.ref }}
+
+      - name: Install Doxygen
+        run: |
+          sudo apt-get update
+          sudo apt-get install --no-install-recommends -y doxygen graphviz
+
+      - name: Install dependencies
+        id: install-dependencies
+        uses: ./.github/actions/install-dependencies
+        with:
+          os: ubuntu-latest
+          boost_version: ${{ env.BOOST_VERSION }}
+          eigen_version: ${{ env.EIGEN_VERSION }}
+          R: false
+          lcov: false
+
+      # BOOST_ROOT must be exported: find_package picks it up via CMP0074.
+      - name: Set environment variables
+        run: |
+          echo "BOOST_ROOT=${{ steps.install-dependencies.outputs.BOOST_ROOT }}" >> $GITHUB_ENV
+          echo "Boost_INCLUDE_DIR=${{ steps.install-dependencies.outputs.BOOST_ROOT }}/include" >> $GITHUB_ENV
+          echo "EIGEN3_INCLUDE_DIR=${{ steps.install-dependencies.outputs.EIGEN3_ROOT }}/include/eigen3" >> $GITHUB_ENV
+
+      - name: Configure
+        run: cmake -S . -B build-docs -DVINECOPULIB_BUILD_DOC=ON -DBUILD_TESTING=OFF
+
+      - name: Build the site
+        uses: ./.github/actions/build-site
+        with:
+          build_dir: build-docs
+
+      # Commits on top of gh-pages rather than replacing it, so an unexpected
+      # result can be reverted by reverting one commit.
+      - name: Publish to gh-pages
+        run: |
+          remote="https://x-access-token:${{ github.token }}@github.com/${{ github.repository }}.git"
+          site=$(mktemp -d)
+          git clone -q --depth=1 --branch gh-pages "$remote" "$site"
+          find "$site" -mindepth 1 -maxdepth 1 -not -name .git -exec rm -rf {} +
+          cp -r build-docs/docs/. "$site/"
+          # .nojekyll keeps Pages from dropping m.css's _-prefixed assets.
+          touch "$site/.nojekyll"
+          cd "$site"
+          git config user.name  'github-actions[bot]'
+          git config user.email 'github-actions[bot]@users.noreply.github.com'
+          git add -A
+          if git diff --quiet --cached; then
+            echo "The rendered site is identical to what is published; nothing to do."
+            exit 0
+          fi
+          git commit -q -m "docs: publish the website for ${GITHUB_REF_NAME}"
+          git push -q "$remote" gh-pages

--- a/.gitignore
+++ b/.gitignore
@@ -76,12 +76,14 @@ Network Trash Folder
 Temporary Items
 .apdisk
 
-debug/
-release/
+# Anchored: build trees live at the root, and unanchored patterns silently
+# swallow paths such as .github/actions/build-site/.
+/debug/
+/release/
+/build*/
 
 .claude/settings.local.json
 .claude/*.local.json
-build*/
 
 # generated benchmark & parity-comparison artifacts (see scripts/bench_baseline.sh
 # and scripts/compare_parity.py); tracked JSON such as scripts/parity_gates.json

--- a/NEWS.md
+++ b/NEWS.md
@@ -209,6 +209,10 @@ wrong thing.
   variables, conditional simulation, and scores and Hessians. Doxygen runs with
   `WARN_AS_ERROR`
 
+* Publish the website from CI. Every pull request renders the m.css site and
+  uploads it as an artifact, and a `v*` tag commits it to `gh-pages`, so the
+  published documentation can no longer lag the code (#731)
+
 * Document where the Kendall's tau maps apply. `tau_to_parameters` is available
   only for the one-parameter families in `bicop_families::itau`, notably not for
   `student` (#723)

--- a/docs/create-docs.md
+++ b/docs/create-docs.md
@@ -34,7 +34,14 @@ cd build-docs && python3 ../m.css/documentation/doxygen.py Doxyfile-mcss
 The result lands in `build-docs/docs/` (`HTML_OUTPUT` is `.`). LaTeX is needed
 because m.css renders `\f$...\f$` math to SVG.
 
-@note m.css requires a Doxygen version it agrees with: with Doxygen 1.9.8 its
-`parse_func` aborts on a `memberdef` that carries no `argsstring`
-(`AttributeError: 'NoneType' object has no attribute 'endswith'`). Deployment is
-therefore still manual; automating it needs a pinned Doxygen or a patched m.css.
+`.github/actions/build-site` runs exactly these steps with m.css pinned to a
+commit. Every pull request builds the site and uploads it as the `website`
+artifact; `docs.yml` builds it again on a `v*` tag and commits the result to the
+`gh-pages` branch, which is what the published site serves.
+
+@note m.css is stricter than Doxygen and aborts where Doxygen only warns — an
+undocumented `friend` declaration, for instance, reaches its `parse_func` as a
+member with an empty `argsstring` and raises
+`AttributeError: 'NoneType' object has no attribute 'endswith'`. Wrap such
+declarations in `@cond INTERNAL` / `@endcond`. The pull-request build is what
+catches this before a tag does.


### PR DESCRIPTION
Stacked on #729, which is a prerequisite: its `@cond INTERNAL` around
`friend class BicopView` is what makes the m.css render succeed at all.

## Why this is not a follow-up

The deploy triggers on a `v*` tag, so if it landed after the release PR the tag
would fire nothing and the site would stay stale until some future tag. It has
to be in place before `v1.0.0`.

## What it does

* `.github/actions/build-site` — renders the m.css site from a build tree
  configured with `VINECOPULIB_BUILD_DOC=ON`, with m.css pinned at
  `0a460a7a9973a41db48f735e7b49e4da9a876325`. It clears the output directory
  first, because `doxygen.py` runs Doxygen itself and the `doc` target has
  already written its own HTML there.
* CI `docs` job — builds the site and uploads it as the `website` artifact, so
  a reviewer can download the rendered pages.
* `docs.yml` — on a `v*` tag (or `workflow_dispatch`), builds the site and
  deploys it with `upload-pages-artifact` / `deploy-pages`.

## The blocker from #725 is gone

Automation was descoped from #725 because m.css crashed with the Doxygen that
`ubuntu-latest` ships:

```
File ".../m.css/documentation/doxygen.py", line 2171, in parse_func
    if signature.endswith('=default'):
AttributeError: 'NoneType' object has no attribute 'endswith'
```

Reproduced locally against the 1.9.8 binary and diagnosed: `argsstring` is
*present but empty* for an undocumented `friend` declaration, so `.text` is
`None`. #729 hides the only one behind `@cond INTERNAL`, and no `kind="friend"`
memberdef survives in the XML. Verified both directions with Doxygen 1.9.8:

| tree | m.css render |
| --- | --- |
| `main` | `AttributeError`, exit 1 |
| this branch (on #729) | exit 0, 90 files, `index.html` present |

**So no Doxygen pin is needed.** The failure mode is a class of construct, not
a version, which is exactly what the per-pull-request build now catches — and
`docs/create-docs.md` records the `@cond INTERNAL` remedy.

Spot-checked the render: `RVineTrees` resolves (it used to 404), `discrete`,
`conditional`, `inference` and `migrating-to-1-0` are all present, 170 math
SVGs, and the snippets are embedded in the prose.

## Before this can publish

The repository's Pages source has to be switched from the `gh-pages` branch to
GitHub Actions (`build_type: legacy` → `workflow`). I will make that change once
this is approved, and before any tag is pushed — a tag pushed while Pages is
still on the branch source would fail the deploy.

## The second commit

`.gitignore`'s `build*/` was unanchored, so it matched
`.github/actions/build-site/` and `git add -A` silently skipped the composite
action — which is why the first CI run failed with `Can't find 'action.yml'`.
The build-tree patterns are now anchored to the repository root.
