### PR TITLE
docs: clarify continuous and discrete data layouts

### DIFF
--- a/docs/conditional.dox
+++ b/docs/conditional.dox
@@ -32,18 +32,20 @@ columns of `u_cond` correspond to `conditioning_set` in the supplied order.
 `u_cond` has one row per output sample; to draw many samples at a single
 conditioning point, repeat that point over the rows.
 
-With an explicit `conditioning_set`, `u_cond` can use either layout from the
-@ref discrete "discrete-data documentation". The preferred expanded layout has
-`2k` columns, while the compact layout has `k + k_d` columns, where `k_d` is the
-number of discrete conditioning variables. The overload without
-`conditioning_set` infers `k` from the column count and retains the compact
-interpretation when the two layouts are ambiguous.
+For all-continuous conditioning variables, `u_cond` is an
+\f$ n \times k \f$ matrix. If any are discrete, the expanded
+\f$ n \times 2k \f$ layout contains their values followed by all left-limits,
+as described in the @ref discrete "discrete-data documentation". With an
+explicit `conditioning_set`, the compact \f$ n \times (k + k_d) \f$ layout is
+also accepted, where `k_d` is the number of discrete conditioning variables.
+The overload without `conditioning_set` infers `k` from the column count and
+uses the compact layout.
 
 The result is an \f$ n \times d \f$ matrix in which the conditioning columns
-reproduce `u_cond` and the remaining ones are draws from the conditional
-distribution. Discrete conditioning variables are supported and need their
-left-limit column as well, as everywhere else — see @ref discrete, and the
-method's own documentation for the exact column layout.
+reproduce the first `k` columns of `u_cond` and the remaining ones are draws
+from the conditional distribution. Discrete conditioning variables are
+supported and need one additional left-limit column each — see @ref discrete,
+and the method's own documentation for the exact column layout.
 
 @snippet conditional.cpp simulate
 

--- a/docs/discrete.dox
+++ b/docs/discrete.dox
@@ -13,22 +13,23 @@ that scale has atoms: the model needs both \f$ F(x) \f$ and the left limit
 
 @section discrete-layout The data layout
 
-Every data-taking method accepts two equivalent conventions. The preferred
-expanded layout has \f$ 2d \f$ columns:
+For an all-continuous model, every data-taking method uses the usual
+\f$ n \times d \f$ matrix: its `d` columns contain \f$ F(x) \f$ in the
+model's variable order. In particular, `Bicop` methods take an
+\f$ n \times 2 \f$ matrix by default.
 
-- the first `d` columns hold \f$ F(x) \f$ for every variable, in the model's
-  variable order;
-- the next `d` columns hold \f$ F(x^-) \f$ in the same order.
+Extra columns are needed only when variables are discrete. In that case, the
+expanded layout has \f$ 2d \f$ columns: its first `d` columns hold
+\f$ F(x) \f$ and its next `d` columns hold \f$ F(x^-) \f$ in the same order.
 
 For continuous variables \f$ F(x^-) = F(x) \f$, so their columns in the second
-block duplicate the corresponding columns in the first block. These duplicate
-columns may be omitted: if `k` of the `d` variables are discrete, the compact
-layout has \f$ d + k \f$ columns, with the `k` left-limits ordered by the
-positions of the discrete variables in the first block.
+block are duplicates. These duplicates may be omitted: if `k` of the `d`
+variables are discrete, the compact \f$ n \times (d + k) \f$ layout appends
+only their `k` left-limits, ordered by their positions in the first block.
 
-Both layouts are accepted throughout the library. The expanded layout is often
-more convenient for interfaces because its shape does not depend on
-`var_types`; the compact layout avoids storing duplicate continuous columns.
+Both discrete-data layouts are accepted throughout the library. The expanded
+layout has a fixed shape independent of `var_types`; the compact layout avoids
+storing duplicate continuous columns.
 
 @section discrete-bicop Bivariate copulas
 

--- a/docs/snippets/discrete.cpp
+++ b/docs/snippets/discrete.cpp
@@ -29,7 +29,7 @@ void
 snippet_bicop_discrete()
 {
   //! [bicop]
-  // The preferred layout has two full blocks: F(x), followed by F(x-).
+  // A discrete model uses an F(x) block followed by an F(x-) block.
   auto continuous = tools_stats::simulate_uniform(500, 2, false, { 1 });
   auto disc = discretize(continuous.col(0), 5);
 
@@ -57,7 +57,7 @@ void
 snippet_vinecop_discrete()
 {
   //! [vinecop]
-  // Same convention for vines: the expanded layout has 2d columns.
+  // Same convention for vines: discrete data uses two d-column blocks.
   size_t d = 4;
   auto continuous = tools_stats::simulate_uniform(500, d, false, { 2 });
   auto disc0 = discretize(continuous.col(0), 4);

--- a/include/vinecopulib/bicop/implementation/class.ipp
+++ b/include/vinecopulib/bicop/implementation/class.ipp
@@ -184,9 +184,11 @@ Bicop::to_file(const std::string& filename) const
 //! variables the left limit and the cdf itself coincide. Respective columns can
 //! be omitted in the second block.
 //!
-//! @param u An \f$ n \times 4 \f$ or \f$ n \times (2 + k) \f$ matrix of
-//!   observations contained in \f$(0, 1) \f$, where \f$ k \f$ is the number
-//!   of discrete variables.
+//! @param u An \f$ n \times 2 \f$ matrix of observations for a continuous
+//!   model. For a model with \f$ k \f$ discrete variables, use an
+//!   \f$ n \times 4 \f$ matrix containing the values and their left-limits;
+//!   left-limit columns for continuous variables may be omitted to obtain the
+//!   compact \f$ n \times (2 + k) \f$ layout (see @ref discrete).
 //! @return A length n vector of copula densities evaluated at \c u.
 inline Eigen::VectorXd
 Bicop::pdf(const Eigen::MatrixXd& u) const
@@ -207,9 +209,11 @@ Bicop::pdf(const Eigen::MatrixXd& u) const
 //! variables the left limit and the cdf itself coincide. Respective columns can
 //! be omitted in the second block.
 //!
-//! @param u An \f$ n \times 4 \f$ or \f$ n \times (2 + k) \f$ matrix of
-//!   observations contained in \f$(0, 1) \f$, where \f$ k \f$ is the number
-//!   of discrete variables.
+//! @param u An \f$ n \times 2 \f$ matrix of observations for a continuous
+//!   model. For a model with \f$ k \f$ discrete variables, use an
+//!   \f$ n \times 4 \f$ matrix containing the values and their left-limits;
+//!   left-limit columns for continuous variables may be omitted to obtain the
+//!   compact \f$ n \times (2 + k) \f$ layout (see @ref discrete).
 //! @return A length n vector of copula probabilities evaluated at \c u.
 inline Eigen::VectorXd
 Bicop::cdf(const Eigen::MatrixXd& u) const
@@ -246,9 +250,11 @@ Bicop::cdf(const Eigen::MatrixXd& u) const
 //! variables the left limit and the cdf itself coincide. Respective columns can
 //! be omitted in the second block.
 //!
-//! @param u An \f$ n \times 4 \f$ or \f$ n \times (2 + k) \f$ matrix of
-//!   observations contained in \f$(0, 1) \f$, where \f$ k \f$ is the number
-//!   of discrete variables.
+//! @param u An \f$ n \times 2 \f$ matrix of observations for a continuous
+//!   model. For a model with \f$ k \f$ discrete variables, use an
+//!   \f$ n \times 4 \f$ matrix containing the values and their left-limits;
+//!   left-limit columns for continuous variables may be omitted to obtain the
+//!   compact \f$ n \times (2 + k) \f$ layout (see @ref discrete).
 //! @return A length n vector of the first h-function evaluated at \c u.
 inline Eigen::VectorXd
 Bicop::hfunc1(const Eigen::MatrixXd& u) const
@@ -274,9 +280,11 @@ Bicop::hfunc1(const Eigen::MatrixXd& u) const
 //! variables the left limit and the cdf itself coincide. Respective columns can
 //! be omitted in the second block.
 //!
-//! @param u An \f$ n \times 4 \f$ or \f$ n \times (2 + k) \f$ matrix of
-//!   observations contained in \f$(0, 1) \f$, where \f$ k \f$ is the number
-//!   of discrete variables.
+//! @param u An \f$ n \times 2 \f$ matrix of observations for a continuous
+//!   model. For a model with \f$ k \f$ discrete variables, use an
+//!   \f$ n \times 4 \f$ matrix containing the values and their left-limits;
+//!   left-limit columns for continuous variables may be omitted to obtain the
+//!   compact \f$ n \times (2 + k) \f$ layout (see @ref discrete).
 //! @return A length n vector of the second h-function evaluated at \c u.
 inline Eigen::VectorXd
 Bicop::hfunc2(const Eigen::MatrixXd& u) const
@@ -303,9 +311,11 @@ Bicop::hfunc2(const Eigen::MatrixXd& u) const
 //! variables the left limit and the cdf itself coincide. Respective columns can
 //! be omitted in the second block.
 //!
-//! @param u An \f$ n \times 4 \f$ or \f$ n \times (2 + k) \f$ matrix of
-//!   observations contained in \f$(0, 1) \f$, where \f$ k \f$ is the number
-//!   of discrete variables.
+//! @param u An \f$ n \times 2 \f$ matrix of observations for a continuous
+//!   model. For a model with \f$ k \f$ discrete variables, use an
+//!   \f$ n \times 4 \f$ matrix containing the values and their left-limits;
+//!   left-limit columns for continuous variables may be omitted to obtain the
+//!   compact \f$ n \times (2 + k) \f$ layout (see @ref discrete).
 //! @return A length n vector of the inverse of the first h-function evaluated
 //! at \c u.
 inline Eigen::VectorXd
@@ -333,9 +343,11 @@ Bicop::hinv1(const Eigen::MatrixXd& u) const
 //! variables the left limit and the cdf itself coincide. Respective columns can
 //! be omitted in the second block.
 //!
-//! @param u An \f$ n \times 4 \f$ or \f$ n \times (2 + k) \f$ matrix of
-//!   observations contained in \f$(0, 1) \f$, where \f$ k \f$ is the number
-//!   of discrete variables.
+//! @param u An \f$ n \times 2 \f$ matrix of observations for a continuous
+//!   model. For a model with \f$ k \f$ discrete variables, use an
+//!   \f$ n \times 4 \f$ matrix containing the values and their left-limits;
+//!   left-limit columns for continuous variables may be omitted to obtain the
+//!   compact \f$ n \times (2 + k) \f$ layout (see @ref discrete).
 //! @return A length n vector of the inverse of the second h-function evaluated
 //! at \c u.
 inline Eigen::VectorXd
@@ -475,9 +487,11 @@ BicopView::swap_arguments(const Eigen::MatrixXd& u)
 //!
 //! Common arguments:
 //!
-//! - `u`: an \f$ n \times 4 \f$ or \f$ n \times (2 + k) \f$ matrix of
-//!   observations (see the single-argument overloads for the layout with
-//!   discrete variables).
+//! - `u`: an \f$ n \times 2 \f$ matrix for a continuous model. For a model
+//!   with `k` discrete variables, use an \f$ n \times 4 \f$ matrix containing
+//!   the values and their left-limits; left-limit columns for continuous
+//!   variables may be omitted to obtain the compact
+//!   \f$ n \times (2 + k) \f$ layout (see @ref discrete).
 //! - `parameters`: an \f$ n \times p \f$ matrix, where `p` is the number of
 //!   family parameters (`get_parameters().size()`) and row `i` holds the
 //!   parameter set used for row `i` of `u`. Parameters are given in the
@@ -1564,9 +1578,11 @@ Bicop::simulate(const Eigen::MatrixXd& parameters,
 //! variables the left limit and the cdf itself coincide. Respective columns can
 //! be omitted in the second block.
 //!
-//! @param u An \f$ n \times 4 \f$ or \f$ n \times (2 + k) \f$ matrix of
-//!   observations contained in \f$(0, 1) \f$, where \f$ k \f$ is the number
-//!   of discrete variables.
+//! @param u An \f$ n \times 2 \f$ matrix of observations for a continuous
+//!   model. For a model with \f$ k \f$ discrete variables, use an
+//!   \f$ n \times 4 \f$ matrix containing the values and their left-limits;
+//!   left-limit columns for continuous variables may be omitted to obtain the
+//!   compact \f$ n \times (2 + k) \f$ layout (see @ref discrete).
 //! @return The log-likelihood evaluated at \c u.
 inline double
 Bicop::loglik(const Eigen::MatrixXd& u) const
@@ -1588,9 +1604,11 @@ Bicop::loglik(const Eigen::MatrixXd& u) const
 //! The AIC is a consistent model selection criterion even
 //! for nonparametric models.
 //!
-//! @param u An \f$ n \times 4 \f$ or \f$ n \times (2 + k) \f$ matrix of
-//!   observations contained in \f$(0, 1) \f$, where \f$ k \f$ is the number
-//!   of discrete variables.
+//! @param u An \f$ n \times 2 \f$ matrix of observations for a continuous
+//!   model. For a model with \f$ k \f$ discrete variables, use an
+//!   \f$ n \times 4 \f$ matrix containing the values and their left-limits;
+//!   left-limit columns for continuous variables may be omitted to obtain the
+//!   compact \f$ n \times (2 + k) \f$ layout (see @ref discrete).
 //! @return The AIC evaluated at \c u.
 inline double
 Bicop::aic(const Eigen::MatrixXd& u) const
@@ -1607,9 +1625,11 @@ Bicop::aic(const Eigen::MatrixXd& u) const
 //! The BIC is a consistent model selection criterion
 //! for parametric models.
 //!
-//! @param u An \f$ n \times 4 \f$ or \f$ n \times (2 + k) \f$ matrix of
-//!   observations contained in \f$(0, 1) \f$, where \f$ k \f$ is the number
-//!   of discrete variables.
+//! @param u An \f$ n \times 2 \f$ matrix of observations for a continuous
+//!   model. For a model with \f$ k \f$ discrete variables, use an
+//!   \f$ n \times 4 \f$ matrix containing the values and their left-limits;
+//!   left-limit columns for continuous variables may be omitted to obtain the
+//!   compact \f$ n \times (2 + k) \f$ layout (see @ref discrete).
 //! @return The BIC evaluated at \c u.
 inline double
 Bicop::bic(const Eigen::MatrixXd& u) const
@@ -1634,9 +1654,11 @@ Bicop::bic(const Eigen::MatrixXd& u) const
 //! non-independence copula and \f$ I \f$ is an indicator for the family being
 //! non-independence.
 //!
-//! @param u An \f$ n \times 4 \f$ or \f$ n \times (2 + k) \f$ matrix of
-//!   observations contained in \f$(0, 1) \f$, where \f$ k \f$ is the number
-//!   of discrete variables.
+//! @param u An \f$ n \times 2 \f$ matrix of observations for a continuous
+//!   model. For a model with \f$ k \f$ discrete variables, use an
+//!   \f$ n \times 4 \f$ matrix containing the values and their left-limits;
+//!   left-limit columns for continuous variables may be omitted to obtain the
+//!   compact \f$ n \times (2 + k) \f$ layout (see @ref discrete).
 //! @param psi0 Prior probability of a non-independence copula.
 //! @return The mBIC evaluated at \c u.
 // clang-format on
@@ -1914,15 +1936,22 @@ Bicop::check_data_dim(const Eigen::MatrixXd& u) const
   unsigned short n_cols_exp = static_cast<unsigned short>(2 + n_disc);
   if ((n_cols != n_cols_exp) & (n_cols != 4)) {
     std::stringstream msg;
-    msg << "data has wrong number of columns; "
-        << "expected: 4 or " << n_cols_exp << ", actual: " << n_cols
-        << " (model contains ";
+    msg << "data has wrong number of columns; expected: ";
     if (n_disc == 0) {
-      msg << "no discrete variables)." << std::endl;
-    } else if (n_disc == 1) {
-      msg << "1 discrete variable)." << std::endl;
+      msg << "2 (n x 2 continuous layout)";
+    } else if (n_cols_exp == 4) {
+      msg << "4 (n x 4 expanded or n x (2 + k) compact layout)";
     } else {
-      msg << get_n_discrete() << " discrete variables)." << std::endl;
+      msg << "4 (n x 4 expanded layout) or " << n_cols_exp
+          << " (n x (2 + k) compact layout)";
+    }
+    msg << ", actual: " << n_cols << " (model contains ";
+    if (n_disc == 0) {
+      msg << "no discrete variables).";
+    } else if (n_disc == 1) {
+      msg << "1 discrete variable).";
+    } else {
+      msg << n_disc << " discrete variables).";
     }
     throw std::runtime_error(msg.str());
   }
@@ -2074,9 +2103,11 @@ Bicop::as_continuous() const
 //!
 //! Incomplete observations (i.e., ones with a NaN value) are discarded.
 //!
-//! @param data An \f$ n \times 4 \f$ or \f$ n \times (2 + k) \f$ matrix of
-//!   observations contained in \f$(0, 1) \f$, where \f$ k \f$ is the number
-//!   of discrete variables.
+//! @param data An \f$ n \times 2 \f$ matrix of observations for a continuous
+//!   model. For a model with \f$ k \f$ discrete variables, use an
+//!   \f$ n \times 4 \f$ matrix containing the values and their left-limits;
+//!   left-limit columns for continuous variables may be omitted to obtain the
+//!   compact \f$ n \times (2 + k) \f$ layout (see @ref discrete).
 //! @param controls The controls (see `FitControlsBicop`).
 inline void
 Bicop::fit(const Eigen::MatrixXd& data, const FitControlsBicop& controls)
@@ -2123,9 +2154,11 @@ Bicop::fit(const Eigen::MatrixXd& data, const FitControlsBicop& controls)
 //!
 //! Incomplete observations (i.e., ones with a NaN value) are discarded.
 //!
-//! @param data An \f$ n \times 4 \f$ or \f$ n \times (2 + k) \f$ matrix of
-//!   observations contained in \f$(0, 1) \f$, where \f$ k \f$ is the number
-//!   of discrete variables.
+//! @param data An \f$ n \times 2 \f$ matrix of observations for a continuous
+//!   model. For a model with \f$ k \f$ discrete variables, use an
+//!   \f$ n \times 4 \f$ matrix containing the values and their left-limits;
+//!   left-limit columns for continuous variables may be omitted to obtain the
+//!   compact \f$ n \times (2 + k) \f$ layout (see @ref discrete).
 //! @param controls The controls (see `FitControlsBicop`).
 inline void
 Bicop::select(const Eigen::MatrixXd& data, FitControlsBicop controls)

--- a/include/vinecopulib/vinecop/implementation/class.ipp
+++ b/include/vinecopulib/vinecop/implementation/class.ipp
@@ -329,8 +329,11 @@ Vinecop::make_pair_copula_store(const size_t d, const size_t trunc_lvl)
 //! so that the maximal available information is used.
 //!
 //!
-//! @param data \f$ n \times 2d \f$ or \f$ n \times (d + k) \f$ matrix of
-//!   observations, where \f$ k \f$ is the number of discrete variables.
+//! @param data An \f$ n \times d \f$ matrix of observations for a continuous
+//!   model. For a model with \f$ k \f$ discrete variables, use an
+//!   \f$ n \times 2d \f$ matrix containing the values and their left-limits;
+//!   left-limit columns for continuous variables may be omitted to obtain the
+//!   compact \f$ n \times (d + k) \f$ layout (see @ref discrete).
 //! @param controls The controls to the algorithm (see `FitControlsVinecop()`).
 inline void
 Vinecop::select(const Eigen::MatrixXd& data, const FitControlsVinecop& controls)
@@ -586,8 +589,11 @@ Vinecop::reorient(const std::vector<size_t>& conditioning_set)
 //! and a `FitControlsVinecop` object instantiated
 //! with `select_families = false`.
 //!
-//! @param data \f$ n \times 2d \f$ or \f$ n \times (d + k) \f$ matrix of
-//!   observations, where \f$ k \f$ is the number of discrete variables.
+//! @param data An \f$ n \times d \f$ matrix of observations for a continuous
+//!   model. For a model with \f$ k \f$ discrete variables, use an
+//!   \f$ n \times 2d \f$ matrix containing the values and their left-limits;
+//!   left-limit columns for continuous variables may be omitted to obtain the
+//!   compact \f$ n \times (d + k) \f$ layout (see @ref discrete).
 //! @param controls The controls for each bivariate fit (see
 //! `FitControlsBicop()`).
 //! @param num_threads The number of threads to use for parallel computation.
@@ -1109,9 +1115,11 @@ Vinecop::get_var_types() const
 //! limit and the cdf itself coincide. Respective columns can be omitted in the
 //! second block.
 //!
-//! @param u An \f$ n \times 2d \f$ or \f$ n \times (d + k) \f$ matrix of
-//!   evaluation points, where \f$ k \f$ is the number of discrete variables
-//!   (see `Vinecop::select()`).
+//! @param u An \f$ n \times d \f$ matrix of evaluation points for a
+//!   continuous model. For a model with \f$ k \f$ discrete variables, use an
+//!   \f$ n \times 2d \f$ matrix containing the values and their left-limits;
+//!   left-limit columns for continuous variables may be omitted to obtain the
+//!   compact \f$ n \times (d + k) \f$ layout (see @ref discrete).
 //! @param num_threads The number of threads to use for computations; if greater
 //!   than 1, the function will be applied concurrently to `num_threads` batches
 //!   of `u`.
@@ -1346,9 +1354,11 @@ Vinecop::pdf_full(Eigen::MatrixXd u,
 //! limit and the cdf itself coincide. Respective columns can be omitted in the
 //! second block.
 //!
-//! @param u An \f$ n \times 2d \f$ or \f$ n \times (d + k) \f$ matrix of
-//!   evaluation points, where \f$ k \f$ is the number of discrete variables
-//!   (see `Vinecop::select()`).
+//! @param u An \f$ n \times d \f$ matrix of evaluation points for a
+//!   continuous model. For a model with \f$ k \f$ discrete variables, use an
+//!   \f$ n \times 2d \f$ matrix containing the values and their left-limits;
+//!   left-limit columns for continuous variables may be omitted to obtain the
+//!   compact \f$ n \times (d + k) \f$ layout (see @ref discrete).
 //! @param num_threads The number of threads to use for computations; if greater
 //!   than 1, the function will be applied concurrently to `num_threads` batches
 //!   of `u`.
@@ -1642,9 +1652,11 @@ Vinecop::build_deriv_cache(const Eigen::MatrixXd& u,
 //! the caches below stay empty). Models with nonparametric pair copulas are
 //! rejected (differentiating w.r.t. the interpolation grid is meaningless).
 //!
-//! @param u An \f$ n \times 2d \f$ or \f$ n \times (d + k) \f$ matrix of
-//!   evaluation points, where \f$ k \f$ is the number of discrete variables
-//!   (see `select()`).
+//! @param u An \f$ n \times d \f$ matrix of evaluation points for a
+//!   continuous model. For a model with \f$ k \f$ discrete variables, use an
+//!   \f$ n \times 2d \f$ matrix containing the values and their left-limits;
+//!   left-limit columns for continuous variables may be omitted to obtain the
+//!   compact \f$ n \times (d + k) \f$ layout (see @ref discrete).
 //! @param step_wise if `false`, full gradient of the log-likelihood; if `true`,
 //!   score function of the step-wise MLE (gradients computed per pair-copula,
 //!   treating the pseudo-observations as fixed).
@@ -2111,9 +2123,11 @@ Vinecop::scores_full(Eigen::MatrixXd u,
 //! with respect to the parameters. This is a thin wrapper around
 //! `scores_full()`; see there for the computational details.
 //!
-//! @param u An \f$ n \times 2d \f$ or \f$ n \times (d + k) \f$ matrix of
-//!   evaluation points, where \f$ k \f$ is the number of discrete variables
-//!   (see `select()`).
+//! @param u An \f$ n \times d \f$ matrix of evaluation points for a
+//!   continuous model. For a model with \f$ k \f$ discrete variables, use an
+//!   \f$ n \times 2d \f$ matrix containing the values and their left-limits;
+//!   left-limit columns for continuous variables may be omitted to obtain the
+//!   compact \f$ n \times (d + k) \f$ layout (see @ref discrete).
 //! @param step_wise if `false`, full gradient of the log-likelihood; if `true`,
 //!   score function of the step-wise MLE (gradients computed per pair-copula,
 //!   treating the pseudo-observations as fixed).
@@ -2145,9 +2159,11 @@ Vinecop::scores(Eigen::MatrixXd u,
 //! Returns the observation-average of `scores()` as a vector of length
 //! `npars`, mirroring how `hessian()` averages `hessian_full()`.
 //!
-//! @param u An \f$ n \times 2d \f$ or \f$ n \times (d + k) \f$ matrix of
-//!   evaluation points, where \f$ k \f$ is the number of discrete variables
-//!   (see `select()`).
+//! @param u An \f$ n \times d \f$ matrix of evaluation points for a
+//!   continuous model. For a model with \f$ k \f$ discrete variables, use an
+//!   \f$ n \times 2d \f$ matrix containing the values and their left-limits;
+//!   left-limit columns for continuous variables may be omitted to obtain the
+//!   compact \f$ n \times (d + k) \f$ layout (see @ref discrete).
 //! @param step_wise if `false`, full gradient of the log-likelihood; if `true`,
 //!   score function of the step-wise MLE (gradients computed per pair-copula,
 //!   treating the pseudo-observations as fixed).
@@ -2192,9 +2208,11 @@ Vinecop::gradient(Eigen::MatrixXd u,
 //! Models with discrete variables use central finite differences of
 //! `scores()` instead; models with nonparametric pair copulas are rejected.
 //!
-//! @param u An \f$ n \times 2d \f$ or \f$ n \times (d + k) \f$ matrix of
-//!   evaluation points, where \f$ k \f$ is the number of discrete variables
-//!   (see `select()`).
+//! @param u An \f$ n \times d \f$ matrix of evaluation points for a
+//!   continuous model. For a model with \f$ k \f$ discrete variables, use an
+//!   \f$ n \times 2d \f$ matrix containing the values and their left-limits;
+//!   left-limit columns for continuous variables may be omitted to obtain the
+//!   compact \f$ n \times (d + k) \f$ layout (see @ref discrete).
 //! @param step_wise if `false`, full gradient of the log-likelihood; if `true`,
 //!   score function of the step-wise MLE (gradients computed per pair-copula).
 //! @param num_threads The number of threads to use for computations; if greater
@@ -2527,9 +2545,11 @@ Vinecop::hessian_full(Eigen::MatrixXd u,
 //! \f$ \mathrm{npars} \times \mathrm{npars} \f$ matrix (use `hessian_full()`
 //! for the per-observation decomposition).
 //!
-//! @param u An \f$ n \times 2d \f$ or \f$ n \times (d + k) \f$ matrix of
-//!   evaluation points, where \f$ k \f$ is the number of discrete variables
-//!   (see `select()`).
+//! @param u An \f$ n \times d \f$ matrix of evaluation points for a
+//!   continuous model. For a model with \f$ k \f$ discrete variables, use an
+//!   \f$ n \times 2d \f$ matrix containing the values and their left-limits;
+//!   left-limit columns for continuous variables may be omitted to obtain the
+//!   compact \f$ n \times (d + k) \f$ layout (see @ref discrete).
 //! @param step_wise if `false`, full gradient of the log-likelihood; if `true`,
 //!   score function of the step-wise MLE (gradients computed per pair-copula).
 //! @param num_threads The number of threads to use for computations; if greater
@@ -2603,9 +2623,11 @@ Vinecop::hessian(Eigen::MatrixXd u,
 //! matrix. Together with `hessian()` this forms the sandwich estimator of the
 //! asymptotic covariance.
 //!
-//! @param u An \f$ n \times 2d \f$ or \f$ n \times (d + k) \f$ matrix of
-//!   evaluation points, where \f$ k \f$ is the number of discrete variables
-//!   (see `select()`).
+//! @param u An \f$ n \times d \f$ matrix of evaluation points for a
+//!   continuous model. For a model with \f$ k \f$ discrete variables, use an
+//!   \f$ n \times 2d \f$ matrix containing the values and their left-limits;
+//!   left-limit columns for continuous variables may be omitted to obtain the
+//!   compact \f$ n \times (d + k) \f$ layout (see @ref discrete).
 //! @param step_wise if `false`, full gradient of the log-likelihood; if `true`,
 //!   score function of the step-wise MLE (gradients computed per pair-copula).
 //! @param num_threads The number of threads to use for computations; if greater
@@ -2653,9 +2675,11 @@ Vinecop::scores_cov(Eigen::MatrixXd u,
 //! limit and the cdf itself coincide. Respective columns can be omitted in the
 //! second block.
 //!
-//! @param u An \f$ n \times 2d \f$ or \f$ n \times (d + k) \f$ matrix of
-//!   evaluation points, where \f$ k \f$ is the number of discrete variables
-//!   (see `Vinecop::select()`).
+//! @param u An \f$ n \times d \f$ matrix of evaluation points for a
+//!   continuous model. For a model with \f$ k \f$ discrete variables, use an
+//!   \f$ n \times 2d \f$ matrix containing the values and their left-limits;
+//!   left-limit columns for continuous variables may be omitted to obtain the
+//!   compact \f$ n \times (d + k) \f$ layout (see @ref discrete).
 //! @param N Integer for the number of quasi-random numbers to draw
 //! to evaluate the distribution (default: 1e4).
 //! @param num_threads The number of threads to use for computations; if greater
@@ -2742,10 +2766,14 @@ Vinecop::simulate(const size_t n,
 //! conditioned variables are then drawn using the randomized transform of
 //! `rosenblatt()` (see its `randomize_discrete` note).
 //!
-//! @param u_cond An \f$ n \times (k + k_d) \f$ matrix of conditioning values,
-//!   where `k` is the number of conditioning variables and `k_d` the number of
-//!   discrete ones among them. Row `j` is the conditioning point for output
-//!   sample `j` (`n` is the number of rows of `u_cond`). The first `k` columns
+//! @param u_cond An \f$ n \times k \f$ matrix of conditioning values when all
+//!   conditioning variables are continuous. This overload infers `k` from the
+//!   column count and therefore uses the compact layout: if `k_d` conditioning
+//!   variables are discrete, append their left-limits to obtain an
+//!   \f$ n \times (k + k_d) \f$ matrix. Use the overload with an explicit
+//!   `conditioning_set` to supply the expanded \f$ n \times 2k \f$ layout.
+//!   Row `j` is the conditioning point for output sample `j` (`n` is the number
+//!   of rows of `u_cond`). The first `k` columns
 //!   hold the values \f$ F(x) \f$; column `i` corresponds to the
 //!   `(d - k + i)`-th variable of the vine order, i.e. the columns correspond,
 //!   left to right, to the last `k` entries of the order. The next `k_d`
@@ -2756,10 +2784,9 @@ Vinecop::simulate(const size_t n,
 //!   supplying only `k` columns when a conditioning variable is discrete may be
 //!   silently reinterpreted as a different `k`. To draw many samples at a
 //!   single conditioning point, pass that point repeated over `n` rows.
-//!   The overload taking `conditioning_set` also accepts the expanded
-//!   \f$ n \times 2k \f$ layout, with one left-limit column per conditioning
-//!   variable. Use that overload whenever the expanded layout is ambiguous
-//!   with a compact layout for a different number of conditioning variables.
+//!   The overload taking `conditioning_set` accepts both layouts; use it for
+//!   the expanded layout because that shape can be ambiguous with a compact
+//!   layout for a different number of conditioning variables.
 //! @param qrng Set to true for quasi-random numbers (over the conditioned
 //!   variables).
 //! @param num_threads The number of threads to use for computations.
@@ -2794,9 +2821,9 @@ Vinecop::simulate_conditional(const Eigen::MatrixXd& u_cond,
   }
   if (k == 0) {
     throw std::runtime_error(
-      "u_cond has an invalid number of columns; expected k + (number of "
-      "discrete conditioning variables) columns for some number of "
-      "conditioning variables k in 1, ..., d - 1.");
+      "u_cond has an invalid number of columns; expected k columns for "
+      "all-continuous conditioning, or k + k_d columns when k_d conditioning "
+      "variables are discrete, for some k in 1, ..., d - 1.");
   }
 
   std::vector<size_t> conditioning_set(k);
@@ -2808,11 +2835,13 @@ Vinecop::simulate_conditional(const Eigen::MatrixXd& u_cond,
 
 //! @brief Simulates conditionally on a specified set of variables.
 //!
-//! @param u_cond An \f$ n \times (k + k_d) \f$ compact or \f$ n \times 2k
-//!   \f$ expanded matrix of conditioning values, with one conditioning point
-//!   per row. The first `k` columns follow `conditioning_set`; left-limits
-//!   follow in the same order for the expanded layout and only for discrete
-//!   variables in the compact layout.
+//! @param u_cond An \f$ n \times k \f$ matrix of conditioning values when all
+//!   conditioning variables are continuous, with one conditioning point per
+//!   row. If any are discrete, use an \f$ n \times 2k \f$ matrix containing
+//!   the values followed by all left-limits. Left-limit columns for continuous
+//!   variables may be omitted to obtain the compact
+//!   \f$ n \times (k + k_d) \f$ layout, where `k_d` is the number of discrete
+//!   conditioning variables. The first `k` columns follow `conditioning_set`.
 //! @param conditioning_set The 1-based conditioning-variable indices. The
 //!   first `k` columns of `u_cond` correspond to these variables in the given
 //!   order. In the expanded layout, the next `k` columns contain their
@@ -2857,9 +2886,18 @@ Vinecop::simulate_conditional_impl(const Eigen::MatrixXd& u_cond,
   const size_t n_cols = static_cast<size_t>(u_cond.cols());
   const bool expanded = n_cols == 2 * k;
   if (!expanded && (n_cols != k + kd)) {
-    throw std::runtime_error(
-      "u_cond must have 2 * k columns or one column per conditioning variable "
-      "plus one left-limit column per discrete conditioning variable.");
+    std::stringstream msg;
+    msg << "u_cond has wrong number of columns; expected: ";
+    if (kd == 0) {
+      msg << k << " (n x k continuous layout)";
+    } else if (k + kd == 2 * k) {
+      msg << 2 * k << " (n x 2k expanded or n x (k + k_d) compact layout)";
+    } else {
+      msg << 2 * k << " (n x 2k expanded layout) or " << k + kd
+          << " (n x (k + k_d) compact layout)";
+    }
+    msg << ", actual: " << n_cols << ".";
+    throw std::runtime_error(msg.str());
   }
   if (!tools_eigen::check_if_in_unit_cube(u_cond)) {
     throw std::runtime_error("all elements of u_cond must be in (0, 1).");
@@ -2901,9 +2939,11 @@ Vinecop::simulate_conditional_impl(const Eigen::MatrixXd& u_cond,
 //! \f[ \mathrm{loglik} = \sum_{i = 1}^n \log c(U_{1, i}, ..., U_{d, i}), \f]
 //! where \f$ c \f$ is the copula density, see `Vinecop::pdf()`.
 //!
-//! @param u An \f$ n \times 2d \f$ or \f$ n \times (d + k) \f$ matrix of
-//!   evaluation points, where \f$ k \f$ is the number of discrete variables
-//!   (see `select()` or `Vinecop::pdf()`).
+//! @param u An \f$ n \times d \f$ matrix of evaluation points for a
+//!   continuous model. For a model with \f$ k \f$ discrete variables, use an
+//!   \f$ n \times 2d \f$ matrix containing the values and their left-limits;
+//!   left-limit columns for continuous variables may be omitted to obtain the
+//!   compact \f$ n \times (d + k) \f$ layout (see @ref discrete).
 //! @param num_threads The number of threads to use for computations; if greater
 //!   than 1, the function will be applied concurrently to `num_threads` batches
 //!   of `u`.
@@ -2941,9 +2981,11 @@ Vinecop::loglik(const Eigen::MatrixXd& u,
 //! The AIC is a consistent model selection criterion even
 //! for nonparametric models.
 //!
-//! @param u An \f$ n \times 2d \f$ or \f$ n \times (d + k) \f$ matrix of
-//!   evaluation points, where \f$ k \f$ is the number of discrete variables
-//!   (see `select()` or `Vinecop::pdf()`).
+//! @param u An \f$ n \times d \f$ matrix of evaluation points for a
+//!   continuous model. For a model with \f$ k \f$ discrete variables, use an
+//!   \f$ n \times 2d \f$ matrix containing the values and their left-limits;
+//!   left-limit columns for continuous variables may be omitted to obtain the
+//!   compact \f$ n \times (d + k) \f$ layout (see @ref discrete).
 //! @param num_threads The number of threads to use for computations; if greater
 //!   than 1, the function will be applied concurrently to `num_threads` batches
 //!   of `u`.
@@ -2963,9 +3005,11 @@ Vinecop::aic(const Eigen::MatrixXd& u, const size_t num_threads) const
 //! The BIC is a consistent model selection criterion
 //! for nonparametric models.
 //!
-//! @param u An \f$ n \times 2d \f$ or \f$ n \times (d + k) \f$ matrix of
-//!   evaluation points, where \f$ k \f$ is the number of discrete variables
-//!   (see `Vinecop::select()` or `Vinecop::pdf()`).
+//! @param u An \f$ n \times d \f$ matrix of evaluation points for a
+//!   continuous model. For a model with \f$ k \f$ discrete variables, use an
+//!   \f$ n \times 2d \f$ matrix containing the values and their left-limits;
+//!   left-limit columns for continuous variables may be omitted to obtain the
+//!   compact \f$ n \times (d + k) \f$ layout (see @ref discrete).
 //! @param num_threads The number of threads to use for computations; if greater
 //!   than 1, the function will be applied concurrently to `num_threads` batches
 //!   of `u`.
@@ -2991,9 +3035,11 @@ Vinecop::bic(const Eigen::MatrixXd& u, const size_t num_threads) const
 //! selection criterion for parametric sparse vine copula models when
 //! \f$ d = o(\sqrt{n \log n})\f$.
 //!
-//! @param u An \f$ n \times 2d \f$ or \f$ n \times (d + k) \f$ matrix of
-//!   evaluation points, where \f$ k \f$ is the number of discrete variables
-//!   (see `Vinecop::select()` or `Vinecop::pdf()`).
+//! @param u An \f$ n \times d \f$ matrix of evaluation points for a
+//!   continuous model. For a model with \f$ k \f$ discrete variables, use an
+//!   \f$ n \times 2d \f$ matrix containing the values and their left-limits;
+//!   left-limit columns for continuous variables may be omitted to obtain the
+//!   compact \f$ n \times (d + k) \f$ layout (see @ref discrete).
 //! @param psi0 Baseline prior probability of a non-independence copula.
 //! @param num_threads The number of threads to use for computations; if greater
 //!   than 1, the function will be applied concurrently to `num_threads` batches
@@ -3062,8 +3108,11 @@ Vinecop::get_npars() const
 //! \f[ F(V_{M[d - j, j]} | V_{M[d - j - 1, j - 1]}, \dots, V_{M[0, 0]}), \f]
 //! set `randomize_discrete = FALSE`.
 //!
-//! @param u An \f$ n \times 2d \f$ or \f$ n \times (d + k) \f$ matrix of
-//!   evaluation points, where \f$ k \f$ is the number of discrete variables.
+//! @param u An \f$ n \times d \f$ matrix of evaluation points for a
+//!   continuous model. For a model with \f$ k \f$ discrete variables, use an
+//!   \f$ n \times 2d \f$ matrix containing the values and their left-limits;
+//!   left-limit columns for continuous variables may be omitted to obtain the
+//!   compact \f$ n \times (d + k) \f$ layout (see @ref discrete).
 //! @param num_threads The number of threads to use for computations; if greater
 //!   than 1, the function will be applied concurrently to `num_threads` batches
 //!   of `u`.
@@ -3092,8 +3141,11 @@ Vinecop::rosenblatt(Eigen::MatrixXd u,
 //! @details The vine is evaluated in an admissible sampling order whose tail
 //! contains exactly `conditioning_set`. The model itself is not modified.
 //!
-//! @param u An \f$ n \times 2d \f$ or \f$ n \times (d + k) \f$ matrix of
-//!   evaluation points, where \f$ k \f$ is the number of discrete variables.
+//! @param u An \f$ n \times d \f$ matrix of evaluation points for a
+//!   continuous model. For a model with \f$ k \f$ discrete variables, use an
+//!   \f$ n \times 2d \f$ matrix containing the values and their left-limits;
+//!   left-limit columns for continuous variables may be omitted to obtain the
+//!   compact \f$ n \times (d + k) \f$ layout (see @ref discrete).
 //! @param conditioning_set The 1-based indices of the conditioning variables.
 //! @param num_threads The number of threads to use for computations.
 //! @param randomize_discrete Whether to randomize the transform for discrete
@@ -3264,10 +3316,11 @@ Vinecop::rosenblatt_impl(Eigen::MatrixXd u,
 //! `Vinecop::inverse_rosenblatt()` computes \f[ V_{M[d - j, j]}= F^{-1}(U_{M[d
 //! - j, j]} | U_{M[d - j - 1, j - 1]}, \dots, U_{M[0, 0]}). \f]
 //!
-//! @param u An \f$ n \times 2d \f$, \f$ n \times (d + k) \f$, or
-//!   \f$ n \times d \f$ matrix of independent uniform variates, where \f$ k \f$
-//!   is the number of discrete variables. Only the first \f$ d \f$ columns are
-//!   used.
+//! @param u An \f$ n \times d \f$ matrix of independent uniform variates.
+//!   Only these first \f$ d \f$ columns are used; the \f$ n \times 2d \f$
+//!   expanded and \f$ n \times (d + k) \f$ compact discrete-data layouts are
+//!   also accepted for convenience, where \f$ k \f$ is the number of discrete
+//!   variables.
 //! @param num_threads The number of threads to use for computations; if greater
 //!   than 1, the function will be applied concurrently to `num_threads` batches
 //!   of `u`.
@@ -3284,10 +3337,11 @@ Vinecop::inverse_rosenblatt(const Eigen::MatrixXd& u,
 //! @details The vine is evaluated in an admissible sampling order whose tail
 //! contains exactly `conditioning_set`. The model itself is not modified.
 //!
-//! @param u An \f$ n \times 2d \f$, \f$ n \times (d + k) \f$, or
-//!   \f$ n \times d \f$ matrix of independent uniform variates, where \f$ k \f$
-//!   is the number of discrete variables. Only the first \f$ d \f$ columns are
-//!   used.
+//! @param u An \f$ n \times d \f$ matrix of independent uniform variates.
+//!   Only these first \f$ d \f$ columns are used; the \f$ n \times 2d \f$
+//!   expanded and \f$ n \times (d + k) \f$ compact discrete-data layouts are
+//!   also accepted for convenience, where \f$ k \f$ is the number of discrete
+//!   variables.
 //! @param conditioning_set The 1-based indices of the conditioning variables.
 //! @param num_threads The number of threads to use for computations.
 //! @return An \f$ n \times d \f$ matrix of transformed values.
@@ -3309,10 +3363,10 @@ Vinecop::inverse_rosenblatt_impl(const Eigen::MatrixXd& u,
   const size_t n_cols = static_cast<size_t>(u.cols());
   const size_t compact_cols = d_ + get_n_discrete();
   if ((n_cols != d_) && (n_cols != compact_cols) && (n_cols != 2 * d_)) {
-    throw std::runtime_error(
-      "data has wrong number of columns; expected: " + std::to_string(2 * d_) +
-      ", " + std::to_string(compact_cols) + ", or " + std::to_string(d_) +
-      ", actual: " + std::to_string(n_cols) + ".");
+    std::stringstream msg;
+    msg << "data has wrong number of columns; expected: " << d_
+        << " (n x d input), actual: " << n_cols << ".";
+    throw std::runtime_error(msg.str());
   }
   if (u.rows() < 1) {
     throw std::runtime_error("data must have at least one row");
@@ -3411,15 +3465,22 @@ Vinecop::check_data_dim(const Eigen::MatrixXd& data) const
   size_t d_exp = d_ + n_disc;
   if ((d_data != d_exp) & (d_data != 2 * d_)) {
     std::stringstream msg;
-    msg << "data has wrong number of columns; "
-        << "expected: " << 2 * d_ << " or " << d_exp << ", actual: " << d_data
-        << " (model contains ";
+    msg << "data has wrong number of columns; expected: ";
     if (n_disc == 0) {
-      msg << "no discrete variables)." << std::endl;
-    } else if (n_disc == 1) {
-      msg << "1 discrete variable)." << std::endl;
+      msg << d_ << " (n x d continuous layout)";
+    } else if (d_exp == 2 * d_) {
+      msg << d_exp << " (n x 2d expanded or n x (d + k) compact layout)";
     } else {
-      msg << get_n_discrete() << " discrete variables)." << std::endl;
+      msg << 2 * d_ << " (n x 2d expanded layout) or " << d_exp
+          << " (n x (d + k) compact layout)";
+    }
+    msg << ", actual: " << d_data << " (model contains ";
+    if (n_disc == 0) {
+      msg << "no discrete variables).";
+    } else if (n_disc == 1) {
+      msg << "1 discrete variable).";
+    } else {
+      msg << n_disc << " discrete variables).";
     }
     throw std::runtime_error(msg.str());
   }

--- a/test/src_test/test_bicop_sanity_checks.cpp
+++ b/test/src_test/test_bicop_sanity_checks.cpp
@@ -90,9 +90,39 @@ TEST(bicop_sanity_checks, catches_data_dim)
 {
   Bicop bicop;
   auto u = tools_stats::simulate_uniform(10, 3, false, { 1 });
-  EXPECT_ANY_THROW(bicop.select(u));
+  try {
+    bicop.select(u);
+    FAIL() << "expected invalid column count to throw";
+  } catch (const std::runtime_error& error) {
+    EXPECT_EQ(error.what(),
+              std::string("data has wrong number of columns; expected: 2 "
+                          "(n x 2 continuous layout), actual: 3 (model "
+                          "contains no discrete variables)."));
+  }
+
+  bicop.set_var_types({ "d", "c" });
+  auto u_continuous_shape = tools_stats::simulate_uniform(10, 2, false, { 2 });
+  try {
+    bicop.select(u_continuous_shape);
+    FAIL() << "expected missing discrete left-limit column to throw";
+  } catch (const std::runtime_error& error) {
+    EXPECT_EQ(error.what(),
+              std::string("data has wrong number of columns; expected: 4 "
+                          "(n x 4 expanded layout) or 3 (n x (2 + k) compact "
+                          "layout), actual: 2 (model contains 1 discrete "
+                          "variable)."));
+  }
+
   bicop.set_var_types({ "d", "d" });
-  EXPECT_ANY_THROW(bicop.select(u));
+  try {
+    bicop.select(u);
+    FAIL() << "expected invalid discrete column count to throw";
+  } catch (const std::runtime_error& error) {
+    EXPECT_EQ(error.what(),
+              std::string("data has wrong number of columns; expected: 4 "
+                          "(n x 4 expanded or n x (2 + k) compact layout), "
+                          "actual: 3 (model contains 2 discrete variables)."));
+  }
 }
 
 TEST(bicop_sanity_checks, catches_not_fitted_to_data)

--- a/test/src_test/test_vinecop_class.cpp
+++ b/test/src_test/test_vinecop_class.cpp
@@ -858,12 +858,48 @@ TEST(VinecopConditionalSimulation, custom_set_validates_inputs)
     u_cond, std::vector<size_t>{ 1, 1 }, false, 1, { 1 }));
   EXPECT_ANY_THROW(model.simulate_conditional(
     u_cond, std::vector<size_t>{ 1, 3 }, false, 1, { 1 }));
-  EXPECT_ANY_THROW(
+  try {
     model.simulate_conditional(Eigen::MatrixXd::Constant(3, 1, 0.5),
                                std::vector<size_t>{ 1, 2 },
                                false,
                                1,
-                               { 1 }));
+                               { 1 });
+    FAIL() << "expected invalid conditional column count to throw";
+  } catch (const std::runtime_error& error) {
+    EXPECT_EQ(error.what(),
+              std::string("u_cond has wrong number of columns; expected: 2 "
+                          "(n x k continuous layout), actual: 1."));
+  }
+
+  model.set_var_types({ "d", "c", "c", "c" });
+  try {
+    model.simulate_conditional(Eigen::MatrixXd::Constant(3, 2, 0.5),
+                               std::vector<size_t>{ 1, 2 },
+                               false,
+                               1,
+                               { 1 });
+    FAIL() << "expected invalid discrete conditional column count to throw";
+  } catch (const std::runtime_error& error) {
+    EXPECT_EQ(error.what(),
+              std::string("u_cond has wrong number of columns; expected: 4 "
+                          "(n x 2k expanded layout) or 3 (n x (k + k_d) "
+                          "compact layout), actual: 2."));
+  }
+
+  model.set_var_types({ "d", "d", "c", "c" });
+  try {
+    model.simulate_conditional(Eigen::MatrixXd::Constant(3, 3, 0.5),
+                               std::vector<size_t>{ 1, 2 },
+                               false,
+                               1,
+                               { 1 });
+    FAIL() << "expected missing discrete conditional column to throw";
+  } catch (const std::runtime_error& error) {
+    EXPECT_EQ(error.what(),
+              std::string("u_cond has wrong number of columns; expected: 4 "
+                          "(n x 2k expanded or n x (k + k_d) compact layout), "
+                          "actual: 3."));
+  }
 }
 
 TEST_F(VinecopTest, simulate_conditional_throws)

--- a/test/src_test/test_vinecop_sanity_checks.cpp
+++ b/test/src_test/test_vinecop_sanity_checks.cpp
@@ -31,10 +31,49 @@ TEST(vinecop_sanity_checks, catches_wrong_size)
   Vinecop vinecop(mat, pair_copulas);
 
   Eigen::MatrixXd U = Eigen::MatrixXd::Constant(4, 4, 0.5);
-  EXPECT_ANY_THROW(vinecop.pdf(U));
+  try {
+    vinecop.pdf(U);
+    FAIL() << "expected invalid column count to throw";
+  } catch (const std::runtime_error& error) {
+    EXPECT_EQ(error.what(),
+              std::string("data has wrong number of columns; expected: 3 "
+                          "(n x d continuous layout), actual: 4 (model "
+                          "contains no discrete variables)."));
+  }
   EXPECT_ANY_THROW(vinecop.cdf(U));
-  EXPECT_ANY_THROW(vinecop.inverse_rosenblatt(U));
+  try {
+    vinecop.inverse_rosenblatt(U);
+    FAIL() << "expected invalid inverse Rosenblatt column count to throw";
+  } catch (const std::runtime_error& error) {
+    EXPECT_EQ(error.what(),
+              std::string("data has wrong number of columns; expected: 3 "
+                          "(n x d input), actual: 4."));
+  }
   EXPECT_ANY_THROW(vinecop.select(U));
+
+  vinecop.set_var_types({ "d", "c", "c" });
+  auto U_discrete = Eigen::MatrixXd::Constant(4, 3, 0.5);
+  try {
+    vinecop.pdf(U_discrete);
+    FAIL() << "expected invalid discrete column count to throw";
+  } catch (const std::runtime_error& error) {
+    EXPECT_EQ(error.what(),
+              std::string("data has wrong number of columns; expected: 6 "
+                          "(n x 2d expanded layout) or 4 (n x (d + k) "
+                          "compact layout), actual: 3 (model contains 1 "
+                          "discrete variable)."));
+  }
+
+  vinecop.set_var_types({ "d", "d", "d" });
+  try {
+    vinecop.pdf(U_discrete);
+    FAIL() << "expected missing discrete left-limit columns to throw";
+  } catch (const std::runtime_error& error) {
+    EXPECT_EQ(error.what(),
+              std::string("data has wrong number of columns; expected: 6 "
+                          "(n x 2d expanded or n x (d + k) compact layout), "
+                          "actual: 3 (model contains 3 discrete variables)."));
+  }
 
   vinecop = Vinecop(301);
   U = tools_stats::simulate_uniform(1, 301, false, { 1 });


### PR DESCRIPTION
## What this changes

- documents `n x 2` for `Bicop` and `n x d` for `Vinecop` as the ordinary all-continuous inputs across the public Doxygen API
- presents `n x 4` / `n x 2d` as the primary discrete-data layout, with the compact `n x (2 + k)` / `n x (d + k)` layout also accepted
- applies the same ordering to conditional-simulation documentation and examples
- aligns wrong-column-count errors with the model type: continuous shapes first for continuous models, expanded then compact shapes for discrete models
- adds exact-message tests for continuous, mixed-discrete, and all-discrete validation paths

## API and behavior

This does not change accepted input layouts or numerical behavior. It clarifies the user-facing contract:

- all-continuous models normally take `n x 2` or `n x d`
- discrete models normally take the expanded `n x 4` or `n x 2d` layout
- compact discrete layouts remain supported
- inverse Rosenblatt input remains `n x d`; extra discrete-data columns are accepted but ignored

This builds on the unified data-layout API introduced by #729, which has now been squash-merged into `main`.

## Tests

- full `test_bicop_sanity_checks_only`: 15 passed
- full `test_vinecop_sanity_checks_only`: 6 passed
- full `test_vinecop_class_only`: 64 passed
- all documentation snippets compiled and ran
- Doxygen target passed
- `git diff --check` passed

No separate NEWS entry is needed because this clarifies the feature already covered by #729.
