### PR TITLE
docs(bicop): stop the friend guard from swallowing the next declaration's docs

### DIFF
--- a/include/vinecopulib/bicop/class.hpp
+++ b/include/vinecopulib/bicop/class.hpp
@@ -45,9 +45,7 @@ using BicopPtr = std::shared_ptr<AbstractBicop>;
 //!
 class Bicop
 {
-  //! @cond INTERNAL
   friend class BicopView;
-  //! @endcond
 
 public:
   // Constructors


### PR DESCRIPTION
Found while porting `pyvinecopulib` to the 1.0.0 pin. **I will not merge.**

## The defect

```cpp
class Bicop
{
  //! @cond INTERNAL
  friend class BicopView;
  //! @endcond

public:
  // Constructors
  Bicop(const BicopFamily family = BicopFamily::indep, ...);
```

libclang associates `//! @cond INTERNAL` / `//! @endcond` as the doc comment of
the **next** declaration — the family constructor. Downstream,
`scripts/generate_docstring.py` strips `@cond`/`@endcond` pairs, so that comment
becomes the empty string, and the extractor drops overloads without
documentation (an intentional rule, so deprecated stubs don't pollute the
overload-naming set).

The result: `Bicop`'s family constructor gets **no** entry in the generated
header. `pyvinecopulib`'s `Bicop.from_family` and `Bicop.__init__` lose their
documentation, and the binding stops compiling —
`bicop_doc.ctor.doc_4args_family_rotation_parameters_var_types` no longer exists.

## Verified

Building `pyvinecopulib` against this branch:

```
$ grep -c "Instantiates a specific bivariate copula model" src/include/docstr.hpp
1          # 0 before this change
$ uv pip install -e . --no-build-isolation
EXIT=0     # fails to compile before this change
```

## Why removal is the right fix

The guard was redundant. The friend declaration sits in the class's private
section and `EXTRACT_PRIVATE = NO` in `docs/Doxyfile.in`, so Doxygen never
documented it. `BicopView` itself keeps its own `@cond INTERNAL` at class scope
(`class.hpp:429`), which is what actually keeps it out of the website.

`include/` has only one other `@cond INTERNAL` pair (`class.ipp:406`, also on
`BicopView`); it precedes a definition that carries its own `//!` block, so it is
unaffected.

## Note for the downstream policy

This class of defect is invisible upstream — the Doxygen site looks identical
either way — and only shows up as a missing Python docstring or a downstream
compile error. Worth remembering when `@cond` is used inside a class body:
anything it wraps steals the documentation of whatever follows it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)