### PR TITLE
fix(vinecop): report select_threshold on the "Select threshold" line

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -146,6 +146,12 @@ wrong thing.
 
 ### BUG FIXES
 
+* Report `select_threshold` rather than `select_trunc_lvl` on the
+  "Select threshold" line of `FitControlsVinecop::str()` (#735)
+
+* Remove the declaration of `tools_stats::dependence_matrix`, which had no
+  definition anywhere in the library, so any call to it failed to link (#735)
+
 * Treat omitted pair-copulas as implicit independence during evaluation of a
   `Vinecop` constructed from a full structure, preventing conditional
   simulation from accessing an empty pair-copula store (#729)

--- a/include/vinecopulib/misc/tools_stats.hpp
+++ b/include/vinecopulib/misc/tools_stats.hpp
@@ -172,9 +172,6 @@ pairwise_mcor(const Eigen::MatrixXd& x,
               const Eigen::VectorXd& weights = Eigen::VectorXd());
 
 Eigen::MatrixXd
-dependence_matrix(const Eigen::MatrixXd& x, const std::string& measure);
-
-Eigen::MatrixXd
 ghalton(const size_t& n,
         const size_t& d,
         const std::vector<int>& seeds = std::vector<int>());

--- a/include/vinecopulib/vinecop/implementation/fit_controls.ipp
+++ b/include/vinecopulib/vinecop/implementation/fit_controls.ipp
@@ -504,7 +504,7 @@ FitControlsVinecop::str() const
                                                                   : "no")
                << std::endl;
   controls_str << "Select threshold: "
-               << static_cast<std::string>(get_select_trunc_lvl() ? "yes"
+               << static_cast<std::string>(get_select_threshold() ? "yes"
                                                                   : "no")
                << std::endl;
   controls_str << "Select families: "

--- a/test/src_test/test_vinecop_sanity_checks.cpp
+++ b/test/src_test/test_vinecop_sanity_checks.cpp
@@ -93,6 +93,26 @@ TEST(vinecop_sanity_checks, controls_print)
 {
   auto controls = FitControlsVinecop();
   EXPECT_NO_THROW(controls.str());
+
+  // Each flag has to report itself. The two "Select ..." lines are adjacent
+  // and otherwise identical, so one reading the other's getter still prints
+  // something plausible.
+  auto reports = [](const FitControlsVinecop& c, const std::string& label) {
+    const auto str = c.str();
+    const auto at = str.find(label + ": ");
+    EXPECT_NE(at, std::string::npos) << label << " missing from str()";
+    return str.substr(at + label.size() + 2, 3) == "yes";
+  };
+
+  controls.set_select_trunc_lvl(true);
+  controls.set_select_threshold(false);
+  EXPECT_TRUE(reports(controls, "Select truncation level"));
+  EXPECT_FALSE(reports(controls, "Select threshold"));
+
+  controls.set_select_trunc_lvl(false);
+  controls.set_select_threshold(true);
+  EXPECT_FALSE(reports(controls, "Select truncation level"));
+  EXPECT_TRUE(reports(controls, "Select threshold"));
 }
 
 TEST(vinecop_sanity_checks, fit_controls_config_works)


### PR DESCRIPTION
## What

`FitControlsVinecop::str()` printed `get_select_trunc_lvl()` under **both** the
"Select truncation level" and the "Select threshold" label:

```cpp
controls_str << "Select threshold: "
             << static_cast<std::string>(get_select_trunc_lvl() ? "yes" : "no")
```

The two lines are adjacent and otherwise identical, so the wrong getter still
prints a plausible yes/no and nothing looks amiss. But whenever the two flags
differ, anyone printing their controls to check a sparse-selection setup is
told the opposite of what they configured:

```cpp
FitControlsVinecop c;
c.set_select_threshold(true);   // c.str() reports "Select threshold: no"
```

## Also in this PR

The declaration of `tools_stats::dependence_matrix` is removed. It appears
exactly once in the whole library — a declaration in `misc/tools_stats.hpp`
with no definition and no caller — so it is not part of the API in any usable
sense: naming it from a translation unit produces an undefined symbol at link
time. Found while trying to bind it for Python, where it linked a wheel that
failed to import.

## Test

`vinecop_sanity_checks.controls_print` previously only asserted that `str()`
does not throw, which a copy-paste like this passes. It now sets the two flags
against each other and reads both lines back, so each has to report itself.
It fails on `main` and passes here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)