### PR TITLE
fix(bicop): compute a real discrete density for kernel pair copulas

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -64,6 +64,12 @@ wrong thing.
 
 ### BEHAVIOR CHANGES
 
+* Every discrete or mixed fit with a nonparametric (`tll`) pair copula changes:
+  the fitted grid, density, `loglik`, `aic`, `bic` and `mbicv` all move, so
+  family and structure selection can differ. `tll` is the default family, so
+  this is the default path for discrete data. Continuous fits are unaffected;
+  see BUG FIXES (#739)
+
 * TLL fits change near the boundary of the unit square: the endpoint clamping of
   the interpolation grid was removed, so every `tll` fit differs slightly from
   0.7.3 (#654)
@@ -145,6 +151,19 @@ wrong thing.
 * Exit structure selection early when the graph is already a tree (#661)
 
 ### BUG FIXES
+
+* Compute a real discrete density for kernel pair copulas. `KernelBicop`
+  overrode `pdf`, `hfunc1` and `hfunc2` to return the continuous quantity at the
+  atom midpoint, so the difference quotients in `AbstractBicop::pdf_c_d` /
+  `pdf_d_d` were unreachable. The midpoint rule violates
+  `sum_atoms c * (u1 - u1^-) = 1` by up to 10% without converging, reached 40%
+  per cell, and shifted a three-dimensional discrete vine's `loglik` by 6.5
+  (#739)
+
+* Use the latent sample when fitting a `tll` pair copula to discrete data.
+  `TllBicop::fit` assigned `find_latent_sample`'s result to `psobs` but fitted on
+  `z_data`, which was already built from the jittered ranks, so declaring a
+  variable discrete had no effect on the fitted grid at all (#736, #739)
 
 * Report `select_threshold` rather than `select_trunc_lvl` on the
   "Select threshold" line of `FitControlsVinecop::str()` (#735)

--- a/include/vinecopulib/bicop/abstract.hpp
+++ b/include/vinecopulib/bicop/abstract.hpp
@@ -100,7 +100,8 @@ protected:
 
   virtual void flip() = 0;
 
-  // following are virtual so they can be overriden by KernelBicop
+  // state-based dispatchers: they read var_types_ and route discrete
+  // arguments through the difference quotients below
   virtual Eigen::VectorXd pdf(const Eigen::MatrixXd& u);
 
   virtual Eigen::VectorXd hfunc1(const Eigen::MatrixXd& u);

--- a/include/vinecopulib/bicop/implementation/kernel.ipp
+++ b/include/vinecopulib/bicop/implementation/kernel.ipp
@@ -31,17 +31,6 @@ KernelBicop::pdf_raw(const Eigen::MatrixXd& u, const Eigen::MatrixXd&)
 }
 
 inline Eigen::VectorXd
-KernelBicop::pdf(const Eigen::MatrixXd& u)
-{
-  if (u.cols() == 4) {
-    // evaluate jittered density at mid rank for stability
-    return pdf_raw((u.leftCols(2) + u.rightCols(2)).array() / 2.0,
-                   Eigen::MatrixXd());
-  }
-  return pdf_raw(u, Eigen::MatrixXd());
-}
-
-inline Eigen::VectorXd
 KernelBicop::cdf(const Eigen::MatrixXd& u, const Eigen::MatrixXd&)
 {
   return interp_grid_->integrate_2d(u);
@@ -57,28 +46,6 @@ inline Eigen::VectorXd
 KernelBicop::hfunc2_raw(const Eigen::MatrixXd& u, const Eigen::MatrixXd&)
 {
   return interp_grid_->integrate_1d(u, 2);
-}
-
-inline Eigen::VectorXd
-KernelBicop::hfunc1(const Eigen::MatrixXd& u)
-{
-  if (u.cols() == 4) {
-    auto u_avg = u;
-    u_avg.col(0) = (u.col(0) + u.col(2)).array() / 2.0;
-    return hfunc1_raw(u_avg.leftCols(2), Eigen::MatrixXd());
-  }
-  return hfunc1_raw(u, Eigen::MatrixXd());
-}
-
-inline Eigen::VectorXd
-KernelBicop::hfunc2(const Eigen::MatrixXd& u)
-{
-  if (u.cols() == 4) {
-    auto u_avg = u;
-    u_avg.col(1) = (u.col(1) + u.col(3)).array() / 2.0;
-    return hfunc2_raw(u_avg.leftCols(2), Eigen::MatrixXd());
-  }
-  return hfunc2_raw(u, Eigen::MatrixXd());
 }
 
 inline Eigen::VectorXd

--- a/include/vinecopulib/bicop/implementation/tll.ipp
+++ b/include/vinecopulib/bicop/implementation/tll.ipp
@@ -254,6 +254,7 @@ TllBicop::fit(const Eigen::MatrixXd& data,
   if (var_types_[0] == "d" || var_types_[1] == "d") {
     psobs =
       tools_stats::find_latent_sample(data, std::pow(B(0, 0) * B(1, 1), 0.25));
+    z_data = tools_stats::qnorm(psobs);
   }
 
   // compute the density estimator (first column estimate, second influence)

--- a/include/vinecopulib/bicop/kernel.hpp
+++ b/include/vinecopulib/bicop/kernel.hpp
@@ -52,13 +52,6 @@ protected:
   Eigen::VectorXd hinv2_raw(const Eigen::MatrixXd& u,
                             const Eigen::MatrixXd& parameters) override;
 
-  // state-based dispatchers (overridden for grid-specific jitter handling)
-  Eigen::VectorXd pdf(const Eigen::MatrixXd& u) override;
-
-  Eigen::VectorXd hfunc1(const Eigen::MatrixXd& u) override;
-
-  Eigen::VectorXd hfunc2(const Eigen::MatrixXd& u) override;
-
   double get_npars() const override;
 
   void set_npars(const double& npars) override;

--- a/test/src_test/test_discrete.cpp
+++ b/test/src_test/test_discrete.cpp
@@ -107,7 +107,9 @@ TEST(zero_inflated, bicop)
     EXPECT_EQ(bc.cdf(uu.topRows(20)),
               bc.as_continuous().cdf(uu.leftCols(2).topRows(20)));
     // tll
-    bc.select(uu.topRows(20), FitControlsBicop({ BicopFamily::tll }));
+    // The whole sample, not topRows(20): now that the latent sample
+    // reaches the fit, 20 observations no longer identify the density.
+    bc.select(uu, FitControlsBicop({ BicopFamily::tll }));
     EXPECT_NEAR(bc.parameters_to_tau(bc.get_parameters()), tau, 0.15);
 
     // c_d
@@ -124,7 +126,9 @@ TEST(zero_inflated, bicop)
     EXPECT_EQ(bc.cdf(uu.topRows(20)),
               bc.as_continuous().cdf(uu.leftCols(2).topRows(20)));
     // tll
-    bc.select(uu.topRows(20), FitControlsBicop({ BicopFamily::tll }));
+    // The whole sample, not topRows(20): now that the latent sample
+    // reaches the fit, 20 observations no longer identify the density.
+    bc.select(uu, FitControlsBicop({ BicopFamily::tll }));
     EXPECT_NEAR(bc.parameters_to_tau(bc.get_parameters()), tau, 0.15);
 
     // d_d
@@ -139,7 +143,9 @@ TEST(zero_inflated, bicop)
     bc.select(uu.topRows(20)); // all families
 
     // tll
-    bc.select(uu.topRows(20), FitControlsBicop({ BicopFamily::tll }));
+    // The whole sample, not topRows(20): now that the latent sample
+    // reaches the fit, 20 observations no longer identify the density.
+    bc.select(uu, FitControlsBicop({ BicopFamily::tll }));
     EXPECT_NEAR(bc.parameters_to_tau(bc.get_parameters()), tau, 0.15);
   }
 }
@@ -399,6 +405,77 @@ TEST(discrete, edge_case_parameter_shapes)
   EXPECT_TRUE(pdf_tll.allFinite());
   EXPECT_NO_THROW(tll.hfunc1(u_disc));
   EXPECT_NO_THROW(tll.hfunc2(u_disc));
+}
+
+// A discrete/continuous density must satisfy, for every u2,
+//
+//     sum_atoms c(u1, u2) * (u1 - u1^-)  =  h2(1, u2) - h2(0, u2)  =  1,
+//
+// because the difference quotients telescope over the atoms. KernelBicop used
+// to override pdf / hfunc1 / hfunc2 and return the *continuous* density at the
+// atom midpoint instead, which violates this by up to 10% and does not converge
+// away as the atoms shrink. The parametric families satisfy it exactly, so the
+// same check is run on gaussian as a control.
+TEST(discrete, kernel_pdf_is_normalized)
+{
+  auto gauss =
+    Bicop(BicopFamily::gaussian, 0, Eigen::VectorXd::Constant(1, 0.6));
+  auto u = gauss.simulate(2000, true, { 7 });
+
+  // Fit continuously and declare the types afterwards, so this exercises the
+  // evaluation path alone and not the (separate) discrete fit.
+  auto tll = Bicop();
+  tll.select(u, FitControlsBicop({ BicopFamily::tll }));
+
+  for (const auto& family : { BicopFamily::tll, BicopFamily::gaussian }) {
+    auto bc = family == BicopFamily::tll ? tll : gauss;
+    bc.set_var_types({ "d", "c" });
+    for (size_t k : { 2, 8, 32 }) {
+      for (double u2 : { 0.1, 0.5, 0.9 }) {
+        Eigen::MatrixXd uu(k, 4);
+        for (size_t i = 0; i < k; ++i) {
+          uu(i, 0) = static_cast<double>(i + 1) / static_cast<double>(k);
+          uu(i, 2) = static_cast<double>(i) / static_cast<double>(k);
+          uu(i, 1) = u2;
+          uu(i, 3) = u2;
+        }
+        const auto pdf = bc.pdf(uu);
+        const double mass =
+          (pdf.array() * (uu.col(0) - uu.col(2)).array()).sum();
+        EXPECT_NEAR(mass, 1.0, 1e-6) << "family " << bc.get_family_name()
+                                     << ", k = " << k << ", u2 = " << u2;
+      }
+    }
+  }
+}
+
+// TllBicop::fit computes a latent sample for discrete data via
+// find_latent_sample. Its result used to be assigned to `psobs` and never fed
+// back into `z_data`, so the fitted grid was bit-identical to the one the same
+// data produces when declared continuous -- i.e. declaring a variable discrete
+// had no effect on the fit at all.
+TEST(discrete, kernel_fit_uses_the_latent_sample)
+{
+  auto gauss =
+    Bicop(BicopFamily::gaussian, 0, Eigen::VectorXd::Constant(1, 0.6));
+  auto u = gauss.simulate(2000, true, { 3 });
+
+  Eigen::MatrixXd u_disc(u.rows(), 4);
+  u_disc.col(0) = (u.col(0).array() * 5).ceil() / 5;
+  u_disc.col(2) = (u.col(0).array() * 5).floor() / 5;
+  u_disc.col(1) = (u.col(1).array() * 5).ceil() / 5;
+  u_disc.col(3) = (u.col(1).array() * 5).floor() / 5;
+
+  auto cont = Bicop();
+  cont.select(u_disc.leftCols(2), FitControlsBicop({ BicopFamily::tll }));
+
+  auto disc = Bicop();
+  disc.set_var_types({ "d", "d" });
+  disc.select(u_disc, FitControlsBicop({ BicopFamily::tll }));
+
+  const double diff =
+    (disc.get_parameters() - cont.get_parameters()).array().abs().maxCoeff();
+  EXPECT_GT(diff, 1e-6);
 }
 
 }


### PR DESCRIPTION
Two defects made every discrete or mixed fit with a nonparametric pair copula
wrong. `tll` is the default family in `FitControlsVinecop`, so this was the
default path for discrete data. Neither the test suite nor pyvinecopulib's caught
it, because every discrete test uses a parametric family and every `tll` test
uses continuous data.

Closes #736.

## 1. Evaluation: the discrete density was never computed

`AbstractBicop::pdf` / `hfunc1` / `hfunc2` are `virtual` and `KernelBicop`
overrode all three:

```cpp
// bicop/implementation/kernel.ipp, before
KernelBicop::pdf(const Eigen::MatrixXd& u)
{
  if (u.cols() == 4) {
    // evaluate jittered density at mid rank for stability
    return pdf_raw((u.leftCols(2) + u.rightCols(2)).array() / 2.0,
                   Eigen::MatrixXd());
  }
  return pdf_raw(u, Eigen::MatrixXd());
}
```

So a four-column argument returned the **continuous** interpolated quantity at
the atom midpoint, and `AbstractBicop::pdf_c_d` / `pdf_d_d` and the discrete
`hfunc*` difference quotients were unreachable for kernel families — in fact
unreachable at all, since `Bicop::pdf(u, parameters)`, the only other entry to
them, rejects nonparametric families in `format_parameters`.

### Why the midpoint rule is a defect and not a modelling choice

A discrete/continuous density must satisfy, for every `u2`,

```
sum_atoms c(u1, u2) * (u1 - u1^-)  =  h2(1, u2) - h2(0, u2)  =  1
```

because the difference quotients telescope over the atoms. Measured on one
fitted 30×30 grid:

| atoms | u2 = 0.1 | u2 = 0.5 | u2 = 0.9 | source |
|---|---|---|---|---|
| 2 | 1.019639 | 1.036184 | 0.899977 | shipped `Bicop::pdf` |
| 2 | **1.000000** | **1.000000** | **1.000000** | difference quotient |
| 8 | 1.013834 | 0.996600 | 1.033555 | shipped `Bicop::pdf` |
| 8 | **1.000000** | **1.000000** | **1.000000** | difference quotient |
| 32 | 1.002292 | 1.001842 | 1.003035 | shipped `Bicop::pdf` |
| 32 | **1.000000** | **1.000000** | **1.000000** | difference quotient |

The quotient is exact at every resolution; the midpoint rule is off by up to
10% and does not converge away. Per cell the error reached **40%**. On a
three-dimensional discrete vine, `Vinecop::pdf` was off by up to a factor of
two and `loglik` was **522.11** against a correct **515.56** — which feeds
`aic` / `bic` / `mbicv` and therefore biases family and structure selection
toward `tll` on discrete data.

All eleven parametric families satisfy the identity to ~1e-15, so `tll`'s
discrete surface disagreed with every parametric one.

### The fix

Deleting the three overrides is sufficient. `KernelBicop::cdf` and the `*_raw`
members already supply everything the inherited dispatchers need, and they ignore
their `parameters` argument, so nothing has to be plumbed. #700 had already
hardened `pdf_c_d` / `pdf_d_d` against the 30×30 grid parameter shape — which is
precisely what makes reaching them safe now.

After the change, `Bicop::pdf` on a discrete kernel edge equals the difference
quotient of its own `hfunc2` **exactly** (max relative difference `0.0` over
3000 rows), and the atom masses sum to `1.0000000000`.

## 2. Fitting: the latent sample was discarded (#736)

`TllBicop::fit` computes a latent sample for discrete data and then throws it
away — `z_data` is built from the jittered ranks at line 247, `find_latent_sample`
assigns to `psobs` at 255, and `fit_local_likelihood` reads `z_data`. `psobs` is
next touched where the EDF branch overwrites it with mid ranks, so the latent
sample has no effect whatsoever. One line inside the existing branch fixes it:

```cpp
  if (var_types_[0] == "d" || var_types_[1] == "d") {
    psobs =
      tools_stats::find_latent_sample(data, std::pow(B(0, 0) * B(1, 1), 0.25));
    z_data = tools_stats::qnorm(psobs);          // added
  }
```

Nothing between the two points reads `psobs`, so this is safe by inspection.

The effect is easiest to see as an identity that used to hold and should not:
fitting the same data as `{"d","c"}`, `{"c","d"}` and `{"d","d"}` returned
**bit-identical grids and bit-identical Kendall's tau**. Recovered tau against a
true 0.6, zero-inflated margins:

| n | before (all three var_types) | after: d/c | after: c/d | after: d/d |
|---|---|---|---|---|
| 20 | 0.5052 | 0.0351 | 0.1393 | 0.1304 |
| 200 | 0.5593 | 0.3361 | 0.3360 | 0.2975 |
| 1000 | 0.5693 | 0.5391 | 0.5551 | 0.5331 |
| 5000 | 0.5759 | 0.5848 | 0.5878 | 0.5825 |

The "before" column is identical across var_types by construction — that is the
bug. Afterwards the estimator actually uses the atom structure and converges to
0.6; the price is genuine small-sample variance, which the old code hid by
ignoring discreteness altogether.

## This is a behavior change

Every discrete or mixed fit with a `tll` pair copula now has a different grid,
density, `loglik`, `aic`, `bic` and `mbicv`, so family and structure selection can
change. **Continuous fits are untouched** — neither code path runs when every
variable type is `"c"`, which is the useful control.

One existing test moved with it: the three `tll` fits in `zero_inflated.bicop`
now use the whole sample instead of `topRows(20)`. Their tau assertions passed
only because the fit ignored the atoms; once the latent sample reaches it, 20
observations no longer identify a nonparametric density. **The tolerance is
unchanged** — only the sample size, which was arbitrary.

## Tests

- `discrete.kernel_pdf_is_normalized` — the identity above for `tll` at 2, 8 and
  32 atoms and three `u2`, with `gaussian` as a control. It needs no reference
  implementation and no tolerance argument.
- `discrete.kernel_fit_uses_the_latent_sample` — a discrete fit must no longer
  reproduce the grid the same data produces when declared continuous.

Full suite: **714 tests pass**.

## Two follow-ups, deliberately not in this PR

- `pdf_c_d` / `pdf_d_d` and the discrete `hfunc*` branches loop row by row,
  constructing an `Eigen::MatrixXd par_i` per observation. For kernels that is
  now on the hot path, so a vectorized `KernelBicop::pdf_c_d` / `pdf_d_d`
  override is worth having. This PR is the correctness half only.
- With the overrides gone nothing overrides `pdf` / `hfunc1` / `hfunc2` any more,
  so they need not stay `virtual`. Left alone here to keep the diff to the
  defect.

## Related, in wdm

`rank(..., "random")` accumulates the tie weight in the wrong order
(`wdm/include/wdm/ranks.hpp`, the `"random"` branch adds `ww` before
accumulating it where `"first"` accumulates first). A tie group of 6 occupying
rank slots 4..9 comes back as `[4,4,5,6,7,8]` — minimum duplicated, maximum
dropped — so `to_pseudo_obs(x, "random")` returns data that still contains ties
and is not idempotent. Its only call site here is `tll.ipp`'s jittering, which
after this PR only seeds the bandwidth. Filed separately.
