### PR TITLE
docs(stats): document find_latent_sample with a Doxygen comment

### DIFF
--- a/include/vinecopulib/misc/implementation/tools_stats.ipp
+++ b/include/vinecopulib/misc/implementation/tools_stats.ipp
@@ -237,11 +237,32 @@ BoxCovering::swap_sample(size_t i, const Eigen::VectorXd& new_sample)
   boxes_[k * K_ + j].insert(i);
 }
 
-// Recovers a (continuous) latent sample from a sample of a discrete copula by
-// treating it as an interval-censored density estimation problem.
-// @param u A matrix of samples.
-// @param b The bandwidth of the kernel density estimator.
-// @param niter The number of iterations.
+//! @brief Recovers a continuous latent sample from a sample of a discrete
+//! copula.
+//!
+//! Treats the discrete sample as an interval-censored density estimation
+//! problem: observation \f$ i \f$ is only known to lie in the rectangle
+//! \f$ (u_{i1}^-, u_{i1}] \times (u_{i2}^-, u_{i2}] \f$. A latent point is
+//! initialized inside that rectangle and then refined by `niter` sweeps: for
+//! each observation, one of the observations whose current latent point falls
+//! in its own rectangle (widened by \f$ b \f$ on the normal scale) is picked
+//! uniformly at random, and the latent point is set to that neighbor's value
+//! plus Gaussian noise of scale \f$ b \f$ --- a draw from a Gaussian kernel
+//! density estimate restricted to the compatible observations. The refined
+//! points are not confined to the original rectangles.
+//!
+//! The draw is deterministic: every random component is a quasi-random sequence
+//! with a fixed seed, so repeated calls on the same input agree bit for bit.
+//!
+//! @param u An \f$ n \times 4 \f$ matrix \f$ (u_1, u_2, u_1^-, u_2^-) \f$
+//! holding each observation's distribution function values and their left
+//! limits; any other number of columns throws.
+//! @param b The bandwidth of the kernel density estimator.
+//! @param niter The number of sweeps.
+//!
+//! @return An \f$ n \times 2 \f$ matrix of pseudo-observations of the latent
+//! sample, i.e. on the copula scale rather than the normal scale the sweeps run
+//! on.
 inline Eigen::MatrixXd
 find_latent_sample(const Eigen::MatrixXd& u, double b, size_t niter)
 {


### PR DESCRIPTION
`tools_stats::find_latent_sample` carried its documentation as a plain `//` comment, so
Doxygen and every downstream extractor saw nothing. The text was already in the right shape —
an explanation plus `@param` lines — it just needed `//!`.

Closes #740.

## What is filled in beyond the conversion

Three things a caller can get wrong that were not written down anywhere:

- **`u` must have exactly four columns** `(u₁, u₂, u₁⁻, u₂⁻)`. Any other count throws.
- **The draw is deterministic.** Every random component is a quasi-random sequence with a
  fixed seed (`simulate_uniform(n, 2, true, {5})`, `simulate_normal(n, 2, true, {it, 5})`,
  `simulate_uniform(n, 1, true, {it, 55})`), so repeated calls on the same input agree bit
  for bit. That is a useful guarantee to be able to rely on.
- **What the return value is**: pseudo-observations on the *copula* scale, since the function
  ends in `to_pseudo_obs(x)` — not the normal scale the sweeps run on.

And one correction to what a reader would otherwise assume: **the refined points are not
confined to the original censoring rectangles.** "Interval-censored" invites exactly that
reading, but each sweep sets `x_i = x_j + b·N(0,1)` from a neighbor `j` and then re-ranks
through `to_pseudo_obs`, so the constraint holds only for the initialization.

The description of the sweep itself is now explicit — pick uniformly at random among the
observations whose current latent point lies in observation `i`'s own rectangle widened by
`b` on the normal scale, then add Gaussian noise of scale `b` — because "interval-censored
density estimation problem" alone does not say what the algorithm does.

## Scope

Five other definitions in `tools_stats.ipp` also use plain `//` (`pseudo_obs_1d_impl`,
`BoxCovering::get_box_indices` ×2, `BoxCovering::swap_sample`, `next_power_of_two`).
`find_latent_sample` is the **only one of the six declared in the public header**
(`tools_stats.hpp:168`), so it is the only one whose missing documentation is visible outside
the implementation. The others are left alone deliberately.

## Verified

Comment-only, no behavior change. Checked that it actually reaches a downstream consumer:
pyvinecopulib's libclang extractor now produces a valid numpydoc docstring from it (a
`Parameters` section with all three arguments typed and a `Returns` section), where before
the extracted text was the empty string. `clang-format` clean.

## Why it came up

pyvinecopulib's PyTorch TLL fitter reuses this function to reproduce `TllBicop::fit`'s
discrete path after #739, rather than reimplementing a stochastic iterative reconstruction
and hoping the fitted grids still agree — they agree to 1.5e-13. It is currently bound under
a private name only because a public binding there must take its docstring from upstream, so
that the two cannot drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
