### PR TITLE
fix(vinecop): read an empty pair-copula store as independence everywhere

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -152,6 +152,12 @@ wrong thing.
 
 ### BUG FIXES
 
+* Read an empty pair-copula store as independence in the paths that still
+  assumed a full one, completing (#729). `Vinecop::reorient` and `get_trees`
+  indexed the store out of bounds, `truncate` gave it tree slots holding no pair
+  copula at all, which `pdf` then dereferenced, and deserializing a vine written
+  without pair copulas threw a JSON type error instead of round-tripping (#743)
+
 * Compute a real discrete density for kernel pair copulas. `KernelBicop`
   overrode `pdf`, `hfunc1` and `hfunc2` to return the continuous quantity at the
   atom midpoint, so the difference quotients in `AbstractBicop::pdf_c_d` /

--- a/include/vinecopulib/vinecop/implementation/class.ipp
+++ b/include/vinecopulib/vinecop/implementation/class.ipp
@@ -134,26 +134,32 @@ inline Vinecop::Vinecop(
 //!      a valid R-vine structure.
 inline Vinecop::Vinecop(const nlohmann::json& input, const bool check)
 {
-  rvine_structure_ = RVineStructure(input["structure"], check);
+  rvine_structure_ = RVineStructure(input.at("structure"), check);
   d_ = static_cast<size_t>(rvine_structure_.get_dim());
   size_t trunc_lvl = rvine_structure_.get_trunc_lvl();
 
-  nlohmann::json pcs_json = input["pair copulas"];
+  const auto pcs_json = input.value("pair copulas", nlohmann::json::object());
   for (size_t tree = 0; tree < std::min(d_, trunc_lvl); ++tree) {
-    nlohmann::json tree_json;
-    try {
-      tree_json = pcs_json["tree" + std::to_string(tree)];
-    } catch (...) {
-      break; // vine was truncated, no more trees to parse
+    const auto tree_key = "tree" + std::to_string(tree);
+    if (!pcs_json.contains(tree_key)) {
+      break; // fewer trees stored than the structure has; the rest are
+             // independence
     }
+    const auto& tree_json = pcs_json[tree_key];
+
     // reserve space for pair copulas of this tree
     pair_copulas_.resize(tree + 1);
     pair_copulas_[tree].resize(d_ - tree - 1);
 
     for (size_t edge = 0; edge < d_ - tree - 1; ++edge) {
-      nlohmann::json pc_json = tree_json["pc" + std::to_string(edge)];
-      pair_copulas_[tree][edge] = Bicop(pc_json);
+      pair_copulas_[tree][edge] =
+        Bicop(tree_json.at("pc" + std::to_string(edge)));
     }
+  }
+
+  // as in set_all_pair_copulas(): the structure follows the store it has
+  if (!pair_copulas_.empty()) {
+    rvine_structure_.truncate(pair_copulas_.size());
   }
 
   // try block for backwards compatibility
@@ -564,6 +570,13 @@ Vinecop::reorient(const std::vector<size_t>& conditioning_set)
   if (reorientation.identity)
     return;
 
+  // an empty store means every pair copula is independence: there is nothing
+  // to permute or flip, only the representation changes
+  if (pair_copulas_.empty()) {
+    rvine_structure_ = std::move(reorientation.structure);
+    return;
+  }
+
   std::vector<std::vector<Bicop>> pair_copulas(d_ - 1);
   for (size_t tree = 0; tree < d_ - 1; ++tree) {
     pair_copulas[tree].reserve(d_ - 1 - tree);
@@ -913,6 +926,12 @@ Vinecop::get_trees() const
 {
   // decompose in original labels: the diagonal `get_order()`, the original-
   // label structure array, and the pair-copulas share the same labelling.
+  if (pair_copulas_.empty()) {
+    // an empty store means independence, which is what this constructor puts
+    // on every edge
+    return RVineTrees(rvine_structure_.get_order(),
+                      rvine_structure_.get_struct_array(false));
+  }
   return RVineTrees(rvine_structure_.get_order(),
                     rvine_structure_.get_struct_array(false),
                     pair_copulas_);
@@ -3594,7 +3613,11 @@ Vinecop::truncate(size_t trunc_lvl)
 {
   if (trunc_lvl < this->get_trunc_lvl()) {
     rvine_structure_.truncate(trunc_lvl);
-    pair_copulas_.resize(trunc_lvl);
+    // an empty store already means independence at every level; resizing it
+    // would add tree slots holding no pair copula at all
+    if (!pair_copulas_.empty()) {
+      pair_copulas_.resize(trunc_lvl);
+    }
   }
 }
 

--- a/test/src_test/test_serialization.cpp
+++ b/test/src_test/test_serialization.cpp
@@ -127,6 +127,24 @@ TEST(serialization, mixed_vinecop_cbor_roundtrip)
   expect_vinecops_equal(truncated, Vinecop(truncated_file.filename()));
 }
 
+TEST(serialization, structure_only_vinecop_cbor_roundtrip)
+{
+  // an empty pair-copula store means independence; nothing is written for it,
+  // so the reader has to accept a file without a single tree
+  const Vinecop vinecop(DVineStructure({ 1, 2, 3, 4 }));
+  ASSERT_TRUE(vinecop.get_all_pair_copulas().empty());
+
+  TemporaryFile file("serialization_vinecop_structure_only.cbor");
+  vinecop.to_file(file.filename());
+  const Vinecop restored(file.filename());
+
+  expect_vinecops_equal(vinecop, restored);
+  EXPECT_TRUE(restored.get_all_pair_copulas().empty());
+  const auto data = tools_stats::simulate_uniform(20, 4, false, { 1 });
+  EXPECT_TRUE(
+    all_close(restored.pdf(data), Eigen::VectorXd::Ones(data.rows())));
+}
+
 TEST(serialization, rvine_structure_cbor_roundtrip)
 {
   const RVineStructure structure(DVineStructure({ 1, 2, 3, 4 }, 2));

--- a/test/src_test/test_vinecop_class.cpp
+++ b/test/src_test/test_vinecop_class.cpp
@@ -52,6 +52,47 @@ TEST(VinecopConstructor, omitted_pair_copulas_are_independence)
   EXPECT_TRUE(all_close(simulated.col(1), u_cond.col(1)));
 }
 
+// An empty pair-copula store means independence, whatever the structure's
+// truncation level, so no structural operation may index it.
+TEST(VinecopConstructor, omitted_pair_copulas_survive_structure_operations)
+{
+  const size_t d = 4;
+  const auto data = tools_stats::simulate_uniform(20, d, false, { 1 });
+  const Eigen::VectorXd ones = Eigen::VectorXd::Ones(data.rows());
+  const Vinecop model(DVineStructure({ 1, 2, 3, 4 }));
+
+  // {1} is not the order tail, so this does not take the identity fast path
+  Vinecop reoriented = model;
+  ASSERT_NO_THROW(reoriented.reorient({ 1 }));
+  EXPECT_EQ(reoriented.get_order().back(), 1u);
+  EXPECT_TRUE(reoriented.get_all_pair_copulas().empty());
+  EXPECT_TRUE(all_close(reoriented.pdf(data), ones));
+  EXPECT_NO_THROW(RVineStructure(reoriented.get_matrix()));
+
+  // every edge of the decomposition is independence, and it still round-trips
+  const auto trees = model.get_trees();
+  ASSERT_EQ(trees.get_trunc_lvl(), d - 1);
+  for (const auto& tree : trees.get_trees()) {
+    for (const auto& edge : tree) {
+      EXPECT_EQ(edge.pair_copula.get_family(), BicopFamily::indep);
+    }
+  }
+  EXPECT_EQ(model.get_rvine_structure(), RVineStructure(trees));
+
+  // truncation keeps the store empty rather than adding empty tree slots
+  Vinecop truncated = model;
+  truncated.truncate(2);
+  EXPECT_EQ(truncated.get_trunc_lvl(), 2u);
+  EXPECT_TRUE(truncated.get_all_pair_copulas().empty());
+  EXPECT_TRUE(all_close(truncated.pdf(data), ones));
+
+  // variable types are labelled in the original order and survive relabeling
+  Vinecop discrete(DVineStructure({ 1, 2, 3, 4 }), {}, { "c", "d", "c", "d" });
+  ASSERT_NO_THROW(discrete.reorient({ 1 }));
+  EXPECT_EQ(discrete.get_var_types(),
+            std::vector<std::string>({ "c", "d", "c", "d" }));
+}
+
 TEST_F(VinecopTest, copy)
 {
   auto pair_copulas = Vinecop::make_pair_copula_store(7);


### PR DESCRIPTION
Closes #737.

`Vinecop`'s constructor documents an empty `pair_copulas` as "all pair-copulas are treated as independence" and leaves the member empty. #729 taught the evaluation paths that convention through `get_effective_trunc_lvl()`. Four paths still assumed a full store — the reported one and three more found while fixing it. Each was confirmed failing under `-DVINECOPULIB_SANITIZERS=ON` before being touched.

| path | before |
| --- | --- |
| `reorient()` | `pair_copulas_[location.tree][location.edge]` unconditionally → `SEGV` at `class.ipp:573` on `Vinecop(structure).reorient({1})` (the reported bug). The `identity` fast path returns before the loop, which is why a set that already was the order tail happened to be safe. |
| `get_trees()` | handed the empty store to `RVineTrees`, which indexes `[t][e]` for every edge the structure has → the same `SEGV`, via `rvine_trees.ipp:57` |
| `truncate()` | resized the empty store to `trunc_lvl`, giving it tree slots holding no pair copula at all; `get_effective_trunc_lvl()` then reported those levels as present and `pdf()` dereferenced them → `SEGV` in `pdf_full` |
| JSON reader | the `try`/`catch` around `pcs_json["tree" + k]` never fired: non-const `operator[]` *inserts* a null instead of throwing. A vine written without pair copulas came back as `Bicop(null)` and threw `json.exception.type_error.305`, so a structure-only vine could not round-trip through `to_file` / `from_file` at all. |

Per @tnagler's vote on the issue, all four treat the empty store as independence rather than throwing.

### The invariant

`pair_copulas_` is either **empty** — every pair copula is independence, whatever the structure's truncation level — or holds **exactly `rvine_structure_.get_trunc_lvl()`** trees, tree `t` having `d - 1 - t` edges. `set_all_pair_copulas()` already maintained it; the reader now does too, truncating the structure to the number of trees a short file actually carries, so the partially-filled state stays unreachable. The reader also reaches its required nodes with `at()`, so a foreign file throws instead of tripping nlohmann's assert and reading past a non-object.

### Tests

- `VinecopConstructor.omitted_pair_copulas_survive_structure_operations` walks a structure-only vine through `reorient`, `get_trees`, `truncate` + `pdf`, and a discrete-`var_types` relabeling. A plain `TEST`, so it runs without Rscript — unlike the `VinecopTest` fixture the other `reorient` tests hang off.
- `serialization.structure_only_vinecop_cbor_roundtrip` covers the reader.

### Verification

- `716/716` with `-DVINECOPULIB_SANITIZERS=ON` (Debug, ASAN + UBSAN, R parity tests included).
- `716/716` with `-DVINECOPULIB_PRECOMPILED=ON` (Release).
- `clang-format-14 --dry-run --Werror` clean on all three files.

NEWS.md entry follows in the next commit, once this PR has a number.

### Noted, not fixed here

`Vinecop(structure).fit(data)` silently does nothing: `fit` early-returns on `get_effective_trunc_lvl() == 0`, so fitting a structure whose families were never set is a no-op and the model only fails later at `check_fitted`. That is a behavior decision with downstream reach (fit independence-initialized families, or throw), so it wants its own issue rather than a drive-by change here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)