### PR TITLE
build: regenerate the precompiled sources when their headers change

### DIFF
--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -182,6 +182,14 @@ jobs:
             cmake --build . --target install
           fi
         shell: bash
+      - name: Check that an edited .ipp regenerates its translation unit
+        run: |
+          probe=include/vinecopulib/bicop/implementation/abstract.ipp
+          printf '\n// regeneration probe\n' >> "$probe"
+          cmake --build release --target vinecopulib
+          grep -q "regeneration probe" release/generated/src/bicop/abstract.cpp
+          git checkout -- "$probe"
+        shell: bash
       - name: Test the install (bicop and vinecop examples)
         run: |
           for ex in bicop vinecop; do

--- a/NEWS.md
+++ b/NEWS.md
@@ -207,6 +207,13 @@ wrong thing.
 
 ### BUILD SYSTEM AND DEPENDENCIES
 
+* Regenerate the precompiled translation units when the header they are derived
+  from changes. The `.ipp` to `.cpp` translation runs at configure time, and
+  `CONFIGURE_DEPENDS` on the glob only re-runs it when the set of files changes,
+  so editing a header in a `VINECOPULIB_PRECOMPILED` build tree silently linked
+  the previous implementation. A CI step now edits an `.ipp` and checks that its
+  translation unit follows (#753)
+
 * Modernize the CMake project: `GNUInstallDirs`, a namespaced export,
   `target_compile_features`, an architecture-independent version file,
   `CMakePresets.json`, and appended rather than assigned compiler flags, so

--- a/cmake/findHeaders.cmake
+++ b/cmake/findHeaders.cmake
@@ -11,6 +11,13 @@ if(VINECOPULIB_PRECOMPILED)
             "// vinecopulib or https://vinecopulib.github.io/vinecopulib/. \n")
 
     file(GLOB_RECURSE vinecopulib_ipp CONFIGURE_DEPENDS ${vinecopulib_includes}/*.ipp)
+    file(GLOB_RECURSE vinecopulib_all_hpp CONFIGURE_DEPENDS
+            ${vinecopulib_includes}/*.hpp)
+    # The translation below runs at configure time, and CONFIGURE_DEPENDS on a
+    # glob only re-runs it when the set of matched files changes. Depend on the
+    # contents as well, so that editing a header regenerates what it feeds.
+    set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS
+            ${vinecopulib_ipp} ${vinecopulib_all_hpp})
     foreach (file ${vinecopulib_ipp})
 
         # Get directory, name and path for header/source files. Paths are
@@ -51,7 +58,8 @@ if(VINECOPULIB_PRECOMPILED)
 
     endforeach ()
 
-    file(GLOB_RECURSE vinecopulib_hpp ${vinecopulib_includes}/vinecopulib/*.hpp)
+    file(GLOB_RECURSE vinecopulib_hpp CONFIGURE_DEPENDS
+            ${vinecopulib_includes}/vinecopulib/*.hpp)
     foreach (file ${vinecopulib_hpp})
         # Get directory, name and path for header/source files
         get_filename_component(name_without_extension ${file} NAME_WE)


### PR DESCRIPTION
Closes #745.

In a `VINECOPULIB_PRECOMPILED` build tree, editing an `.ipp` and running `make` rebuilt nothing relevant and linked the **previous** implementation — no warning, no diagnostic. A test suite could report green against code that was not in the working tree, which is how this was found: #744's new test "passed" in the precompiled build against a stale `abstract.cpp`, and failed after a bare reconfigure.

### Why

The `.ipp` → `.cpp` translation in `cmake/findHeaders.cmake` runs at **configure** time (`file(READ)`, strip `inline`, `file(WRITE)`). Its only dependency edge was

```cmake
file(GLOB_RECURSE vinecopulib_ipp CONFIGURE_DEPENDS ${vinecopulib_includes}/*.ipp)
```

and `CONFIGURE_DEPENDS` re-runs CMake when the *set* of matched files changes — one added or removed — not when a file's contents change. So nothing regenerated the translation unit and `make` saw an up-to-date target. The generated headers had it worse: that glob had no `CONFIGURE_DEPENDS` at all, so a newly added `.hpp` was not even picked up.

### The fix

Both globs carry `CONFIGURE_DEPENDS`, and the matched files go into the directory's `CMAKE_CONFIGURE_DEPENDS`, so a content edit re-runs the configure step that derives from them. It stays inside the `if(VINECOPULIB_PRECOMPILED)` branch — the header-only build derives nothing and needs no such edge.

Cost is one extra configure (~2 s) per header edit, and no extra compilation: the generation already writes only when the result differs, so unchanged files keep their timestamps.

The alternative shape is to move the generation to build time (`add_custom_command` per `.ipp`, with the transformation extracted into a `cmake -P` script). That is the more usual pattern for generated sources and would parallelize, but it is a real refactor of `findHeaders.cmake`; this is the one-line-per-glob correction. Happy to do the bigger version instead if you prefer it for 1.0.0.

### Verified

```
$ cmake -S . -B build-pc -DCMAKE_BUILD_TYPE=Release -DVINECOPULIB_PRECOMPILED=ON -DBUILD_TESTING=OFF
$ cmake --build build-pc --target vinecopulib
$ printf '\n// STALENESS-PROBE-MARKER\n' >> include/vinecopulib/bicop/implementation/abstract.ipp
$ grep -c STALENESS-PROBE-MARKER build-pc/generated/src/bicop/abstract.cpp   # 0
$ cmake --build build-pc --target vinecopulib
[  2%] Building CXX object CMakeFiles/vinecopulib.dir/generated/src/bicop/abstract.cpp.o
$ grep -c STALENESS-PROBE-MARKER build-pc/generated/src/bicop/abstract.cpp   # 1
```

Exactly one translation unit recompiled, which is the "no extra compilation" claim above.

A CI step in the precompiled matrix job now does the same thing — edit an `.ipp`, rebuild the library target alone, check the marker reached `generated/src/bicop/abstract.cpp`, revert — so this cannot silently come back. CI configures a fresh tree per job, which is why it never hit the bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)