### PR TITLE
feat(vinecop): add Chatterjee's xi as a tree criterion

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -42,7 +42,7 @@ inputs:
       The wdm commit to install. Keep in sync with the FetchContent GIT_TAG in
       cmake/findDependencies.cmake.
     required: false
-    default: '6b85eebc3e0097672be1047f6f43848bc77acb52'
+    default: '536099dbc8da175b8e3ad63edc335a6e4f1d36e3'
   lcov:
     description: 'Whether to install lcov'
     required: false

--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -42,7 +42,7 @@ inputs:
       The wdm commit to install. Keep in sync with the FetchContent GIT_TAG in
       cmake/findDependencies.cmake.
     required: false
-    default: '03651d719152ee1ba28578ee737e919ff19abb73'
+    default: '1c444ae923104987abf537ac022a09cbd215647b'
   lcov:
     description: 'Whether to install lcov'
     required: false
@@ -123,9 +123,13 @@ runs:
       run: |
           # Relative path: ${{runner.temp}} is a backslash path on Windows,
           # which bash mangles.
-          git clone https://github.com/tnagler/wdm.git wdm
+          git init wdm
           cd wdm
-          git checkout --detach ${{ inputs.wdm_ref }}
+          git remote add origin https://github.com/tnagler/wdm.git
+          # Fetch the commit by name: a pin may point at a commit that no
+          # branch reaches, which a plain clone would not bring along.
+          git fetch --depth 1 origin ${{ inputs.wdm_ref }}
+          git checkout --detach FETCH_HEAD
           mkdir release && cd release
           if [ "${{ inputs.os }}" != "windows-latest" ]; then
             cmake .. -DCMAKE_BUILD_TYPE=Release

--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -42,7 +42,7 @@ inputs:
       The wdm commit to install. Keep in sync with the FetchContent GIT_TAG in
       cmake/findDependencies.cmake.
     required: false
-    default: '536099dbc8da175b8e3ad63edc335a6e4f1d36e3'
+    default: 'ae077fccacbb4ba980cb5e7dbc14105f821ea98e'
   lcov:
     description: 'Whether to install lcov'
     required: false

--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -42,7 +42,7 @@ inputs:
       The wdm commit to install. Keep in sync with the FetchContent GIT_TAG in
       cmake/findDependencies.cmake.
     required: false
-    default: 'e13b5f61191620be234ac04f8d9bc8680e4248b9'
+    default: '03651d719152ee1ba28578ee737e919ff19abb73'
   lcov:
     description: 'Whether to install lcov'
     required: false
@@ -123,13 +123,9 @@ runs:
       run: |
           # Relative path: ${{runner.temp}} is a backslash path on Windows,
           # which bash mangles.
-          git init wdm
+          git clone https://github.com/tnagler/wdm.git wdm
           cd wdm
-          git remote add origin https://github.com/tnagler/wdm.git
-          # Fetch the commit by name: a pin may point at a commit that no
-          # branch reaches, which a plain clone would not bring along.
-          git fetch --depth 1 origin ${{ inputs.wdm_ref }}
-          git checkout --detach FETCH_HEAD
+          git checkout --detach ${{ inputs.wdm_ref }}
           mkdir release && cd release
           if [ "${{ inputs.os }}" != "windows-latest" ]; then
             cmake .. -DCMAKE_BUILD_TYPE=Release

--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -39,10 +39,10 @@ inputs:
     default: 'true'
   wdm_ref:
     description: >
-      The wdm commit to install. Keep in sync with the FetchContent GIT_TAG in
-      cmake/findDependencies.cmake.
+      The wdm commit or tag to install. Keep in sync with the FetchContent
+      GIT_TAG in cmake/findDependencies.cmake.
     required: false
-    default: 'ae077fccacbb4ba980cb5e7dbc14105f821ea98e'
+    default: 'v0.3.0'
   lcov:
     description: 'Whether to install lcov'
     required: false

--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -42,7 +42,7 @@ inputs:
       The wdm commit to install. Keep in sync with the FetchContent GIT_TAG in
       cmake/findDependencies.cmake.
     required: false
-    default: '61a88acce7b6c379557638e3c6e5baaac1417709'
+    default: 'ca1c0bd95dd9bff91b305b5af834d745d21ea03d'
   lcov:
     description: 'Whether to install lcov'
     required: false

--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -42,7 +42,7 @@ inputs:
       The wdm commit to install. Keep in sync with the FetchContent GIT_TAG in
       cmake/findDependencies.cmake.
     required: false
-    default: '1c444ae923104987abf537ac022a09cbd215647b'
+    default: '6b85eebc3e0097672be1047f6f43848bc77acb52'
   lcov:
     description: 'Whether to install lcov'
     required: false
@@ -123,13 +123,9 @@ runs:
       run: |
           # Relative path: ${{runner.temp}} is a backslash path on Windows,
           # which bash mangles.
-          git init wdm
+          git clone https://github.com/tnagler/wdm.git wdm
           cd wdm
-          git remote add origin https://github.com/tnagler/wdm.git
-          # Fetch the commit by name: a pin may point at a commit that no
-          # branch reaches, which a plain clone would not bring along.
-          git fetch --depth 1 origin ${{ inputs.wdm_ref }}
-          git checkout --detach FETCH_HEAD
+          git checkout --detach ${{ inputs.wdm_ref }}
           mkdir release && cd release
           if [ "${{ inputs.os }}" != "windows-latest" ]; then
             cmake .. -DCMAKE_BUILD_TYPE=Release

--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -42,7 +42,7 @@ inputs:
       The wdm commit to install. Keep in sync with the FetchContent GIT_TAG in
       cmake/findDependencies.cmake.
     required: false
-    default: 'ca1c0bd95dd9bff91b305b5af834d745d21ea03d'
+    default: 'e13b5f61191620be234ac04f8d9bc8680e4248b9'
   lcov:
     description: 'Whether to install lcov'
     required: false
@@ -123,9 +123,13 @@ runs:
       run: |
           # Relative path: ${{runner.temp}} is a backslash path on Windows,
           # which bash mangles.
-          git clone https://github.com/tnagler/wdm.git wdm
+          git init wdm
           cd wdm
-          git checkout --detach ${{ inputs.wdm_ref }}
+          git remote add origin https://github.com/tnagler/wdm.git
+          # Fetch the commit by name: a pin may point at a commit that no
+          # branch reaches, which a plain clone would not bring along.
+          git fetch --depth 1 origin ${{ inputs.wdm_ref }}
+          git checkout --detach FETCH_HEAD
           mkdir release && cd release
           if [ "${{ inputs.os }}" != "windows-latest" ]; then
             cmake .. -DCMAKE_BUILD_TYPE=Release

--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -42,7 +42,7 @@ inputs:
       The wdm commit to install. Keep in sync with the FetchContent GIT_TAG in
       cmake/findDependencies.cmake.
     required: false
-    default: 'c837460853570690ccd9367c059e41b851d6f816'
+    default: '61a88acce7b6c379557638e3c6e5baaac1417709'
   lcov:
     description: 'Whether to install lcov'
     required: false

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -248,7 +248,7 @@ Discovered in
   behind `tree_algorithm`), **Math** (distributions, constants, special
   functions, `quadrature::tanh_sinh` for 1-d integration, `tools::minima`),
   and **Random** (`mt19937`, behind QRNG scrambling and structure simulation).
-- **wdm 0.2.6** — `find_package(wdm 0.2.6 QUIET)` with a **FetchContent
+- **wdm 0.2.7** — `find_package(wdm 0.2.7 QUIET)` with a **FetchContent
   fallback** that clones `tnagler/wdm`. Installed under
   `<prefix>/include/vinecopulib/wdm/`.
 - **Threads** — required.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -502,7 +502,8 @@ For any behavior change:
 - **`FitControlsVinecop`**
   ([fit_controls.hpp](include/vinecopulib/vinecop/fit_controls.hpp))
   inherits `FitControlsBicop` and adds the structure knobs: `trunc_lvl`,
-  `tree_criterion` (`"tau"`/`"rho"`/`"hoeffd"`/`"mcor"`/`"joe"`/`"custom"`,
+  `tree_criterion`
+  (`"tau"`/`"rho"`/`"hoeffd"`/`"mcor"`/`"cxi"`/`"joe"`/`"custom"`,
   the last backed by `tree_criterion_function`), `threshold`,
   `tree_algorithm` (`"mst_prim"` default, `"mst_kruskal"`,
   `"random_weighted"`, `"random_unweighted"`), `select_trunc_lvl` /

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -248,7 +248,7 @@ Discovered in
   behind `tree_algorithm`), **Math** (distributions, constants, special
   functions, `quadrature::tanh_sinh` for 1-d integration, `tools::minima`),
   and **Random** (`mt19937`, behind QRNG scrambling and structure simulation).
-- **wdm 0.2.7** — `find_package(wdm 0.2.7 QUIET)` with a **FetchContent
+- **wdm 0.3.0** — `find_package(wdm 0.3.0 QUIET)` with a **FetchContent
   fallback** that clones `tnagler/wdm`. Installed under
   `<prefix>/include/vinecopulib/wdm/`.
 - **Threads** — required.

--- a/NEWS.md
+++ b/NEWS.md
@@ -64,6 +64,13 @@ wrong thing.
 
 ### BEHAVIOR CHANGES
 
+* `to_pseudo_obs(..., "random")` returns different values for a given seed, and
+  every discrete `tll` fit moves with it, because the jitter it applies goes
+  through that path. wdm's random tie-breaking assigned its offsets one step out
+  of phase, so a tie group of two always came out equal and larger groups lost
+  one rank; ranks are now a permutation of `1, ..., n` as intended. Requires the
+  wdm bump under BUILD SYSTEM AND DEPENDENCIES (#754)
+
 * `Vinecop::fit` throws when the model has no pair copulas to fit, rather than
   returning and leaving it unfitted, and a model whose structure is truncated at
   zero records the independence fit (`loglik` 0) instead; see BUG FIXES (#752)
@@ -108,8 +115,7 @@ wrong thing.
 * Add `"cxi"` as a `tree_criterion`, weighting edges by Chatterjee's xi
   symmetrized as `max(xi(X, Y), xi(Y, X))`. Like `"hoeffd"` it picks up
   non-monotonic dependence, and unlike it, it detects functional relationships
-  even when they are not smooth. Requires wdm at commit `ca1c0bd` or later, so
-  the pinned version was bumped (#754)
+  even when they are not smooth (#754)
 
 * `Vinecop::reorient` and conditioning-aware selection now support truncated
   models. Only the trees a model stores take part in the re-orientation and the
@@ -281,6 +287,12 @@ wrong thing.
   (#676)
 
 ### BUILD SYSTEM AND DEPENDENCIES
+
+* Require wdm at commit `e13b5f6` or later, for Chatterjee's xi and for the
+  random tie-breaking fix. Since xi carries wdm's unchanged `0.2.6` version
+  number, `find_package` cannot rule out an older installation on the version
+  alone, so the include directory it reports is checked for `wdm/cxi.hpp`
+  (#754)
 
 * Regenerate the precompiled translation units when the header they are derived
   from changes. The `.ipp` to `.cpp` translation runs at configure time, and

--- a/NEWS.md
+++ b/NEWS.md
@@ -288,7 +288,7 @@ wrong thing.
 
 ### BUILD SYSTEM AND DEPENDENCIES
 
-* Require wdm 0.2.7, for Chatterjee's xi and for the random tie-breaking fix
+* Require wdm 0.3.0, for Chatterjee's xi and for the random tie-breaking fix
   (#754)
 
 * Fix `-Dwdm_INCLUDE_DIRS=<path>`, which configured but failed every link with

--- a/NEWS.md
+++ b/NEWS.md
@@ -108,7 +108,7 @@ wrong thing.
 * Add `"cxi"` as a `tree_criterion`, weighting edges by Chatterjee's xi
   symmetrized as `max(xi(X, Y), xi(Y, X))`. Like `"hoeffd"` it picks up
   non-monotonic dependence, and unlike it, it detects functional relationships
-  even when they are not smooth. Requires wdm at commit `61a88ac` or later, so
+  even when they are not smooth. Requires wdm at commit `ca1c0bd` or later, so
   the pinned version was bumped (#754)
 
 * `Vinecop::reorient` and conditioning-aware selection now support truncated

--- a/NEWS.md
+++ b/NEWS.md
@@ -290,9 +290,13 @@ wrong thing.
 
 * Require wdm at commit `6b85eeb` or later, for Chatterjee's xi and for the
   random tie-breaking fix. Since xi carries wdm's unchanged `0.2.6` version
-  number, `find_package` cannot rule out an older installation on the version
-  alone, so the include directory it reports is checked for `wdm/cxi.hpp`
-  (#754)
+  number, no version check can rule out an older wdm, so whichever include
+  directory is used is checked for `wdm/cxi.hpp` (#754)
+
+* Fix `-Dwdm_INCLUDE_DIRS=<path>`, which configured but failed every link with
+  `cannot find -lwdm`: the build links wdm by target name, and that target is
+  only defined on the `find_package` and FetchContent paths. It is now defined
+  for a caller-supplied path too (#754)
 
 * Regenerate the precompiled translation units when the header they are derived
   from changes. The `.ipp` to `.cpp` translation runs at configure time, and

--- a/NEWS.md
+++ b/NEWS.md
@@ -105,6 +105,12 @@ wrong thing.
 
 ### NEW FEATURES
 
+* Add `"cxi"` as a `tree_criterion`, weighting edges by Chatterjee's xi
+  symmetrized as `max(xi(X, Y), xi(Y, X))`. Like `"hoeffd"` it picks up
+  non-monotonic dependence, and unlike it, it detects functional relationships
+  even when they are not smooth. Requires wdm at commit `61a88ac` or later, so
+  the pinned version was bumped (#754)
+
 * `Vinecop::reorient` and conditioning-aware selection now support truncated
   models. Only the trees a model stores take part in the re-orientation and the
   truncation level is preserved, so `FitControlsVinecop::set_conditioning_set()`

--- a/NEWS.md
+++ b/NEWS.md
@@ -288,10 +288,8 @@ wrong thing.
 
 ### BUILD SYSTEM AND DEPENDENCIES
 
-* Require wdm at commit `6b85eeb` or later, for Chatterjee's xi and for the
-  random tie-breaking fix. Since xi carries wdm's unchanged `0.2.6` version
-  number, no version check can rule out an older wdm, so whichever include
-  directory is used is checked for `wdm/cxi.hpp` (#754)
+* Require wdm 0.2.7, for Chatterjee's xi and for the random tie-breaking fix
+  (#754)
 
 * Fix `-Dwdm_INCLUDE_DIRS=<path>`, which configured but failed every link with
   `cannot find -lwdm`: the build links wdm by target name, and that target is

--- a/NEWS.md
+++ b/NEWS.md
@@ -64,6 +64,13 @@ wrong thing.
 
 ### BEHAVIOR CHANGES
 
+* `to_pseudo_obs(..., "random")` returns different values for a given seed, and
+  every discrete `tll` fit moves with it, because the jitter it applies goes
+  through that path. wdm's random tie-breaking assigned its offsets one step out
+  of phase, so a tie group of two always came out equal and larger groups lost
+  one rank; ranks are now a permutation of `1, ..., n` as intended. Requires the
+  wdm bump under BUILD SYSTEM AND DEPENDENCIES (#754)
+
 * `Vinecop::fit` throws when the model has no pair copulas to fit, rather than
   returning and leaving it unfitted, and a model whose structure is truncated at
   zero records the independence fit (`loglik` 0) instead; see BUG FIXES (#752)
@@ -281,10 +288,11 @@ wrong thing.
 
 ### BUILD SYSTEM AND DEPENDENCIES
 
-* Require wdm at commit `03651d7` or later, for Chatterjee's xi. Since xi
-  carries wdm's unchanged `0.2.6` version number, `find_package` cannot rule out
-  an older installation on the version alone, so the include directory it
-  reports is checked for `wdm/cxi.hpp` (#754)
+* Require wdm at commit `1c444ae` or later, for Chatterjee's xi and for the
+  random tie-breaking fix. Since xi carries wdm's unchanged `0.2.6` version
+  number, `find_package` cannot rule out an older installation on the version
+  alone, so the include directory it reports is checked for `wdm/cxi.hpp`
+  (#754)
 
 * Regenerate the precompiled translation units when the header they are derived
   from changes. The `.ipp` to `.cpp` translation runs at configure time, and

--- a/NEWS.md
+++ b/NEWS.md
@@ -64,13 +64,6 @@ wrong thing.
 
 ### BEHAVIOR CHANGES
 
-* `to_pseudo_obs(..., "random")` returns different values for a given seed, and
-  every discrete `tll` fit moves with it, because the jitter it applies goes
-  through that path. wdm's random tie-breaking assigned its offsets one step out
-  of phase, so a tie group of two always came out equal and larger groups lost
-  one rank; ranks are now a permutation of `1, ..., n` as intended. Requires the
-  wdm bump under BUILD SYSTEM AND DEPENDENCIES (#754)
-
 * `Vinecop::fit` throws when the model has no pair copulas to fit, rather than
   returning and leaving it unfitted, and a model whose structure is truncated at
   zero records the independence fit (`loglik` 0) instead; see BUG FIXES (#752)
@@ -288,11 +281,10 @@ wrong thing.
 
 ### BUILD SYSTEM AND DEPENDENCIES
 
-* Require wdm at commit `e13b5f6` or later, for Chatterjee's xi and for the
-  random tie-breaking fix. Since xi carries wdm's unchanged `0.2.6` version
-  number, `find_package` cannot rule out an older installation on the version
-  alone, so the include directory it reports is checked for `wdm/cxi.hpp`
-  (#754)
+* Require wdm at commit `03651d7` or later, for Chatterjee's xi. Since xi
+  carries wdm's unchanged `0.2.6` version number, `find_package` cannot rule out
+  an older installation on the version alone, so the include directory it
+  reports is checked for `wdm/cxi.hpp` (#754)
 
 * Regenerate the precompiled translation units when the header they are derived
   from changes. The `.ipp` to `.cpp` translation runs at configure time, and

--- a/NEWS.md
+++ b/NEWS.md
@@ -288,7 +288,7 @@ wrong thing.
 
 ### BUILD SYSTEM AND DEPENDENCIES
 
-* Require wdm at commit `1c444ae` or later, for Chatterjee's xi and for the
+* Require wdm at commit `6b85eeb` or later, for Chatterjee's xi and for the
   random tie-breaking fix. Since xi carries wdm's unchanged `0.2.6` version
   number, `find_package` cannot rule out an older installation on the version
   alone, so the include directory it reports is checked for `wdm/cxi.hpp`

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ algorithms for both vine copula and bivariate copula models — with
 | CMake | **3.14** or later |
 | [Eigen](https://eigen.tuxfamily.org/) | 3.3 or later |
 | [Boost](https://www.boost.org/) | **1.75** or later (headers only) |
-| [wdm](https://github.com/tnagler/wdm) | commit `e13b5f6` or later (post-0.2.6, for Chatterjee's xi) — found via `find_package`, otherwise fetched at configure time |
+| [wdm](https://github.com/tnagler/wdm) | commit `03651d7` or later (post-0.2.6, for Chatterjee's xi) — found via `find_package`, otherwise fetched at configure time |
 | R (optional) | only for the parity tests, with VineCopula >= 2.6.2 |
 
 ## Quickstart

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ algorithms for both vine copula and bivariate copula models — with
 | CMake | **3.14** or later |
 | [Eigen](https://eigen.tuxfamily.org/) | 3.3 or later |
 | [Boost](https://www.boost.org/) | **1.75** or later (headers only) |
-| [wdm](https://github.com/tnagler/wdm) | commit `03651d7` or later (post-0.2.6, for Chatterjee's xi) — found via `find_package`, otherwise fetched at configure time |
+| [wdm](https://github.com/tnagler/wdm) | commit `1c444ae` or later (post-0.2.6, for Chatterjee's xi) — found via `find_package`, otherwise fetched at configure time |
 | R (optional) | only for the parity tests, with VineCopula >= 2.6.2 |
 
 ## Quickstart

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ algorithms for both vine copula and bivariate copula models — with
 | CMake | **3.14** or later |
 | [Eigen](https://eigen.tuxfamily.org/) | 3.3 or later |
 | [Boost](https://www.boost.org/) | **1.75** or later (headers only) |
-| [wdm](https://github.com/tnagler/wdm) | 0.2.6 — found via `find_package`, otherwise fetched at configure time |
+| [wdm](https://github.com/tnagler/wdm) | commit `61a88ac` or later (post-0.2.6, for Chatterjee's xi) — found via `find_package`, otherwise fetched at configure time |
 | R (optional) | only for the parity tests, with VineCopula >= 2.6.2 |
 
 ## Quickstart

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ algorithms for both vine copula and bivariate copula models — with
 | CMake | **3.14** or later |
 | [Eigen](https://eigen.tuxfamily.org/) | 3.3 or later |
 | [Boost](https://www.boost.org/) | **1.75** or later (headers only) |
-| [wdm](https://github.com/tnagler/wdm) | commit `6b85eeb` or later (post-0.2.6, for Chatterjee's xi) — found via `find_package`, otherwise fetched at configure time |
+| [wdm](https://github.com/tnagler/wdm) | **0.2.7** or later — found via `find_package`, otherwise fetched at configure time |
 | R (optional) | only for the parity tests, with VineCopula >= 2.6.2 |
 
 ## Quickstart

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ algorithms for both vine copula and bivariate copula models — with
 | CMake | **3.14** or later |
 | [Eigen](https://eigen.tuxfamily.org/) | 3.3 or later |
 | [Boost](https://www.boost.org/) | **1.75** or later (headers only) |
-| [wdm](https://github.com/tnagler/wdm) | commit `61a88ac` or later (post-0.2.6, for Chatterjee's xi) — found via `find_package`, otherwise fetched at configure time |
+| [wdm](https://github.com/tnagler/wdm) | commit `ca1c0bd` or later (post-0.2.6, for Chatterjee's xi) — found via `find_package`, otherwise fetched at configure time |
 | R (optional) | only for the parity tests, with VineCopula >= 2.6.2 |
 
 ## Quickstart

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ algorithms for both vine copula and bivariate copula models — with
 | CMake | **3.14** or later |
 | [Eigen](https://eigen.tuxfamily.org/) | 3.3 or later |
 | [Boost](https://www.boost.org/) | **1.75** or later (headers only) |
-| [wdm](https://github.com/tnagler/wdm) | **0.2.7** or later — found via `find_package`, otherwise fetched at configure time |
+| [wdm](https://github.com/tnagler/wdm) | **0.3.0** or later — found via `find_package`, otherwise fetched at configure time |
 | R (optional) | only for the parity tests, with VineCopula >= 2.6.2 |
 
 ## Quickstart

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ algorithms for both vine copula and bivariate copula models — with
 | CMake | **3.14** or later |
 | [Eigen](https://eigen.tuxfamily.org/) | 3.3 or later |
 | [Boost](https://www.boost.org/) | **1.75** or later (headers only) |
-| [wdm](https://github.com/tnagler/wdm) | commit `ca1c0bd` or later (post-0.2.6, for Chatterjee's xi) — found via `find_package`, otherwise fetched at configure time |
+| [wdm](https://github.com/tnagler/wdm) | commit `e13b5f6` or later (post-0.2.6, for Chatterjee's xi) — found via `find_package`, otherwise fetched at configure time |
 | R (optional) | only for the parity tests, with VineCopula >= 2.6.2 |
 
 ## Quickstart

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ algorithms for both vine copula and bivariate copula models — with
 | CMake | **3.14** or later |
 | [Eigen](https://eigen.tuxfamily.org/) | 3.3 or later |
 | [Boost](https://www.boost.org/) | **1.75** or later (headers only) |
-| [wdm](https://github.com/tnagler/wdm) | commit `1c444ae` or later (post-0.2.6, for Chatterjee's xi) — found via `find_package`, otherwise fetched at configure time |
+| [wdm](https://github.com/tnagler/wdm) | commit `6b85eeb` or later (post-0.2.6, for Chatterjee's xi) — found via `find_package`, otherwise fetched at configure time |
 | R (optional) | only for the parity tests, with VineCopula >= 2.6.2 |
 
 ## Quickstart

--- a/cmake/findDependencies.cmake
+++ b/cmake/findDependencies.cmake
@@ -50,7 +50,7 @@ if(NOT DEFINED wdm_INCLUDE_DIRS)
     FetchContent_Declare(
       wdm
       GIT_REPOSITORY https://github.com/tnagler/wdm.git
-      GIT_TAG        ae077fccacbb4ba980cb5e7dbc14105f821ea98e # tnagler/wdm#26; 0.3.0 is not tagged
+      GIT_TAG        v0.3.0
     )
     FetchContent_MakeAvailable(wdm)
     set(wdm_INCLUDE_DIRS "${wdm_SOURCE_DIR}/include")

--- a/cmake/findDependencies.cmake
+++ b/cmake/findDependencies.cmake
@@ -43,14 +43,14 @@ find_package(Threads                      REQUIRED)
 # Check if wdm_INCLUDE_DIRS is defined and if not, try to find it
 if(NOT DEFINED wdm_INCLUDE_DIRS)
   # Download if not found
-  # 0.2.7 for Chatterjee's xi; do not lower.
-  find_package(wdm 0.2.7 QUIET)
+  # 0.3.0 for Chatterjee's xi; do not lower.
+  find_package(wdm 0.3.0 QUIET)
   if(NOT wdm_FOUND)
     include(FetchContent)
     FetchContent_Declare(
       wdm
       GIT_REPOSITORY https://github.com/tnagler/wdm.git
-      GIT_TAG        536099dbc8da175b8e3ad63edc335a6e4f1d36e3 # the 0.2.7 bump; no tag yet
+      GIT_TAG        ae077fccacbb4ba980cb5e7dbc14105f821ea98e # tnagler/wdm#26; 0.3.0 is not tagged
     )
     FetchContent_MakeAvailable(wdm)
     set(wdm_INCLUDE_DIRS "${wdm_SOURCE_DIR}/include")

--- a/cmake/findDependencies.cmake
+++ b/cmake/findDependencies.cmake
@@ -49,11 +49,19 @@ if(NOT DEFINED wdm_INCLUDE_DIRS)
     FetchContent_Declare(
       wdm
       GIT_REPOSITORY https://github.com/tnagler/wdm.git
-      GIT_TAG        c837460853570690ccd9367c059e41b851d6f816 # v0.2.6
+      GIT_TAG        61a88acce7b6c379557638e3c6e5baaac1417709 # post-v0.2.6
     )
     FetchContent_MakeAvailable(wdm)
     set(wdm_INCLUDE_DIRS "${wdm_SOURCE_DIR}/include")
   else()
+    # Chatterjee's xi carries wdm's 0.2.6 version number, so the version check
+    # above cannot rule out an installation that predates it.
+    if(NOT EXISTS "${wdm_INCLUDE_DIRS}/wdm/cxi.hpp")
+      message(FATAL_ERROR "The wdm installation at ${wdm_INCLUDE_DIRS} is "
+              "missing wdm/cxi.hpp, which the \"cxi\" tree criterion needs. "
+              "Install wdm from commit 61a88ac or later, or point wdm_DIR at "
+              "an installation that has it.")
+    endif()
     message(STATUS "Found wdm: ${wdm_INCLUDE_DIRS} (found suitable version \"${wdm_VERSION}\")")
   endif()
 endif()

--- a/cmake/findDependencies.cmake
+++ b/cmake/findDependencies.cmake
@@ -49,7 +49,7 @@ if(NOT DEFINED wdm_INCLUDE_DIRS)
     FetchContent_Declare(
       wdm
       GIT_REPOSITORY https://github.com/tnagler/wdm.git
-      GIT_TAG        1c444ae923104987abf537ac022a09cbd215647b # tnagler/wdm#17
+      GIT_TAG        6b85eebc3e0097672be1047f6f43848bc77acb52 # tnagler/wdm#17
     )
     FetchContent_MakeAvailable(wdm)
     set(wdm_INCLUDE_DIRS "${wdm_SOURCE_DIR}/include")
@@ -59,7 +59,7 @@ if(NOT DEFINED wdm_INCLUDE_DIRS)
     if(NOT EXISTS "${wdm_INCLUDE_DIRS}/wdm/cxi.hpp")
       message(FATAL_ERROR "The wdm installation at ${wdm_INCLUDE_DIRS} is "
               "missing wdm/cxi.hpp, which the \"cxi\" tree criterion needs. "
-              "Install wdm from commit 1c444ae or later, or point wdm_DIR at "
+              "Install wdm from commit 6b85eeb or later, or point wdm_DIR at "
               "an installation that has it.")
     endif()
     message(STATUS "Found wdm: ${wdm_INCLUDE_DIRS} (found suitable version \"${wdm_VERSION}\")")

--- a/cmake/findDependencies.cmake
+++ b/cmake/findDependencies.cmake
@@ -43,29 +43,20 @@ find_package(Threads                      REQUIRED)
 # Check if wdm_INCLUDE_DIRS is defined and if not, try to find it
 if(NOT DEFINED wdm_INCLUDE_DIRS)
   # Download if not found
-  find_package(wdm 0.2.6 QUIET)
+  # 0.2.7 for Chatterjee's xi; do not lower.
+  find_package(wdm 0.2.7 QUIET)
   if(NOT wdm_FOUND)
     include(FetchContent)
     FetchContent_Declare(
       wdm
       GIT_REPOSITORY https://github.com/tnagler/wdm.git
-      GIT_TAG        6b85eebc3e0097672be1047f6f43848bc77acb52 # tnagler/wdm#17
+      GIT_TAG        536099dbc8da175b8e3ad63edc335a6e4f1d36e3 # the 0.2.7 bump; no tag yet
     )
     FetchContent_MakeAvailable(wdm)
     set(wdm_INCLUDE_DIRS "${wdm_SOURCE_DIR}/include")
   else()
     message(STATUS "Found wdm: ${wdm_INCLUDE_DIRS} (found suitable version \"${wdm_VERSION}\")")
   endif()
-endif()
-
-# Chatterjee's xi carries wdm's 0.2.6 version number, so neither the version
-# check above nor a caller-supplied wdm_INCLUDE_DIRS can rule out a wdm that
-# predates it.
-if(NOT EXISTS "${wdm_INCLUDE_DIRS}/wdm/cxi.hpp")
-  message(FATAL_ERROR "The wdm at ${wdm_INCLUDE_DIRS} is missing wdm/cxi.hpp, "
-          "which the \"cxi\" tree criterion needs. Point wdm_DIR or "
-          "wdm_INCLUDE_DIRS at wdm 6b85eeb or later, or unset both to have it "
-          "fetched at configure time.")
 endif()
 
 # The build links wdm by target name, which find_package and FetchContent both

--- a/cmake/findDependencies.cmake
+++ b/cmake/findDependencies.cmake
@@ -49,7 +49,7 @@ if(NOT DEFINED wdm_INCLUDE_DIRS)
     FetchContent_Declare(
       wdm
       GIT_REPOSITORY https://github.com/tnagler/wdm.git
-      GIT_TAG        ca1c0bd95dd9bff91b305b5af834d745d21ea03d # tnagler/wdm#18
+      GIT_TAG        e13b5f61191620be234ac04f8d9bc8680e4248b9 # tnagler/wdm#17
     )
     FetchContent_MakeAvailable(wdm)
     set(wdm_INCLUDE_DIRS "${wdm_SOURCE_DIR}/include")
@@ -59,7 +59,7 @@ if(NOT DEFINED wdm_INCLUDE_DIRS)
     if(NOT EXISTS "${wdm_INCLUDE_DIRS}/wdm/cxi.hpp")
       message(FATAL_ERROR "The wdm installation at ${wdm_INCLUDE_DIRS} is "
               "missing wdm/cxi.hpp, which the \"cxi\" tree criterion needs. "
-              "Install wdm from commit ca1c0bd or later, or point wdm_DIR at "
+              "Install wdm from commit e13b5f6 or later, or point wdm_DIR at "
               "an installation that has it.")
     endif()
     message(STATUS "Found wdm: ${wdm_INCLUDE_DIRS} (found suitable version \"${wdm_VERSION}\")")

--- a/cmake/findDependencies.cmake
+++ b/cmake/findDependencies.cmake
@@ -54,16 +54,27 @@ if(NOT DEFINED wdm_INCLUDE_DIRS)
     FetchContent_MakeAvailable(wdm)
     set(wdm_INCLUDE_DIRS "${wdm_SOURCE_DIR}/include")
   else()
-    # Chatterjee's xi carries wdm's 0.2.6 version number, so the version check
-    # above cannot rule out an installation that predates it.
-    if(NOT EXISTS "${wdm_INCLUDE_DIRS}/wdm/cxi.hpp")
-      message(FATAL_ERROR "The wdm installation at ${wdm_INCLUDE_DIRS} is "
-              "missing wdm/cxi.hpp, which the \"cxi\" tree criterion needs. "
-              "Install wdm from commit 6b85eeb or later, or point wdm_DIR at "
-              "an installation that has it.")
-    endif()
     message(STATUS "Found wdm: ${wdm_INCLUDE_DIRS} (found suitable version \"${wdm_VERSION}\")")
   endif()
+endif()
+
+# Chatterjee's xi carries wdm's 0.2.6 version number, so neither the version
+# check above nor a caller-supplied wdm_INCLUDE_DIRS can rule out a wdm that
+# predates it.
+if(NOT EXISTS "${wdm_INCLUDE_DIRS}/wdm/cxi.hpp")
+  message(FATAL_ERROR "The wdm at ${wdm_INCLUDE_DIRS} is missing wdm/cxi.hpp, "
+          "which the \"cxi\" tree criterion needs. Point wdm_DIR or "
+          "wdm_INCLUDE_DIRS at wdm 6b85eeb or later, or unset both to have it "
+          "fetched at configure time.")
+endif()
+
+# The build links wdm by target name, which find_package and FetchContent both
+# define but a caller-supplied wdm_INCLUDE_DIRS does not. Without this the name
+# is taken for a library to search for, and every link fails on -lwdm.
+if(NOT TARGET wdm)
+  add_library(wdm INTERFACE IMPORTED GLOBAL)
+  set_target_properties(wdm PROPERTIES
+                        INTERFACE_INCLUDE_DIRECTORIES "${wdm_INCLUDE_DIRS}")
 endif()
 
 # Ensure R is available and download googlestest

--- a/cmake/findDependencies.cmake
+++ b/cmake/findDependencies.cmake
@@ -49,7 +49,7 @@ if(NOT DEFINED wdm_INCLUDE_DIRS)
     FetchContent_Declare(
       wdm
       GIT_REPOSITORY https://github.com/tnagler/wdm.git
-      GIT_TAG        03651d719152ee1ba28578ee737e919ff19abb73 # tnagler/wdm#18
+      GIT_TAG        1c444ae923104987abf537ac022a09cbd215647b # tnagler/wdm#17
     )
     FetchContent_MakeAvailable(wdm)
     set(wdm_INCLUDE_DIRS "${wdm_SOURCE_DIR}/include")
@@ -59,7 +59,7 @@ if(NOT DEFINED wdm_INCLUDE_DIRS)
     if(NOT EXISTS "${wdm_INCLUDE_DIRS}/wdm/cxi.hpp")
       message(FATAL_ERROR "The wdm installation at ${wdm_INCLUDE_DIRS} is "
               "missing wdm/cxi.hpp, which the \"cxi\" tree criterion needs. "
-              "Install wdm from commit 03651d7 or later, or point wdm_DIR at "
+              "Install wdm from commit 1c444ae or later, or point wdm_DIR at "
               "an installation that has it.")
     endif()
     message(STATUS "Found wdm: ${wdm_INCLUDE_DIRS} (found suitable version \"${wdm_VERSION}\")")

--- a/cmake/findDependencies.cmake
+++ b/cmake/findDependencies.cmake
@@ -49,7 +49,7 @@ if(NOT DEFINED wdm_INCLUDE_DIRS)
     FetchContent_Declare(
       wdm
       GIT_REPOSITORY https://github.com/tnagler/wdm.git
-      GIT_TAG        61a88acce7b6c379557638e3c6e5baaac1417709 # post-v0.2.6
+      GIT_TAG        ca1c0bd95dd9bff91b305b5af834d745d21ea03d # tnagler/wdm#18
     )
     FetchContent_MakeAvailable(wdm)
     set(wdm_INCLUDE_DIRS "${wdm_SOURCE_DIR}/include")
@@ -59,7 +59,7 @@ if(NOT DEFINED wdm_INCLUDE_DIRS)
     if(NOT EXISTS "${wdm_INCLUDE_DIRS}/wdm/cxi.hpp")
       message(FATAL_ERROR "The wdm installation at ${wdm_INCLUDE_DIRS} is "
               "missing wdm/cxi.hpp, which the \"cxi\" tree criterion needs. "
-              "Install wdm from commit 61a88ac or later, or point wdm_DIR at "
+              "Install wdm from commit ca1c0bd or later, or point wdm_DIR at "
               "an installation that has it.")
     endif()
     message(STATUS "Found wdm: ${wdm_INCLUDE_DIRS} (found suitable version \"${wdm_VERSION}\")")

--- a/cmake/findDependencies.cmake
+++ b/cmake/findDependencies.cmake
@@ -49,7 +49,7 @@ if(NOT DEFINED wdm_INCLUDE_DIRS)
     FetchContent_Declare(
       wdm
       GIT_REPOSITORY https://github.com/tnagler/wdm.git
-      GIT_TAG        e13b5f61191620be234ac04f8d9bc8680e4248b9 # tnagler/wdm#17
+      GIT_TAG        03651d719152ee1ba28578ee737e919ff19abb73 # tnagler/wdm#18
     )
     FetchContent_MakeAvailable(wdm)
     set(wdm_INCLUDE_DIRS "${wdm_SOURCE_DIR}/include")
@@ -59,7 +59,7 @@ if(NOT DEFINED wdm_INCLUDE_DIRS)
     if(NOT EXISTS "${wdm_INCLUDE_DIRS}/wdm/cxi.hpp")
       message(FATAL_ERROR "The wdm installation at ${wdm_INCLUDE_DIRS} is "
               "missing wdm/cxi.hpp, which the \"cxi\" tree criterion needs. "
-              "Install wdm from commit e13b5f6 or later, or point wdm_DIR at "
+              "Install wdm from commit 03651d7 or later, or point wdm_DIR at "
               "an installation that has it.")
     endif()
     message(STATUS "Found wdm: ${wdm_INCLUDE_DIRS} (found suitable version \"${wdm_VERSION}\")")

--- a/docs/overview-vinecop.dox
+++ b/docs/overview-vinecop.dox
@@ -96,8 +96,10 @@ controls argument customizes the fit.
 - `std::string tree_criterion` — the edge-weighting criterion used to grow each
   tree: `"tau"` (default) for Kendall's tau, `"rho"` for Spearman's rho,
   `"hoeffd"` for Hoeffding's D (suited to non-monotonic relationships), `"mcor"`
-  for the maximum correlation, `"joe"` for the Gaussian-copula mutual
-  information, or `"custom"` for a user-supplied callable set through
+  for the maximum correlation, `"cxi"` for Chatterjee's xi symmetrized as
+  \f$ \max\{\xi(X, Y), \xi(Y, X)\} \f$ (also suited to non-monotonic
+  relationships), `"joe"` for the Gaussian-copula mutual information, or
+  `"custom"` for a user-supplied callable set through
   `set_tree_criterion_function()`, which is always evaluated on the calling
   thread.
 - `double threshold` — pair copulas whose weight falls below this are set to

--- a/docs/setup.dox
+++ b/docs/setup.dox
@@ -18,7 +18,7 @@ To build the library, you'll need at minimum:
    - [CMake 3.14 (or later)](https://cmake.org/)
    - [Boost 1.75 (or later)](http://www.boost.org/)
    - [Eigen 3.3 (or later)](http://eigen.tuxfamily.org/index.php?title=Main_Page)
-   - [wdm 0.2.7 (or later)](https://github.com/tnagler/wdm)
+   - [wdm 0.3.0 (or later)](https://github.com/tnagler/wdm)
 
 
 On Linux or OSX, you can install wdm with:

--- a/docs/setup.dox
+++ b/docs/setup.dox
@@ -18,7 +18,7 @@ To build the library, you'll need at minimum:
    - [CMake 3.14 (or later)](https://cmake.org/)
    - [Boost 1.75 (or later)](http://www.boost.org/)
    - [Eigen 3.3 (or later)](http://eigen.tuxfamily.org/index.php?title=Main_Page)
-   - [wdm](https://github.com/tnagler/wdm) (commit `1c444ae` or later)
+   - [wdm](https://github.com/tnagler/wdm) (commit `6b85eeb` or later)
 
 
 On Linux or OSX, you can install wdm with:

--- a/docs/setup.dox
+++ b/docs/setup.dox
@@ -18,7 +18,7 @@ To build the library, you'll need at minimum:
    - [CMake 3.14 (or later)](https://cmake.org/)
    - [Boost 1.75 (or later)](http://www.boost.org/)
    - [Eigen 3.3 (or later)](http://eigen.tuxfamily.org/index.php?title=Main_Page)
-   - [wdm](https://github.com/tnagler/wdm) (commit `03651d7` or later)
+   - [wdm](https://github.com/tnagler/wdm) (commit `1c444ae` or later)
 
 
 On Linux or OSX, you can install wdm with:

--- a/docs/setup.dox
+++ b/docs/setup.dox
@@ -18,7 +18,7 @@ To build the library, you'll need at minimum:
    - [CMake 3.14 (or later)](https://cmake.org/)
    - [Boost 1.75 (or later)](http://www.boost.org/)
    - [Eigen 3.3 (or later)](http://eigen.tuxfamily.org/index.php?title=Main_Page)
-   - [wdm](https://github.com/tnagler/wdm) (commit `61a88ac` or later)
+   - [wdm](https://github.com/tnagler/wdm) (commit `ca1c0bd` or later)
 
 
 On Linux or OSX, you can install wdm with:

--- a/docs/setup.dox
+++ b/docs/setup.dox
@@ -18,7 +18,7 @@ To build the library, you'll need at minimum:
    - [CMake 3.14 (or later)](https://cmake.org/)
    - [Boost 1.75 (or later)](http://www.boost.org/)
    - [Eigen 3.3 (or later)](http://eigen.tuxfamily.org/index.php?title=Main_Page)
-   - [wdm](https://github.com/tnagler/wdm)
+   - [wdm](https://github.com/tnagler/wdm) (commit `61a88ac` or later)
 
 
 On Linux or OSX, you can install wdm with:

--- a/docs/setup.dox
+++ b/docs/setup.dox
@@ -18,7 +18,7 @@ To build the library, you'll need at minimum:
    - [CMake 3.14 (or later)](https://cmake.org/)
    - [Boost 1.75 (or later)](http://www.boost.org/)
    - [Eigen 3.3 (or later)](http://eigen.tuxfamily.org/index.php?title=Main_Page)
-   - [wdm](https://github.com/tnagler/wdm) (commit `6b85eeb` or later)
+   - [wdm 0.2.7 (or later)](https://github.com/tnagler/wdm)
 
 
 On Linux or OSX, you can install wdm with:

--- a/docs/setup.dox
+++ b/docs/setup.dox
@@ -18,7 +18,7 @@ To build the library, you'll need at minimum:
    - [CMake 3.14 (or later)](https://cmake.org/)
    - [Boost 1.75 (or later)](http://www.boost.org/)
    - [Eigen 3.3 (or later)](http://eigen.tuxfamily.org/index.php?title=Main_Page)
-   - [wdm](https://github.com/tnagler/wdm) (commit `ca1c0bd` or later)
+   - [wdm](https://github.com/tnagler/wdm) (commit `e13b5f6` or later)
 
 
 On Linux or OSX, you can install wdm with:

--- a/docs/setup.dox
+++ b/docs/setup.dox
@@ -18,7 +18,7 @@ To build the library, you'll need at minimum:
    - [CMake 3.14 (or later)](https://cmake.org/)
    - [Boost 1.75 (or later)](http://www.boost.org/)
    - [Eigen 3.3 (or later)](http://eigen.tuxfamily.org/index.php?title=Main_Page)
-   - [wdm](https://github.com/tnagler/wdm) (commit `e13b5f6` or later)
+   - [wdm](https://github.com/tnagler/wdm) (commit `03651d7` or later)
 
 
 On Linux or OSX, you can install wdm with:

--- a/include/vinecopulib/misc/implementation/tools_stats.ipp
+++ b/include/vinecopulib/misc/implementation/tools_stats.ipp
@@ -528,6 +528,27 @@ pairwise_mcor(const Eigen::MatrixXd& x, const Eigen::VectorXd& weights)
   Eigen::MatrixXd phi = ace(x, weights);
   return wdm::wdm(phi, "cor", weights)(0, 1);
 }
+
+//! @brief calculates the pairwise symmetrized Chatterjee's xi.
+//!
+//! Chatterjee's xi measures how well one variable is a measurable function of
+//! the other and is therefore asymmetric. The symmetrized version is the
+//! larger of the two directions, so it detects a functional relationship
+//! whichever way it runs.
+//!
+//! @literature
+//! Chatterjee, Sourav. *A New Coefficient of Correlation*. Journal of the
+//! American Statistical Association 116(536), 2009-2022, 2021
+inline double
+pairwise_cxi(const Eigen::MatrixXd& x, const Eigen::VectorXd& weights)
+{
+  double xi12 = wdm::wdm(x.col(0), x.col(1), "cxi", weights);
+  double xi21 = wdm::wdm(x.col(1), x.col(0), "cxi", weights);
+  if (std::isnan(xi12) || std::isnan(xi21)) {
+    return std::numeric_limits<double>::quiet_NaN();
+  }
+  return std::max(xi12, xi21);
+}
 //! @}
 
 //! @brief Simulates from the multivariate Generalized Halton Sequence.

--- a/include/vinecopulib/misc/implementation/tools_stats.ipp
+++ b/include/vinecopulib/misc/implementation/tools_stats.ipp
@@ -542,13 +542,8 @@ pairwise_mcor(const Eigen::MatrixXd& x, const Eigen::VectorXd& weights)
 inline double
 pairwise_cxi(const Eigen::MatrixXd& x, const Eigen::VectorXd& weights)
 {
-  // wdm breaks ties in the first argument at random, seeding from
-  // std::random_device when no seed is given. A fixed seed keeps the criterion
-  // a deterministic function of the data, and gives every pair the same
-  // tie-breaking realization.
-  static const std::vector<int> seeds = { 5 };
-  double xi12 = wdm::wdm(x.col(0), x.col(1), "cxi", weights, true, seeds);
-  double xi21 = wdm::wdm(x.col(1), x.col(0), "cxi", weights, true, seeds);
+  double xi12 = wdm::wdm(x.col(0), x.col(1), "cxi", weights);
+  double xi21 = wdm::wdm(x.col(1), x.col(0), "cxi", weights);
   if (std::isnan(xi12) || std::isnan(xi21)) {
     return std::numeric_limits<double>::quiet_NaN();
   }

--- a/include/vinecopulib/misc/implementation/tools_stats.ipp
+++ b/include/vinecopulib/misc/implementation/tools_stats.ipp
@@ -542,8 +542,13 @@ pairwise_mcor(const Eigen::MatrixXd& x, const Eigen::VectorXd& weights)
 inline double
 pairwise_cxi(const Eigen::MatrixXd& x, const Eigen::VectorXd& weights)
 {
-  double xi12 = wdm::wdm(x.col(0), x.col(1), "cxi", weights);
-  double xi21 = wdm::wdm(x.col(1), x.col(0), "cxi", weights);
+  // wdm breaks ties in the first argument at random, seeding from
+  // std::random_device when no seed is given. A fixed seed keeps the criterion
+  // a deterministic function of the data, and gives every pair the same
+  // tie-breaking realization.
+  static const std::vector<int> seeds = { 5 };
+  double xi12 = wdm::wdm(x.col(0), x.col(1), "cxi", weights, true, seeds);
+  double xi21 = wdm::wdm(x.col(1), x.col(0), "cxi", weights, true, seeds);
   if (std::isnan(xi12) || std::isnan(xi21)) {
     return std::numeric_limits<double>::quiet_NaN();
   }

--- a/include/vinecopulib/misc/tools_stats.hpp
+++ b/include/vinecopulib/misc/tools_stats.hpp
@@ -171,6 +171,10 @@ double
 pairwise_mcor(const Eigen::MatrixXd& x,
               const Eigen::VectorXd& weights = Eigen::VectorXd());
 
+double
+pairwise_cxi(const Eigen::MatrixXd& x,
+             const Eigen::VectorXd& weights = Eigen::VectorXd());
+
 Eigen::MatrixXd
 ghalton(const size_t& n,
         const size_t& d,

--- a/include/vinecopulib/vinecop/fit_controls.hpp
+++ b/include/vinecopulib/vinecop/fit_controls.hpp
@@ -61,7 +61,8 @@ public:
   size_t get_trunc_lvl() const;
 
   //! @return the edge-weighting criterion used to grow the structure
-  //! (one of `"tau"`, `"rho"`, `"hoeffd"`, `"mcor"`, `"joe"`, `"custom"`).
+  //! (one of `"tau"`, `"rho"`, `"hoeffd"`, `"mcor"`, `"cxi"`, `"joe"`,
+  //! `"custom"`).
   std::string get_tree_criterion() const;
 
   //! @return the custom edge-weight function used when `tree_criterion` is

--- a/include/vinecopulib/vinecop/implementation/class.ipp
+++ b/include/vinecopulib/vinecop/implementation/class.ipp
@@ -297,8 +297,8 @@ Vinecop::make_pair_copula_store(const size_t d, const size_t trunc_lvl)
 //! The dependence measure used to select trees (default: Kendall's tau) is
 //! corrected for ties (see the [wdm](https://github.com/tnagler/wdm) library).
 //! The dependence measure can be changed using `controls.tree_criterion`,
-//! which can be set to `"tau"`, `"rho"`, `"hoeffd"`, `"mcor"`, `"joe"`, or
-//! `"custom"`. The last one uses the callable supplied through
+//! which can be set to `"tau"`, `"rho"`, `"hoeffd"`, `"mcor"`, `"cxi"`,
+//! `"joe"`, or `"custom"`. The last one uses the callable supplied through
 //! `controls.tree_criterion_function`, which is always called on the thread
 //! that starts the fit, so it need not be thread safe; the pair-copula fits
 //! still use `controls.num_threads` threads.

--- a/include/vinecopulib/vinecop/implementation/fit_controls.ipp
+++ b/include/vinecopulib/vinecop/implementation/fit_controls.ipp
@@ -44,9 +44,9 @@ inline FitControlsVinecop::FitControlsVinecop()
 //!     the local-likelihood nonparametric family (TLLs).
 //! @param trunc_lvl Truncation level for truncated vines.
 //! @param tree_criterion The criterion for selecting the spanning
-//!     tree (`"tau"`, `"rho"`, `"hoeffd"`, `"mcor"`, `"joe"`, or `"custom"`)
-//!     during the tree-wise structure selection. `"custom"` uses the callable
-//!     set through `set_tree_criterion_function()`.
+//!     tree (`"tau"`, `"rho"`, `"hoeffd"`, `"mcor"`, `"cxi"`, `"joe"`, or
+//!     `"custom"`) during the tree-wise structure selection. `"custom"` uses
+//!     the callable set through `set_tree_criterion_function()`.
 //! @param threshold For thresholded vines (0 = no threshold).
 //! @param selection_criterion The selection criterion (`"loglik"`, `"aic"`,
 //!     `"bic"`, `"mbic"`, or `"mbicv"`) for the pair copula families.
@@ -131,9 +131,9 @@ inline FitControlsVinecop::FitControlsVinecop(
 //! @param controls See `FitControlsBicop()`.
 //! @param trunc_lvl Truncation level for truncated vines.
 //! @param tree_criterion The criterion for selecting the spanning
-//!     tree (`"tau"`, `"rho"`, `"hoeffd"`, `"mcor"`, `"joe"`, or `"custom"`)
-//!     during the tree-wise structure selection. `"custom"` uses the callable
-//!     set through `set_tree_criterion_function()`.
+//!     tree (`"tau"`, `"rho"`, `"hoeffd"`, `"mcor"`, `"cxi"`, `"joe"`, or
+//!     `"custom"`) during the tree-wise structure selection. `"custom"` uses
+//!     the callable set through `set_tree_criterion_function()`.
 //! @param threshold For thresholded vines (`0` = no threshold).
 //! @param show_trace Whether to show a trace of the building progress.
 //! @param select_trunc_lvl Whether the truncation shall be selected
@@ -226,10 +226,10 @@ FitControlsVinecop::check_tree_criterion(std::string tree_criterion)
 {
   if (!tools_stl::is_member(
         std::move(tree_criterion),
-        { "tau", "rho", "joe", "hoeffd", "mcor", "custom" })) {
+        { "tau", "rho", "joe", "hoeffd", "mcor", "cxi", "custom" })) {
     throw std::runtime_error("tree_criterion must be one of "
-                             "'tau', 'rho', 'hoeffd', 'mcor', 'joe', or "
-                             "'custom'");
+                             "'tau', 'rho', 'hoeffd', 'mcor', 'cxi', 'joe', "
+                             "or 'custom'");
   }
 }
 

--- a/include/vinecopulib/vinecop/implementation/tools_select.ipp
+++ b/include/vinecopulib/vinecop/implementation/tools_select.ipp
@@ -48,6 +48,8 @@ calculate_criterion_clean(const Eigen::MatrixXd& data,
       w = tree_criterion_function(data, weights);
     } else if (tree_criterion == "mcor") {
       w = tools_stats::pairwise_mcor(data, weights);
+    } else if (tree_criterion == "cxi") {
+      w = tools_stats::pairwise_cxi(data, weights);
     } else if (tree_criterion == "joe") {
       // mutual information for Gaussian copula
       w = wdm::wdm(tools_stats::qnorm(data), "pearson", weights)(0, 1);

--- a/test/src_test/test_tools_stats.cpp
+++ b/test/src_test/test_tools_stats.cpp
@@ -6,6 +6,7 @@
 
 #include "include/test_utils.hpp"
 #include "gtest/gtest.h"
+#include <algorithm>
 #include <vinecopulib.hpp>
 
 namespace test_tools_stats {
@@ -429,19 +430,29 @@ TEST(test_tools_stats, golden_pseudo_obs)
   random_exp <<
     0.090909090909090912, 0.90909090909090906,
     0.27272727272727271, 0.27272727272727271,
-    0.27272727272727271, 0.45454545454545453,
+    0.36363636363636365, 0.45454545454545453,
     0.72727272727272729, 0.090909090909090912,
     0.18181818181818182, 0.18181818181818182,
     0.90909090909090906, 0.54545454545454541,
-    0.54545454545454541, 0.54545454545454541,
+    0.63636363636363635, 0.63636363636363635,
     0.54545454545454541, 0.81818181818181823,
     0.81818181818181823, 0.36363636363636365,
     0.45454545454545453, 0.72727272727272729;
   // clang-format on
-  EXPECT_TRUE(all_close(
-    tools_stats::to_pseudo_obs(x, "random", Eigen::VectorXd(), { 17 }),
-    random_exp,
-    1e-14,
-    1e-14));
+  auto random_obs =
+    tools_stats::to_pseudo_obs(x, "random", Eigen::VectorXd(), { 17 });
+  EXPECT_TRUE(all_close(random_obs, random_exp, 1e-14, 1e-14));
+
+  // `"random"` breaks ties, so each column is a permutation of
+  // 1 / (n + 1), ..., n / (n + 1); golden values alone would not catch a tie
+  // group collapsing onto one rank.
+  double n = static_cast<double>(x.rows());
+  for (Eigen::Index j = 0; j < random_obs.cols(); ++j) {
+    Eigen::VectorXd sorted = random_obs.col(j);
+    std::sort(sorted.data(), sorted.data() + sorted.size());
+    for (Eigen::Index i = 0; i < sorted.size(); ++i) {
+      EXPECT_NEAR(sorted(i), (static_cast<double>(i) + 1.0) / (n + 1.0), 1e-14);
+    }
+  }
 }
 }

--- a/test/src_test/test_tools_stats.cpp
+++ b/test/src_test/test_tools_stats.cpp
@@ -105,6 +105,44 @@ TEST(test_tools_stats, mcor_works)
   ASSERT_TRUE(std::fabs(a1 - a2) < 0.05);
 }
 
+TEST(test_tools_stats, cxi_works)
+{
+  std::vector<int> seeds = { 1, 2, 3, 4, 5 };
+  Eigen::MatrixXd Z = tools_stats::simulate_uniform(2000, 2, false, seeds);
+  Z = tools_stats::qnorm(Z);
+
+  // under independence, xi is centered at zero
+  EXPECT_NEAR(tools_stats::pairwise_cxi(Z), 0.0, 0.1);
+
+  // a deterministic but non-monotonic relationship: Kendall's tau is blind to
+  // it, xi is not
+  Eigen::MatrixXd V(Z.rows(), 2);
+  V.col(0) = Z.col(0);
+  V.col(1) = Z.col(0).cwiseAbs2();
+  EXPECT_NEAR(std::fabs(wdm::wdm(V, "tau")(0, 1)), 0.0, 0.1);
+  EXPECT_GT(tools_stats::pairwise_cxi(V), 0.9);
+
+  // the two directions genuinely differ here, so taking the larger of them is
+  // what makes the criterion independent of the column order
+  double xi12 = wdm::wdm(V.col(0), V.col(1), "cxi");
+  double xi21 = wdm::wdm(V.col(1), V.col(0), "cxi");
+  EXPECT_GT(xi12 - xi21, 0.1);
+  Eigen::MatrixXd V_swapped(V.rows(), 2);
+  V_swapped.col(0) = V.col(1);
+  V_swapped.col(1) = V.col(0);
+  EXPECT_DOUBLE_EQ(tools_stats::pairwise_cxi(V),
+                   tools_stats::pairwise_cxi(V_swapped));
+
+  // uniform weights must not change anything, zero weights must drop rows
+  Eigen::VectorXd weights = Eigen::VectorXd::Ones(V.rows());
+  EXPECT_NEAR(
+    tools_stats::pairwise_cxi(V, weights), tools_stats::pairwise_cxi(V), 1e-10);
+  weights.tail(V.rows() / 2) = Eigen::VectorXd::Zero(V.rows() / 2);
+  EXPECT_NEAR(tools_stats::pairwise_cxi(V, weights),
+              tools_stats::pairwise_cxi(V.topRows(V.rows() / 2)),
+              0.05);
+}
+
 TEST(test_tools_stats, seed_works)
 {
   size_t d = 2;

--- a/test/src_test/test_tools_stats.cpp
+++ b/test/src_test/test_tools_stats.cpp
@@ -6,7 +6,6 @@
 
 #include "include/test_utils.hpp"
 #include "gtest/gtest.h"
-#include <algorithm>
 #include <vinecopulib.hpp>
 
 namespace test_tools_stats {
@@ -430,29 +429,19 @@ TEST(test_tools_stats, golden_pseudo_obs)
   random_exp <<
     0.090909090909090912, 0.90909090909090906,
     0.27272727272727271, 0.27272727272727271,
-    0.36363636363636365, 0.45454545454545453,
+    0.27272727272727271, 0.45454545454545453,
     0.72727272727272729, 0.090909090909090912,
     0.18181818181818182, 0.18181818181818182,
     0.90909090909090906, 0.54545454545454541,
-    0.63636363636363635, 0.63636363636363635,
+    0.54545454545454541, 0.54545454545454541,
     0.54545454545454541, 0.81818181818181823,
     0.81818181818181823, 0.36363636363636365,
     0.45454545454545453, 0.72727272727272729;
   // clang-format on
-  auto random_obs =
-    tools_stats::to_pseudo_obs(x, "random", Eigen::VectorXd(), { 17 });
-  EXPECT_TRUE(all_close(random_obs, random_exp, 1e-14, 1e-14));
-
-  // `"random"` breaks ties, so each column is a permutation of
-  // 1 / (n + 1), ..., n / (n + 1); golden values alone would not catch a tie
-  // group collapsing onto one rank.
-  double n = static_cast<double>(x.rows());
-  for (Eigen::Index j = 0; j < random_obs.cols(); ++j) {
-    Eigen::VectorXd sorted = random_obs.col(j);
-    std::sort(sorted.data(), sorted.data() + sorted.size());
-    for (Eigen::Index i = 0; i < sorted.size(); ++i) {
-      EXPECT_NEAR(sorted(i), (static_cast<double>(i) + 1.0) / (n + 1.0), 1e-14);
-    }
-  }
+  EXPECT_TRUE(all_close(
+    tools_stats::to_pseudo_obs(x, "random", Eigen::VectorXd(), { 17 }),
+    random_exp,
+    1e-14,
+    1e-14));
 }
 }

--- a/test/src_test/test_tools_stats.cpp
+++ b/test/src_test/test_tools_stats.cpp
@@ -142,6 +142,22 @@ TEST(test_tools_stats, cxi_works)
   EXPECT_NEAR(tools_stats::pairwise_cxi(V, weights),
               tools_stats::pairwise_cxi(V.topRows(V.rows() / 2)),
               0.05);
+
+  // ties are broken at random, so without a fixed seed the criterion would
+  // differ between calls on the same data and between the two column orders
+  Eigen::MatrixXd tied(60, 2);
+  for (Eigen::Index i = 0; i < tied.rows(); ++i) {
+    tied(i, 0) = static_cast<double>(i / 12) / 5.0;
+    tied(i, 1) = static_cast<double>(i % 12) / 11.0;
+  }
+  Eigen::MatrixXd tied_swapped(tied.rows(), 2);
+  tied_swapped.col(0) = tied.col(1);
+  tied_swapped.col(1) = tied.col(0);
+  double tied_cxi = tools_stats::pairwise_cxi(tied);
+  for (int rep = 0; rep < 5; ++rep) {
+    EXPECT_DOUBLE_EQ(tools_stats::pairwise_cxi(tied), tied_cxi);
+  }
+  EXPECT_DOUBLE_EQ(tools_stats::pairwise_cxi(tied_swapped), tied_cxi);
 }
 
 TEST(test_tools_stats, seed_works)

--- a/test/src_test/test_tools_stats.cpp
+++ b/test/src_test/test_tools_stats.cpp
@@ -143,8 +143,9 @@ TEST(test_tools_stats, cxi_works)
               tools_stats::pairwise_cxi(V.topRows(V.rows() / 2)),
               0.05);
 
-  // ties are broken at random, so without a fixed seed the criterion would
-  // differ between calls on the same data and between the two column orders
+  // wdm breaks predictor ties at random but seeds that deterministically, so
+  // the criterion must not vary between calls on the same data, nor between
+  // the two column orders
   Eigen::MatrixXd tied(60, 2);
   for (Eigen::Index i = 0; i < tied.rows(); ++i) {
     tied(i, 0) = static_cast<double>(i / 12) / 5.0;

--- a/test/src_test/test_vinecop_class.cpp
+++ b/test/src_test/test_vinecop_class.cpp
@@ -2425,6 +2425,29 @@ TEST_F(VinecopTest, tree_criterion_custom_works)
   EXPECT_NO_THROW(fit_reversed.select(u, reversed));
 }
 
+TEST_F(VinecopTest, tree_criterion_cxi_works)
+{
+  FitControlsVinecop controls({ BicopFamily::indep });
+  controls.set_tree_criterion("cxi");
+  Vinecop fit(7);
+  fit.select(u, controls);
+  EXPECT_NEAR(fit.get_loglik(), fit.loglik(u), 0.001);
+
+  // "cxi" must be exactly the symmetrized Chatterjee's xi, so a custom
+  // criterion spelling it out has to select the same structure
+  auto cxi_fn = [](const Eigen::MatrixXd& data,
+                   const Eigen::VectorXd& weights) {
+    return std::max(wdm::wdm(data.col(0), data.col(1), "cxi", weights),
+                    wdm::wdm(data.col(1), data.col(0), "cxi", weights));
+  };
+  FitControlsVinecop custom({ BicopFamily::indep });
+  custom.set_tree_criterion("custom");
+  custom.set_tree_criterion_function(cxi_fn);
+  Vinecop fit_custom(7);
+  fit_custom.select(u, custom);
+  EXPECT_EQ(fit.get_matrix(), fit_custom.get_matrix());
+}
+
 // A custom criterion is arbitrary user code (an R closure or a Python callable
 // in the wrappers), so it must run on the thread that starts the fit no matter
 // how many threads the fit is allowed to use.

--- a/test/src_test/test_vinecop_sanity_checks.cpp
+++ b/test/src_test/test_vinecop_sanity_checks.cpp
@@ -180,6 +180,7 @@ TEST(vinecop_sanity_checks, fit_controls_config_works)
 TEST(vinecop_sanity_checks, controls_check)
 {
   auto controls = FitControlsVinecop();
+  EXPECT_NO_THROW(controls.set_tree_criterion("cxi"));
   EXPECT_ANY_THROW(controls.set_tree_criterion("foo"));
   EXPECT_ANY_THROW(controls.set_threshold(-1.0));
   EXPECT_ANY_THROW(controls.set_threshold(2.0));


### PR DESCRIPTION
Adds `"cxi"` as a `tree_criterion`, so structure selection can weight edges by
Chatterjee's xi (added to wdm in tnagler/wdm#15).

### What it does

`tools_stats::pairwise_cxi` returns `max(xi(X, Y), xi(Y, X))`. Chatterjee's xi
measures how well one variable is a measurable function of the other and is
therefore **asymmetric**, while the tree criterion weights an *undirected* edge
— the column order of `pc_data` follows the boost graph's edge insertion order.
Symmetrizing makes the criterion a property of the pair rather than of that
order, which the tests pin down (`EXPECT_DOUBLE_EQ` on swapped columns, over a
pair whose two directions differ by more than 0.1).

Like `"hoeffd"` it picks up non-monotonic dependence, and unlike it, it detects
functional relationships even when they are not smooth.

### wdm dependency

Requires **wdm 0.2.7**. `find_package(wdm 0.2.7)` now carries the whole check —
the `wdm/cxi.hpp` probe from earlier revisions of this PR is gone, and the
version check is strictly stronger: it also rejects the wdm whose `cxi.hpp` was
present but threw, which the probe could not see. A too-old installation is
fetched over rather than failing configuration. FetchContent pins
`536099d`, the 0.2.7 bump; that becomes a plain `v0.2.7` once the tag exists.

Three upstream fixes were needed to get here, all merged:

- tnagler/wdm#18 — `rank0` accepting `"max"` ties, without which every
  `wdm(x, y, "cxi")` call threw.
- tnagler/wdm#17 — random tie-breaking in `rank()`. This moves
  `to_pseudo_obs(..., "random")` and with it every discrete `tll` fit, so the
  golden values here are regenerated: the old ones had three repeated ranks in
  one column and two in the other, which is exactly the bug. An assertion that
  each column is a permutation of `1 / (n + 1), ..., n / (n + 1)` guards the
  invariant golden values alone would not catch.
- tnagler/wdm#19 — the weighted xi and its inference. Unweighted, untied
  estimates are unchanged by it, so nothing here depended on the outcome.

### Chatterjee ties are broken at random, so the criterion is seeded

wdm#19 breaks ties in the predictor uniformly at random, seeding from
`std::random_device` when no seed is passed. Left alone that makes
`tree_criterion = "cxi"` **non-reproducible** on any data with tied
pseudo-observations — that is, any fit involving discrete variables. On a
12-point example with tied predictors, eight successive calls returned seven
distinct values spanning `-0.30` to `+0.12`.

`pairwise_cxi` therefore passes a fixed seed, as the discrete `tll` jitter in
`tll.ipp` already does. That keeps the criterion a deterministic function of the
data and gives every pair the same tie-breaking realization, so edges stay
comparable. The test covers it: five repeated calls on tied data must agree
exactly, and so must the two column orders. Both fail without the seed.

### Tests

Verified locally against wdm `main` (Debug, header-only): `test_tools_stats`
(16), `test_vinecop_sanity_checks` (7), `test_discrete` (9),
`test_bicop_kernel` (31), `test_weights` (4) and the `tree_criterion` subset of
`test_vinecop_class` (4) — all passing.

Discovery was checked in all three directions: wdm 0.2.7 installed is accepted;
a stale 0.2.6 install is rejected and fetched over; no wdm at all fetches the
pin. tnagler/wdm#21 was also pre-checked out of band — it changes `cxi.hpp`
(zero-weight observations are dropped, constant responses rejected) and nothing
here moves when it lands.

- `test_tools_stats.cxi_works` — zero under independence; > 0.9 on a
  deterministic non-monotonic relationship where Kendall's tau is ~0;
  invariance to column order; uniform weights are a no-op and zero weights drop
  rows.
- `VinecopTest.tree_criterion_cxi_works` — a fit with `"cxi"` is coherent, and
  selects the same structure as a `"custom"` criterion spelling out the same
  symmetrized xi.
- `vinecop_sanity_checks.controls_check` — `"cxi"` is accepted.

### Also fixes #755

`-Dwdm_INCLUDE_DIRS=<path>`, the escape hatch in `findDependencies.cmake`,
configured but failed every link with `cannot find -lwdm`: the build links wdm
by target name, and that target is only defined on the `find_package` and
FetchContent paths, so on this one the bare name was left to the linker. An
imported interface target carrying the path is now defined when nothing else
has.

The `wdm/cxi.hpp` check also moved out of the `find_package` branch, so it
covers a caller-supplied path too — no version check can rule out a wdm without
xi.

Verified across all four configurations, since this touches the install and
export path:

| configuration | before | after |
|---|---|---|
| `wdm_INCLUDE_DIRS`, header-only | `cannot find -lwdm` | builds, 16 tests pass |
| `wdm_INCLUDE_DIRS`, `PRECOMPILED=ON` + `make install` | `cannot find -lwdm` | builds and installs |
| `wdm_DIR` (`find_package`) | ok | ok |
| neither (FetchContent) | ok | ok |

The exported `INTERFACE_LINK_LIBRARIES` is unchanged
(`Eigen3::Eigen;wdm;Boost::headers;Threads::Threads`), and a downstream consumer
built against the precompiled install links and runs a `"cxi"` fit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)