### PR TITLE
fix(vinecop): bounds-check the per-entry structure accessors

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -179,6 +179,14 @@ wrong thing.
 
 ### BUG FIXES
 
+* `RVineStructure::struct_array()`, `min_array()`, `needed_hfunc1()` and
+  `needed_hfunc2()` throw when the requested tree or edge is not stored, rather
+  than reading past the trapezoid. `TriangularArray::operator()` asserts its
+  bounds and `assert` is compiled out of a release build, so a truncated
+  structure -- which stores only `trunc_lvl` rows -- segfaulted on any tree
+  above its truncation. These four accessors are public, so the crash was
+  reachable from a few lines of user code in any binding.
+
 * Validate the pair-copula store in the `RVineTrees` constructor rather than
   indexing it blindly: an empty store means independence on every edge, and one
   that does not cover the structure array is an error instead of a read past its

--- a/include/vinecopulib/vinecop/implementation/rvine_structure.ipp
+++ b/include/vinecopulib/vinecop/implementation/rvine_structure.ipp
@@ -301,6 +301,7 @@ RVineStructure::get_needed_hfunc2() const
 inline size_t
 RVineStructure::struct_array(size_t tree, size_t edge, bool natural_order) const
 {
+  check_slot(tree, edge);
   if (natural_order) {
     return struct_array_(tree, edge);
   }
@@ -314,6 +315,7 @@ RVineStructure::struct_array(size_t tree, size_t edge, bool natural_order) const
 inline size_t
 RVineStructure::min_array(size_t tree, size_t edge) const
 {
+  check_slot(tree, edge);
   return min_array_(tree, edge);
 }
 
@@ -323,6 +325,7 @@ RVineStructure::min_array(size_t tree, size_t edge) const
 inline bool
 RVineStructure::needed_hfunc1(size_t tree, size_t edge) const
 {
+  check_slot(tree, edge);
   return needed_hfunc1_(tree, edge);
 }
 
@@ -330,6 +333,7 @@ RVineStructure::needed_hfunc1(size_t tree, size_t edge) const
 inline bool
 RVineStructure::needed_hfunc2(size_t tree, size_t edge) const
 {
+  check_slot(tree, edge);
   return needed_hfunc2_(tree, edge);
 }
 
@@ -679,6 +683,23 @@ RVineStructure::check_upper_tri() const
         throw std::runtime_error("not a valid R-vine array: " + problem);
       }
     }
+  }
+}
+
+//! @brief Throws if `(tree, edge)` is outside the stored trapezoid.
+//! @details `TriangularArray::operator()` asserts its bounds, and `assert` is
+//! compiled out of a release build -- so the per-entry accessors read out of
+//! bounds rather than complaining. A truncated structure stores only
+//! `trunc_lvl` rows, and these accessors are public, so the read is reachable
+//! from a few lines of user code in any binding.
+inline void
+RVineStructure::check_slot(size_t tree, size_t edge) const
+{
+  if (tree >= trunc_lvl_ || edge + tree + 1 >= d_) {
+    throw std::runtime_error(
+      "tree = " + std::to_string(tree) + ", edge = " + std::to_string(edge) +
+      " is outside a structure with dimension " + std::to_string(d_) +
+      " and truncation level " + std::to_string(trunc_lvl_) + ".");
   }
 }
 

--- a/include/vinecopulib/vinecop/rvine_structure.hpp
+++ b/include/vinecopulib/vinecop/rvine_structure.hpp
@@ -166,6 +166,7 @@ protected:
     const Eigen::Matrix<size_t, Eigen::Dynamic, Eigen::Dynamic>& mat) const;
   void check_upper_tri() const;
   void check_columns() const;
+  void check_slot(size_t tree, size_t edge) const;
   void check_antidiagonal() const;
   void check_proximity_condition() const;
 

--- a/test/src_test/test_rvine_structure.cpp
+++ b/test/src_test/test_rvine_structure.cpp
@@ -433,4 +433,33 @@ TEST(rvine_structure, cvine_structure)
   EXPECT_EQ(test.get_trunc_lvl(), 4);
   EXPECT_EQ(test_tr.get_trunc_lvl(), 2);
 }
+
+TEST(rvine_structure, per_entry_accessors_reject_a_slot_that_is_not_stored)
+{
+  // A truncated structure stores only `trunc_lvl` rows, and the per-entry
+  // accessors used to index straight into the trapezoid: `operator()` asserts
+  // its bounds, and `assert` is compiled out of a release build. Reading a tree
+  // above the truncation therefore read out of bounds instead of complaining.
+  DVineStructure trunc(tools_stl::seq_int(1, 6), 2);
+  EXPECT_EQ(trunc.get_trunc_lvl(), 2);
+
+  // In range: the two stored trees answer.
+  EXPECT_NO_THROW(trunc.struct_array(1, 0));
+  EXPECT_NO_THROW(trunc.min_array(1, 0));
+  EXPECT_NO_THROW(trunc.needed_hfunc1(1, 0));
+  EXPECT_NO_THROW(trunc.needed_hfunc2(1, 0));
+
+  // Above the truncation: all four refuse.
+  EXPECT_ANY_THROW(trunc.struct_array(2, 0));
+  EXPECT_ANY_THROW(trunc.min_array(2, 0));
+  EXPECT_ANY_THROW(trunc.needed_hfunc1(2, 0));
+  EXPECT_ANY_THROW(trunc.needed_hfunc2(2, 0));
+  EXPECT_ANY_THROW(trunc.struct_array(5, 0));
+
+  // Past the end of a stored row, which shortens as the tree index grows.
+  DVineStructure full(tools_stl::seq_int(1, 6));
+  EXPECT_NO_THROW(full.struct_array(4, 0));
+  EXPECT_ANY_THROW(full.struct_array(4, 1));
+  EXPECT_ANY_THROW(full.struct_array(0, 5));
+}
 }


### PR DESCRIPTION
`RVineStructure::struct_array(tree, edge)` **segfaults** for `tree >= trunc_lvl`,
and so do `min_array`, `needed_hfunc1` and `needed_hfunc2`. All four are public,
so the crash is three lines away in any binding:

```cpp
DVineStructure s(tools_stl::seq_int(1, 6), 2);  // trunc_lvl == 2
s.struct_array(2, 0);                           // reads past the trapezoid
```

## Why it happens

The bounds checks are not missing. They are in `TriangularArray::operator()`:

```cpp
T TriangularArray<T>::operator()(size_t row, size_t column) const
{
  assert(row < trunc_lvl_);
  assert(column < d_ - 1 - row);
  return arr_[row][column];
}
```

`assert` is compiled out of a release build. A truncated structure stores only
`trunc_lvl` rows, so in Release `arr_[row]` indexes past the end of the vector
and the accessor returns whatever is there — or dies. It is only a crash rather
than a silent wrong answer because `arr_` is a `vector<vector<T>>`, so the outer
read usually lands outside the allocation.

I found it from Python: `pyvinecopulib` walks these accessors to build a
relabeling, and on a truncated model the interpreter died with no traceback.

## The fix

A private `check_slot(tree, edge)`, following the existing `check_*` members,
called from the four accessors.

Throwing there rather than in `TriangularArray::operator()` is the deliberate
choice. `operator()` is the inner primitive the evaluation cascades use on every
edge of every observation, and its asserts already cover the development build;
the accessors are the public boundary, which is where a library should refuse.
Note the four accessors are themselves on the `Vinecop::pdf` path
(`class.ipp:686-717`), so this does cost one comparison per edge — against a
pair-copula evaluation, and it never fires there, since those loops are already
bounded by `trunc_lvl`.

If you would rather have the check in `TriangularArray` so it also covers the
library's internal reads, say so and I will move it — it is a one-line change,
just a different performance trade.

## Test

`rvine_structure.per_entry_accessors_reject_a_slot_that_is_not_stored` covers
both bounds and both directions:

- the two stored trees of a `trunc_lvl == 2` structure still answer, on all four
  accessors;
- every tree above the truncation throws, on all four;
- on an *untruncated* structure, a column past the end of a shortening row
  throws too (`struct_array(4, 1)` where row 4 holds one entry).

Reverting `check_slot` fails it. **730 tests pass** with the fix in.
