### PR TITLE
fix(bicop): return the limit for Joe's tau at its removable singularity

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -191,6 +191,17 @@ wrong thing.
 
 ### BUG FIXES
 
+* `Bicop::get_tau()` returns the limiting value for the Joe copula at
+  `theta = 2` instead of `NaN`. Its Kendall's tau,
+  `1 + 2 [psi(2) - psi(2/theta + 1)] / (2 - theta)`, has a removable
+  singularity there: the bracket and the denominator vanish together, so the
+  quotient evaluated to `NaN` at exactly that point and lost most of its
+  significant digits nearby. The limit is `1 - psi'(2) = 2 - pi^2/6`, and a
+  series expansion now covers a small neighbourhood, agreeing with the closed
+  form to about `1e-10` where the direct quotient does not. `theta = 2` is an
+  ordinary interior point of the parameter space that a user can specify
+  directly or reach from a fit.
+
 * `RVineStructure::struct_array()`, `min_array()`, `needed_hfunc1()` and
   `needed_hfunc2()` throw when the requested tree or edge is not stored, rather
   than reading past the trapezoid. `TriangularArray::operator()` asserts its

--- a/include/vinecopulib/bicop/implementation/joe.ipp
+++ b/include/vinecopulib/bicop/implementation/joe.ipp
@@ -722,6 +722,18 @@ inline double
 JoeBicop::parameters_to_tau(const Eigen::MatrixXd& parameters)
 {
   double par = parameters(0);
+  // The closed form 1 + 2 [psi(2) - psi(2/par + 1)] / (2 - par) has a removable
+  // singularity at par = 2, where the bracket and the denominator vanish
+  // together: the quotient evaluates to NaN there and loses most of its
+  // significant digits nearby. The limit is 1 - psi'(2) = 2 - pi^2 / 6.
+  constexpr double eps = 1e-5;
+  if (std::fabs(par - 2.0) < eps) {
+    // tau(2 + d) = 1 - psi'(2) + d [psi'(2) / 2 + psi''(2) / 4] + O(d^2)
+    constexpr double tri2 = 0.6449340668482264;  // psi'(2) = pi^2 / 6 - 1
+    constexpr double tet2 = -0.4041138063191886; // psi''(2)
+    const double d = par - 2.0;
+    return 1.0 - tri2 + d * (tri2 / 2.0 + tet2 / 4.0);
+  }
   double tau = 2 / par + 1;
   tau = boost::math::digamma(2.0) - boost::math::digamma(tau);
   return 1 + 2 * tau / (2 - par);

--- a/test/src_test/test_bicop_sanity_checks.cpp
+++ b/test/src_test/test_bicop_sanity_checks.cpp
@@ -5,6 +5,8 @@
 // vinecopulib or https://vinecopulib.github.io/vinecopulib/.
 
 #include "gtest/gtest.h"
+#include <boost/math/special_functions/digamma.hpp>
+#include <cmath>
 #include <vinecopulib.hpp>
 
 namespace test_bicop_sanity_checks {
@@ -271,6 +273,47 @@ TEST(bicop_sanity_checks, tau_of_integral_families_is_accurate)
     EXPECT_NEAR(bicop.get_tau(), c.tau, 1e-9)
       << "family " << bicop.get_family_name() << ", parameters "
       << par.transpose();
+  }
+}
+
+// Joe's tau has a removable singularity at theta = 2, where the closed form
+// 1 + 2 [psi(2) - psi(2/theta + 1)] / (2 - theta) is 0/0. The limit is
+// 1 - psi'(2) = 2 - pi^2 / 6; the pre-fix implementation returned NaN there and
+// lost most of its significant digits nearby.
+TEST(bicop_sanity_checks, joe_tau_is_finite_at_the_removable_singularity)
+{
+  // 2 - pi^2 / 6
+  const double limit = 2.0 - 1.6449340668482264;
+  Eigen::VectorXd par(1);
+
+  par << 2.0;
+  const double tau = Bicop(BicopFamily::joe, 0, par).get_tau();
+  EXPECT_TRUE(std::isfinite(tau));
+  EXPECT_NEAR(tau, limit, 1e-14);
+
+  // Inside the expansion window the series must track the closed form more
+  // closely than the closed form's own cancellation error. A sign error on the
+  // psi''(2) term shows up here at about 2e-6.
+  const auto closed_form = [](double theta) {
+    return 1.0 + 2.0 *
+                   (boost::math::digamma(2.0) -
+                    boost::math::digamma(2.0 / theta + 1.0)) /
+                   (2.0 - theta);
+  };
+  for (double d : { -1e-5, -5e-6, 5e-6, 1e-5 }) {
+    par << 2.0 + d;
+    EXPECT_NEAR(
+      Bicop(BicopFamily::joe, 0, par).get_tau(), closed_form(2.0 + d), 1e-8)
+      << "theta = " << 2.0 + d;
+  }
+
+  // and tau stays monotone through the singularity
+  double previous = -1.0;
+  for (double theta : { 1.99, 1.999, 1.9999, 2.0, 2.0001, 2.001, 2.01 }) {
+    par << theta;
+    const double t = Bicop(BicopFamily::joe, 0, par).get_tau();
+    EXPECT_GT(t, previous) << "theta = " << theta;
+    previous = t;
   }
 }
 


### PR DESCRIPTION
`Bicop(BicopFamily::joe, 0, 2).get_tau()` returns `NaN`.

Joe's Kendall's tau,

```
tau(theta) = 1 + 2 [psi(2) - psi(2/theta + 1)] / (2 - theta),
```

is 0/0 at `theta = 2`: the bracket and the denominator vanish together. The
quotient was evaluated directly, so the value is `NaN` at exactly that point and
loses most of its significant digits nearby.

`theta = 2` is an ordinary interior point of the parameter space — a user can
specify it directly, and `tau_to_parameters()` maps `tau = 2 - pi^2/6` to within
`3e-10` of it, so a round trip through the two maps lands in the neighbourhood
where the quotient is at its worst.

## The fix

The limit is `1 - psi'(2) = 2 - pi^2/6`. Within `|theta - 2| < 1e-5`:

```
tau(2 + d) = 1 - psi'(2) + d [psi'(2)/2 + psi''(2)/4] + O(d^2)
```

Accuracy against the closed form (evaluated in extended precision):

| theta | before | after |
|---|---|---|
| 2 − 1e-5 | 2.2e-11 | 2.2e-11 |
| 2 | **NaN** | exact to 1e-16 |
| 2 + 1e-5 | 1.0e-10 | 1.0e-10 |

Away from the window nothing changes; inside it the expansion is accurate where
the quotient is not.

## Test

`bicop_sanity_checks.joe_tau_is_finite_at_the_removable_singularity` pins the
limit, compares the expansion against the closed form at `1e-8` — a threshold
chosen to sit between the correct expansion and a sign error in the `psi''(2)`
term — and checks monotonicity through the singularity.

Verified it fails on `main`:

```
Value of: std::isfinite(tau)
  Actual: false
[  FAILED  ] bicop_sanity_checks.joe_tau_is_finite_at_the_removable_singularity
```

Full suite: **733 tests pass**. `clang-format` clean.

## Provenance

Found while building a validation table against **VineCopula** for the
`rvinecopulib` paper (vinecopulib/rvinecopulib#348); VineCopula returns the
limit correctly here. The same fix is carried in that PR's vendored header and
should be dropped from it once this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
