### PR TITLE
fix(vinecop): floor the random-tree weights so Wilson's walk terminates

### DIFF
--- a/include/vinecopulib/vinecop/implementation/tools_select.ipp
+++ b/include/vinecopulib/vinecop/implementation/tools_select.ipp
@@ -645,6 +645,7 @@ VinecopSelector::select_edges_mst_kruskal(VineTree& vine_tree)
 inline void
 VinecopSelector::select_edges_random(VineTree& vine_tree)
 {
+  constexpr double min_weight = 1e-10;
   size_t d = num_vertices(vine_tree);
   std::vector<size_t> predecessors(d);
   boost::mt19937 gen = controls_.get_rng();
@@ -664,10 +665,22 @@ VinecopSelector::select_edges_random(VineTree& vine_tree)
     // Here we inverse the weights to get a spanning tree
     // with probability proportional to the product of the weights
     // (i.e., the higher the weight, the more likely it is to be selected)
+    //
+    // The floor keeps every weight strictly positive. Wilson's algorithm
+    // walks to the next vertex with probability proportional to the incident
+    // weights, so a vertex whose incident weights are all zero is one the
+    // walk can never leave and `random_spanning_tree` does not terminate.
+    // That is reachable: `calculate_criterion` returns exactly 0 for every
+    // edge when there are 10 or fewer observations, and returns 0 for an
+    // individual edge whose criterion is NaN or below the threshold.
+    // Flooring only changes the draw when a vertex has no positive weight at
+    // all, where it samples uniformly among the alternatives rather than
+    // hanging -- with any positive weight present, the floored edges keep a
+    // vanishing share of the mass, as they had before.
     WeightMap original_weights = get(boost::edge_weight, vine_tree);
     std::map<EdgeIterator, double> inv_weights;
     for (auto e : boost::make_iterator_range(edges(vine_tree))) {
-      inv_weights[e] = 1.0 - original_weights[e];
+      inv_weights[e] = std::max(1.0 - original_weights[e], min_weight);
     }
     boost::associative_property_map<std::map<EdgeIterator, double>>
       inv_weight_map(inv_weights);

--- a/test/src_test/test_vinecop_class.cpp
+++ b/test/src_test/test_vinecop_class.cpp
@@ -2502,6 +2502,31 @@ TEST_F(VinecopTest, tree_criterion_custom_is_serial_sparse)
   EXPECT_EQ(*recorder.ids.begin(), std::this_thread::get_id());
 }
 
+// Wilson's algorithm walks to the next vertex with probability proportional
+// to the incident weights, so a vertex whose incident weights are all zero is
+// one the walk can never leave. `calculate_criterion` returns exactly 0 for
+// every edge when there are 10 or fewer observations, which makes every
+// weight zero and the walk non-terminating.
+TEST_F(VinecopTest, select_random_weighted_survives_zero_criteria)
+{
+  auto data = tools_stats::simulate_uniform(10, 4, false, { 1 });
+
+  FitControlsVinecop controls({ BicopFamily::gaussian });
+  controls.set_tree_algorithm("random_weighted");
+  controls.set_seeds({ 1, 2, 3, 4, 5 });
+
+  Vinecop fit(4);
+  fit.select(data, controls);
+  EXPECT_EQ(fit.get_dim(), static_cast<size_t>(4));
+
+  // One row above the floor the criteria are informative again; the same
+  // draw has to keep working there.
+  auto more = tools_stats::simulate_uniform(11, 4, false, { 1 });
+  Vinecop fit_more(4);
+  fit_more.select(more, controls);
+  EXPECT_EQ(fit_more.get_dim(), static_cast<size_t>(4));
+}
+
 TEST_F(VinecopTest, select_finds_different_structures_random)
 {
   // Initialize the controls


### PR DESCRIPTION
`select_edges_random` builds the weight map for `boost::random_spanning_tree`
as `1 - w`, where `w` is what `calculate_criterion` produced — so the weight
the walk sees for an edge **is its criterion**. Wilson's algorithm steps to the
next vertex with probability proportional to the incident weights, so a vertex
whose incident weights are all zero is one the walk can never leave.
`random_spanning_tree` then never terminates: full CPU, flat memory, no error,
no bound.

## Zero criteria are easy to reach

`calculate_criterion` returns exactly `0` for every edge when there are 10 or
fewer observations:

```cpp
if (data.rows() > 10) { ... }
return std::fabs(w);   // w stays 0.0 otherwise
```

So `tree_algorithm = "random_weighted"` hangs on **any** data set with
`n <= 10`. Measured through the Python bindings, 4 columns, fixed seeds:

| n | `random_weighted` | `random_unweighted` |
|---|---|---|
| 8 | hangs | ok |
| 10 | hangs | ok |
| 11 | ok | ok |
| 20 | ok | ok |

It also returns `0` for an individual edge whose criterion is NaN or below the
threshold, and a vertex can collect enough of those to be stranded on ordinary
data. That is how this surfaced: a 460x9 fit that ran three hours instead of
0.4 s. That data set has two perfectly rank-dependent columns (`|tau| = 1`
exactly); the pair copula there leaves a degenerate h-function behind, and by
tree 3 every edge touching that node scores zero. Dropping either column fixes
it; jittering by 1e-6 does not, so it is the near-degeneracy rather than the
exact tie.

Only the weighted sampler is affected — `mst_prim`, `mst_kruskal` and
`random_unweighted` all complete on the same input, which is what a
zero-total-weight stall predicts: the MST variants only take minima, and the
unweighted walk ignores weights.

## The fix

Floor each weight at `1e-10`.

Where any incident weight is positive this changes nothing: a floored edge
keeps a vanishing share of the mass, exactly as a zero one did. Where a vertex
has no positive weight at all, the walk samples uniformly among its edges
instead of never moving — the only defined thing left when the criterion says
nothing about any of them.

## Testing

New `select_random_weighted_survives_zero_criteria`, pinning both sides of the
10-row floor so the fix cannot disturb the case that already worked.

Verified against the downstream bindings, where the fix was developed: every
previously hanging case now completes (`n` = 8, 10 and the 460x9 report, which
returns its 8 trees), and the numerics gate a submodule bump requires —
`test_structure_selection.py`, `test_torch_bicop.py`, `test_torch_vinecop.py` —
passes 182 tests with no selected structure moving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)