### PR TITLE
fix: validate user-supplied shapes before indexing them

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -191,6 +191,22 @@ wrong thing.
 
 ### BUG FIXES
 
+* `Bicop::parameters_to_tau()`, `parameters_to_taildep()` and
+  `parameters_to_beta()` check the shape of their argument, which used to go
+  straight to the leaf family and be indexed positionally. `eigen_assert` is
+  compiled out of a release build, so a wrong shape read past the end of its own
+  storage and an empty matrix dereferenced a null pointer (#761)
+
+* `RVineStructure(mat)` rejects an empty array. Every validity check is vacuous
+  at `d = 0`, and `find_trunc_lvl()` then wrapped `d - 1` around and indexed a
+  row that does not exist. The guard is unconditional, because `check = false`
+  reaches `find_trunc_lvl()` too (#761)
+
+* `Vinecop::set_var_types()` requires one entry per variable. A longer vector
+  was rejected but a shorter one was stored and then indexed per variable,
+  reading out of bounds on every later evaluation; `Bicop::set_var_types()` has
+  always required exactly two (#761)
+
 * `Bicop::get_tau()` returns the limiting value for the Joe copula at
   `theta = 2` instead of `NaN`. Its Kendall's tau,
   `1 + 2 [psi(2) - psi(2/theta + 1)] / (2 - theta)`, has a removable

--- a/include/vinecopulib/bicop/class.hpp
+++ b/include/vinecopulib/bicop/class.hpp
@@ -409,6 +409,8 @@ private:
 
   void flip_abstract_var_types();
 
+  void check_parameters_size(const Eigen::MatrixXd& parameters) const;
+
   void check_weights_size(const Eigen::VectorXd& weights,
                           const Eigen::MatrixXd& data) const;
 

--- a/include/vinecopulib/bicop/implementation/class.ipp
+++ b/include/vinecopulib/bicop/implementation/class.ipp
@@ -1720,6 +1720,7 @@ Bicop::tau_to_parameters(const double& tau) const
 inline double
 Bicop::parameters_to_tau(const Eigen::MatrixXd& parameters) const
 {
+  check_parameters_size(parameters);
   double tau = bicop_->parameters_to_tau(parameters);
   if (tools_stl::is_member(rotation_, { 90, 270 })) {
     tau *= -1;
@@ -1769,6 +1770,7 @@ Bicop::parameters_to_tau(const Eigen::MatrixXd& parameters) const
 inline Eigen::MatrixXd
 Bicop::parameters_to_taildep(const Eigen::MatrixXd& parameters) const
 {
+  check_parameters_size(parameters);
   Eigen::MatrixXd m = bicop_->parameters_to_taildep(parameters);
   // rotate the 2x2 matrix like a grid, counter-clockwise, to match the
   // (counter-clockwise) rotation applied to the data in `rotate_data`.
@@ -1795,6 +1797,7 @@ Bicop::parameters_to_taildep(const Eigen::MatrixXd& parameters) const
 inline double
 Bicop::parameters_to_beta(const Eigen::MatrixXd& parameters) const
 {
+  check_parameters_size(parameters);
   double beta = bicop_->parameters_to_beta(parameters);
   if (tools_stl::is_member(rotation_, { 90, 270 })) {
     beta *= -1;
@@ -2343,6 +2346,29 @@ Bicop::check_rotation(int rotation) const
                                bicop_->get_family_name() + " copula");
     }
   }
+}
+
+//! @brief Checks that a parameter matrix has the current family's shape.
+//!
+//! @details The leaf families index the parameter matrix positionally, and
+//! `eigen_assert` is compiled out of a release build, so a matrix of the wrong
+//! shape reads past the end of its own storage. An empty matrix has no storage
+//! at all: `Eigen` allocates nothing for size zero, so `parameters(0)` would
+//! dereference a null pointer.
+inline void
+Bicop::check_parameters_size(const Eigen::MatrixXd& parameters) const
+{
+  const auto expected = bicop_->get_parameters();
+  if (parameters.rows() == expected.rows() &&
+      parameters.cols() == expected.cols()) {
+    return;
+  }
+  std::stringstream message;
+  message << "parameters have the wrong shape for the " << get_family_name()
+          << " copula; expected: " << expected.rows() << " x "
+          << expected.cols() << ", actual: " << parameters.rows() << " x "
+          << parameters.cols() << std::endl;
+  throw std::runtime_error(message.str());
 }
 
 //! @brief Checks whether weights and data have matching sizes.

--- a/include/vinecopulib/vinecop/implementation/class.ipp
+++ b/include/vinecopulib/vinecop/implementation/class.ipp
@@ -1069,9 +1069,11 @@ inline void
 Vinecop::check_var_types(const std::vector<std::string>& var_types) const
 {
   std::stringstream msg;
-  if (var_types.size() > d_) {
-    msg << "more var_types (" << var_types.size() << ") "
-        << "than variables (" << d_ << ")" << std::endl;
+  if (var_types.size() != d_) {
+    // One entry per variable. A shorter vector used to be accepted and then
+    // indexed per variable when deriving each pair's types.
+    msg << "var_types must have one entry per variable; expected: " << d_
+        << ", actual: " << var_types.size() << std::endl;
     throw std::runtime_error(msg.str());
   }
   for (const auto& t : var_types) {

--- a/include/vinecopulib/vinecop/implementation/rvine_structure.ipp
+++ b/include/vinecopulib/vinecop/implementation/rvine_structure.ipp
@@ -33,6 +33,12 @@ inline RVineStructure::RVineStructure(
   bool check)
 {
   d_ = mat.cols();
+  // Unconditional: `check = false` must not reach find_trunc_lvl() either,
+  // where `d - 1` wraps around for an empty array and the loop then indexes
+  // a row that does not exist.
+  if (d_ == 0) {
+    throw std::runtime_error("d should be greater than 0");
+  }
   if (check) {
     check_if_quadratic(mat);
     check_lower_tri(mat);

--- a/test/src_test/test_bicop_sanity_checks.cpp
+++ b/test/src_test/test_bicop_sanity_checks.cpp
@@ -67,6 +67,39 @@ TEST(bicop_sanity_checks, catches_transposed_parameter_shape)
   EXPECT_ANY_THROW(bc.set_parameters(transposed));
 }
 
+TEST(bicop_sanity_checks, catches_wrong_parameter_shape_in_converters)
+{
+  // `set_parameters` has validated its argument's shape since PR #700, but
+  // `parameters_to_tau`, `parameters_to_taildep` and `parameters_to_beta` took
+  // one straight to the leaf, which indexes it positionally. An empty matrix
+  // has no storage at all, so `parameters(0)` dereferenced a null pointer.
+  for (auto family : bicop_families::all) {
+    auto bc = Bicop(family);
+    const auto expected = bc.get_parameters();
+    // An empty argument is the family's own shape for `indep`, so it stays
+    // legal there; every other family must reject it.
+    if (expected.size() > 0) {
+      EXPECT_ANY_THROW(bc.parameters_to_tau(Eigen::MatrixXd()))
+        << bc.get_family_name();
+      EXPECT_ANY_THROW(bc.parameters_to_taildep(Eigen::MatrixXd()))
+        << bc.get_family_name();
+      EXPECT_ANY_THROW(bc.parameters_to_beta(Eigen::MatrixXd()))
+        << bc.get_family_name();
+    }
+    // The family's own parametrization is always accepted.
+    EXPECT_NO_THROW(bc.parameters_to_tau(expected)) << bc.get_family_name();
+    EXPECT_NO_THROW(bc.parameters_to_taildep(expected)) << bc.get_family_name();
+    EXPECT_NO_THROW(bc.parameters_to_beta(expected)) << bc.get_family_name();
+  }
+
+  // A wrong arity within a parametric family reads past its own storage: a
+  // 1 x 1 argument to a two-parameter family used to return a value computed
+  // from whatever followed the single double in memory.
+  auto bb1_par = (Eigen::MatrixXd(2, 1) << 1.0, 1.5).finished();
+  auto bb1 = Bicop(BicopFamily::bb1, 0, bb1_par);
+  EXPECT_ANY_THROW(bb1.parameters_to_tau(Eigen::MatrixXd::Constant(1, 1, 2.0)));
+}
+
 TEST(bicop_sanity_checks, catches_parameters_out_of_bounds)
 {
   auto cop = Bicop(BicopFamily::gaussian);

--- a/test/src_test/test_rvine_structure.cpp
+++ b/test/src_test/test_rvine_structure.cpp
@@ -434,6 +434,20 @@ TEST(rvine_structure, cvine_structure)
   EXPECT_EQ(test_tr.get_trunc_lvl(), 2);
 }
 
+TEST(rvine_structure, empty_matrix_is_rejected)
+{
+  // `d_ = mat.cols()` accepted an empty array: every check_*() is vacuous at
+  // d = 0, and find_trunc_lvl() then wrapped `d - 1` around and indexed a row
+  // that does not exist. The guard is unconditional because `check = false`
+  // reaches find_trunc_lvl() too.
+  Eigen::Matrix<size_t, Eigen::Dynamic, Eigen::Dynamic> empty(0, 0);
+  // Braces, not parentheses: `RVineStructure(empty)` inside the macro parses
+  // as a declaration of a variable named `empty` (the most vexing parse) and
+  // silently calls the `d = 1` default constructor instead.
+  EXPECT_ANY_THROW(RVineStructure{ empty });
+  EXPECT_ANY_THROW(RVineStructure(empty, false));
+}
+
 TEST(rvine_structure, per_entry_accessors_reject_a_slot_that_is_not_stored)
 {
   // A truncated structure stores only `trunc_lvl` rows, and the per-entry

--- a/test/src_test/test_vinecop_sanity_checks.cpp
+++ b/test/src_test/test_vinecop_sanity_checks.cpp
@@ -105,6 +105,19 @@ TEST(vinecop_sanity_checks, catches_wrong_size)
   EXPECT_ANY_THROW(Vinecop(mat, pair_copulas));
 }
 
+TEST(vinecop_sanity_checks, var_types_needs_one_entry_per_variable)
+{
+  // `check_var_types` rejected a vector longer than the dimension but accepted
+  // a shorter one, which `set_var_types_internal` then stored and the pair-type
+  // derivation indexed per variable -- an out-of-bounds read on every
+  // evaluation. `Bicop::check_var_types` has always required exactly two.
+  auto vinecop = Vinecop(RVineStructure(std::vector<size_t>{ 1, 2, 3, 4 }));
+  EXPECT_ANY_THROW(vinecop.set_var_types({ "c", "c" }));
+  EXPECT_ANY_THROW(vinecop.set_var_types({ "c" }));
+  EXPECT_ANY_THROW(vinecop.set_var_types({ "c", "c", "c", "c", "c" }));
+  EXPECT_NO_THROW(vinecop.set_var_types({ "c", "d", "c", "d" }));
+}
+
 TEST(vinecop_sanity_checks, controls_print)
 {
   auto controls = FitControlsVinecop();


### PR DESCRIPTION
## Summary

Three public entry points read past the end of their own storage on an input that
is wrong but plausible. `eigen_assert` is compiled out of a release build, so each
is an out-of-bounds read there rather than an abort — and the empty case is a null
dereference, because Eigen allocates nothing for size zero and `parameters(0)` then
has no storage to read.

Found while auditing `pyvinecopulib` for its 1.0.0 release. Each one terminates the
Python interpreter; reproductions below.

- **`Bicop::parameters_to_tau()` / `parameters_to_taildep()` / `parameters_to_beta()`**
  took their argument straight to the leaf family, which indexes it positionally.
  `set_parameters()` has validated the same shape since #700 — whose own comment
  records exactly this hazard — but the three converters had no check, so their
  documented *"must be a valid parametrization"* precondition was unenforced.
  They now call a new `Bicop::check_parameters_size()`, alongside the existing
  `check_data`/`check_weights_size`/`check_var_types` family.

- **`RVineStructure(mat)`** accepted an empty array: every validity check is vacuous
  at `d = 0`, and `find_trunc_lvl()` then wrapped `d - 1` around and indexed a row
  that does not exist. The guard is unconditional, because `check = false` reaches
  `find_trunc_lvl()` as well.

- **`Vinecop::set_var_types()`** rejected a vector *longer* than the dimension but
  stored a *shorter* one, which the pair-type derivation then indexed per variable —
  out of bounds on every subsequent evaluation.

## Reproductions (via the Python bindings, release build)

| call | before |
| --- | --- |
| `Bicop(gaussian, 0, [[0.5]]).parameters_to_tau(zeros((0,0)))` | SIGSEGV |
| `.parameters_to_beta(zeros((0,0)))` | SIGSEGV |
| `Bicop(clayton, …).parameters_to_tau(zeros((0,0)))` | SIGSEGV |
| `RVineStructure(zeros((0,0)))` | SIGSEGV |
| `Vinecop(d=4).set_var_types({"c","c"})`, then `pdf()` | SIGSEGV |
| `Bicop(bb1, 0, [[1.0],[1.5]]).parameters_to_tau([[2.0]])` | `-inf` from an out-of-bounds read |

## Behavior changes worth flagging to downstream wrappers

- Requiring `var_types.size() == d` is a behavior change, not only a crash fix. Both
  `Vinecop` constructors already route an *empty* vector to
  `set_continuous_var_types()`, so only a non-empty vector of the wrong length is
  affected — the case that crashed. It also makes `Vinecop` consistent with
  `Bicop::set_var_types()`, which has always required exactly two.
- `tll` ignored the argument to `parameters_to_beta()` entirely and answered from its
  stored grid, so a caller asking for beta at a given parametrization silently got
  beta at the fitted one. That now raises.

## Validation

- `bin/test_all`: **737 passed**, 0 failed (Release, `-DBUILD_TESTING=ON`, GCC 13.3).
- Three regression tests added, one per site, in the existing `*_sanity_checks` /
  `test_rvine_structure` files.
- `clang-format-14 --dry-run --Werror` clean over `include/` and `test/`.
- `NEWS.md` updated under **BUG FIXES**.