### PR TITLE
fix: synchronize the thread pool and widen a sweep counter

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -17,11 +17,8 @@ query-filters:
   - exclude:
       id: cpp/commented-out-code
 
-# Only a backstop: for an analysis that builds the code, path filters are not
-# what keeps a dependency out of the results -- being outside the workspace is
-# (see the Eigen3_ROOT export in codeql.yml). Alert paths are relative to the
-# workspace, so the vendored header needs a glob: it is analyzed through the
-# copy findHeaders.cmake derives under build-codeql/generated/.
-paths-ignore:
-  - eigen-src
-  - '**/nlohmann_json.hpp'
+# No `paths-ignore`: path filters are documented for interpreted languages and
+# for compiled languages analyzed without building, and a dispatch run measured
+# them filtering nothing here. What keeps a dependency out of the results is
+# being outside the workspace -- see the Eigen3_ROOT export in codeql.yml. The
+# vendored JSON header is inside it, so its remaining findings are dismissed.

--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,27 @@
+name: vinecopulib
+
+# `queries` is additive: the default suite runs regardless, and
+# security-and-quality adds the maintainability checks on top of it.
+queries:
+  - uses: security-and-quality
+
+# Two of those maintainability checks cannot be satisfied here.
+query-filters:
+  # Fires on the derivative dispatch functions in bicop/implementation, which
+  # are generated from tools/derivs and run to hundreds of lines of algebra.
+  - exclude:
+      id: cpp/poorly-documented-function
+  # The vendored JSON header is an amalgamation, and the `// #include
+  # <nlohmann/detail/...>` provenance markers it is assembled from are comments
+  # that parse as code.
+  - exclude:
+      id: cpp/commented-out-code
+
+# Only a backstop: for an analysis that builds the code, path filters are not
+# what keeps a dependency out of the results -- being outside the workspace is
+# (see the Eigen3_ROOT export in codeql.yml). Alert paths are relative to the
+# workspace, so the vendored header needs a glob: it is analyzed through the
+# copy findHeaders.cmake derives under build-codeql/generated/.
+paths-ignore:
+  - eigen-src
+  - '**/nlohmann_json.hpp'

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -31,7 +31,7 @@ jobs:
         uses: github/codeql-action/init@v4
         with:
           languages: cpp
-          queries: security-and-quality
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Install dependencies
         id: install-dependencies
@@ -40,15 +40,20 @@ jobs:
           os: ubuntu-latest
           boost_version: 1.84.0
           eigen_version: 3.4.0
+          # Outside the workspace: CodeQL reports only files under it, so this
+          # is what keeps Eigen's headers out of the results.
+          eigen_install_dir: ${{ runner.temp }}/eigen
           R: false
           lcov: false
 
-      # BOOST_ROOT must be exported: find_package picks it up via CMP0074.
+      # BOOST_ROOT and Eigen3_ROOT must be exported: find_package picks them
+      # up via CMP0074, ahead of CMake's user package registry, where the
+      # in-workspace eigen-src build tree registers itself.
       - name: Set environment variables
         run: |
           echo "BOOST_ROOT=${{ steps.install-dependencies.outputs.BOOST_ROOT }}" >> $GITHUB_ENV
           echo "Boost_INCLUDE_DIR=${{ steps.install-dependencies.outputs.BOOST_ROOT }}/include" >> $GITHUB_ENV
-          echo "EIGEN3_INCLUDE_DIR=${{ steps.install-dependencies.outputs.EIGEN3_ROOT }}/include/eigen3" >> $GITHUB_ENV
+          echo "Eigen3_ROOT=${{ runner.temp }}/eigen" >> $GITHUB_ENV
 
       # Precompiled, so the .ipp files become translation units CodeQL can see.
       - name: Build (precompiled, so the .ipp tree is compiled)
@@ -56,7 +61,8 @@ jobs:
           mkdir build-codeql && cd build-codeql
           cmake .. -DCMAKE_BUILD_TYPE=Release \
             -DVINECOPULIB_PRECOMPILED=ON \
-            -DBUILD_TESTING=OFF
+            -DBUILD_TESTING=OFF \
+            -DCMAKE_FIND_USE_PACKAGE_REGISTRY=OFF
           make -j"$(nproc)"
 
       - name: Perform CodeQL analysis

--- a/NEWS.md
+++ b/NEWS.md
@@ -321,6 +321,15 @@ wrong thing.
 * Include the thread header explicitly where it was relied on transitively
   (#676)
 
+* Synchronize `ThreadPool`: it read the stop flag, the job queue, the busy
+  count and the stored exception without holding its mutex, a data race that
+  could let a worker exit or `wait()` return with jobs still queued. An
+  exception stored by a job now also wakes `wait()` (#764)
+
+* Fix `tools_stats::find_latent_sample`, which counted its sweeps in a
+  `uint16_t` against a `size_t niter`: a count above 65535 wrapped to zero and
+  the loop never terminated. Results are unchanged (#764)
+
 ### BUILD SYSTEM AND DEPENDENCIES
 
 * Require wdm 0.3.0, for Chatterjee's xi and for the random tie-breaking fix
@@ -405,6 +414,11 @@ wrong thing.
 * Enforce the clang-format style in CI (#646, #649)
 
 * Fix documentation typos and the mBIC formula (#660, #665, #703, #716)
+
+* Report only actionable CodeQL results: Eigen now installs and resolves
+  outside the workspace, so its own findings are no longer attributed to this
+  repository, and the two query classes that cannot be satisfied here are
+  excluded through a config file (#764)
 
 ## vinecopulib 0.7.3 (April 23, 2025)
 

--- a/benchmarks/src/bench_vinecop.cpp
+++ b/benchmarks/src/bench_vinecop.cpp
@@ -114,6 +114,57 @@ register_select(size_t d, const std::string& label, FitControlsVinecop controls)
   }
 }
 
+//! Thread-pool scaling. `select` dispatches one job per edge, so the pool's
+//! own cost grows with the dimension while each job stays cheap at small `n` --
+//! which is where pool overhead is the largest share of the runtime. `pdf`
+//! batches rows instead, at `num_threads * floor(sqrt(n / num_threads))` jobs,
+//! so it needs a large `n` to queue a comparable number. `threads=1` is the
+//! control: both paths map it to a pool with no workers and run inline.
+void
+register_select_scaling(size_t d, size_t n)
+{
+  auto vc = bench::make_gaussian_vine(d);
+  auto u =
+    std::make_shared<const Eigen::MatrixXd>(vc.simulate(n, false, 1, { 5 }));
+  const std::string suffix =
+    "d=" + std::to_string(d) + "/n=" + std::to_string(n);
+
+  for (size_t threads : { size_t(1), size_t(8), size_t(16), size_t(32) }) {
+    FitControlsVinecop ctrl(bicop_families::itau, "itau");
+    ctrl.set_num_threads(threads);
+    benchmark::RegisterBenchmark(("vinecop/threads/select/" + suffix +
+                                  "/threads=" + std::to_string(threads))
+                                   .c_str(),
+                                 [u, ctrl](benchmark::State& st) {
+                                   for (auto _ : st) {
+                                     Vinecop fitted(
+                                       *u, RVineStructure(), {}, ctrl);
+                                     benchmark::DoNotOptimize(fitted);
+                                   }
+                                 });
+  }
+}
+
+void
+register_pdf_scaling(size_t d, size_t n)
+{
+  auto vc = std::make_shared<const Vinecop>(bench::make_gaussian_vine(d));
+  auto u =
+    std::make_shared<const Eigen::MatrixXd>(vc->simulate(n, false, 1, { 5 }));
+  const std::string suffix =
+    "d=" + std::to_string(d) + "/n=" + std::to_string(n);
+
+  for (size_t threads : { size_t(1), size_t(8), size_t(16), size_t(32) }) {
+    benchmark::RegisterBenchmark(
+      ("vinecop/threads/pdf/" + suffix + "/threads=" + std::to_string(threads))
+        .c_str(),
+      [vc, u, threads](benchmark::State& st) {
+        for (auto _ : st)
+          benchmark::DoNotOptimize(vc->pdf(*u, threads));
+      });
+  }
+}
+
 void
 register_cdf()
 {
@@ -144,6 +195,13 @@ struct Registrar
     register_select(
       10, "itau", FitControlsVinecop(bicop_families::itau, "itau"));
     register_select(5, "tll", FitControlsVinecop({ BicopFamily::tll }));
+
+    for (size_t d : { size_t(5), size_t(10), size_t(20) }) {
+      for (size_t n : { size_t(200), size_t(1000) })
+        register_select_scaling(d, n);
+      for (size_t n : { size_t(1000), size_t(10000) })
+        register_pdf_scaling(d, n);
+    }
   }
 };
 const Registrar registrar;

--- a/include/vinecopulib/bicop/archimedean.hpp
+++ b/include/vinecopulib/bicop/archimedean.hpp
@@ -61,8 +61,6 @@ private:
     const double& u,
     const Eigen::Ref<const Eigen::VectorXd>& parameters) = 0;
 
-  // virtual double generator_derivative2(const double &u) = 0;
-
   Eigen::VectorXd get_start_parameters(const double tau) override;
 };
 }

--- a/include/vinecopulib/bicop/implementation/archimedean.ipp
+++ b/include/vinecopulib/bicop/implementation/archimedean.ipp
@@ -7,20 +7,6 @@
 #include <vinecopulib/misc/tools_eigen.hpp>
 
 namespace vinecopulib {
-// inline Eigen::VectorXd ArchimedeanBicop::pdf(
-//    const Eigen::MatrixXd &u
-//)
-//{
-//    auto f = [this](const double &u1, const double &u2) {
-//        double temp = generator_inv(generator(u1) + generator(u2));
-//        temp = log(std::abs(generator_derivative2(temp))) -
-//            3.0 * log(std::abs(generator_derivative(temp)));
-//        temp += std::log(std::abs(generator_derivative(u1)));
-//        temp += std::log(std::abs(generator_derivative(u2)));
-//        return std::exp(temp);
-//    };
-//    return tools_eigen::binaryExpr_or_nan(u, f);
-//}
 
 inline Eigen::VectorXd
 ArchimedeanBicop::cdf(const Eigen::MatrixXd& u,

--- a/include/vinecopulib/misc/implementation/tools_stats.ipp
+++ b/include/vinecopulib/misc/implementation/tools_stats.ipp
@@ -316,11 +316,14 @@ find_latent_sample(const Eigen::MatrixXd& u, double b, size_t niter)
 
   Eigen::MatrixXd x(n, 2), norm_sim(n, 2);
 
-  for (uint16_t it = 0; it < niter; it++) {
+  for (size_t it = 0; it < niter; it++) {
     uu = to_pseudo_obs(uu);
     x = qnorm(uu);
-    norm_sim = simulate_normal(n, 2, false, { it, 5 }).array() * b;
-    w = simulate_uniform(n, 1, false, { it, 55 });
+    // the seed vectors hold `int`, which a `size_t` does not narrow to
+    // implicitly inside a braced initializer
+    const auto seed = static_cast<int>(it);
+    norm_sim = simulate_normal(n, 2, false, { seed, 5 }).array() * b;
+    w = simulate_uniform(n, 1, false, { seed, 55 });
 
     for (size_t i = 0; i < n; i++) {
       covering.get_box_indices(lb.row(i), ub.row(i), indices);
@@ -759,7 +762,7 @@ pbvt(const Eigen::MatrixXd& z, int nu, double rho)
       xnkh = 0.;
     }
     d1 = h - rho * k;
-    hs = static_cast<int>(d1 >= 0 ? 1 : -1); // d_sign(&c_b91, &d1);
+    hs = static_cast<int>(d1 >= 0 ? 1 : -1);
     d1 = k - rho * h;
     ks = static_cast<int>(d1 >= 0 ? 1 : -1);
     if (nu % 2 == 0) {

--- a/include/vinecopulib/misc/tools_thread.hpp
+++ b/include/vinecopulib/misc/tools_thread.hpp
@@ -9,6 +9,7 @@
 #include <atomic>
 #include <condition_variable>
 #include <future>
+#include <mutex>
 #include <queue>
 #include <thread>
 #include <vector>
@@ -42,16 +43,22 @@ public:
   void clear();
 
 private:
+  // `jobs_`, `stopped_`, `num_busy_` and `error_ptr_` may only be touched
+  // while holding `m_tasks_`. A member whose name ends in `_locked` requires
+  // the caller to hold it and keeps it held; one taking a
+  // `std::unique_lock<std::mutex>&` requires the caller to hold it, but may
+  // release it while waiting.
   void start_worker();
   void do_job(std::function<void()>&& job);
-  void announce_busy();
+  void announce_busy_locked();
   void announce_idle();
   void announce_stop();
   void join_workers();
+  void clear_locked();
 
-  bool has_errored();
-  bool all_jobs_done();
-  bool wait_for_wake_up_event();
+  bool has_errored_locked() const;
+  bool all_jobs_done_locked() const;
+  bool wait_for_wake_up_event(std::unique_lock<std::mutex>& lk);
   void rethrow_exceptions();
 
   std::vector<std::thread> workers_;       // worker threads in the pool
@@ -135,17 +142,20 @@ ThreadPool::map(F&& f, I&& items)
 inline void
 ThreadPool::wait()
 {
-  while (true) {
-    if (wait_for_wake_up_event()) {
-      if (!this->all_jobs_done()) {
-        this->clear(); // cancel all remaining jobs
-        continue;      // wait for currently running jobs
+  {
+    // must hold the lock while reading the shared state; the wake up event
+    // releases it while waiting
+    std::unique_lock<std::mutex> lk(m_tasks_);
+    while (true) {
+      if (this->wait_for_wake_up_event(lk)) {
+        if (this->all_jobs_done_locked())
+          break;
+        // an error makes the jobs that have not started pointless; the ones
+        // already running still have to finish
+        this->clear_locked();
       }
-      if (this->has_errored() || this->all_jobs_done())
-        break;
     }
-    std::this_thread::yield();
-  }
+  } // the lock must be released before the exception is rethrown
 
   this->rethrow_exceptions();
 }
@@ -165,6 +175,14 @@ ThreadPool::clear()
 {
   // must hold lock while modifying job queue
   std::lock_guard<std::mutex> lk(m_tasks_);
+  this->clear_locked();
+}
+
+//! clears the pool from all open jobs (must be called while holding
+//! `m_tasks_`).
+inline void
+ThreadPool::clear_locked()
+{
   std::queue<std::function<void()>>().swap(jobs_);
   cv_tasks_.notify_all();
 }
@@ -174,26 +192,25 @@ inline void
 ThreadPool::start_worker()
 {
   workers_.emplace_back([this] {
-    std::function<void()> job;
-    // observe thread pool; only stop after all jobs are done
-    while ((!stopped_) | (!jobs_.empty())) {
-      // must hold a lock while modifying shared variables
+    while (true) {
+      // must hold a lock while reading or modifying shared variables
       std::unique_lock<std::mutex> lk(m_tasks_);
 
       // thread should wait when there is no job
       cv_tasks_.wait(lk, [this] { return stopped_ || !jobs_.empty(); });
 
-      // queue can be empty if thread pool is stopped
+      // an empty queue implies the pool was stopped, and nothing can be
+      // pushed to a stopped pool; there is no work left to wait for
       if (jobs_.empty())
-        continue;
+        return;
 
       // take job from the queue
-      job = std::move(jobs_.front());
+      auto job = std::move(jobs_.front());
       jobs_.pop();
 
       // lock can be released before starting work, but must signal
       // that thread will be busy before (!) to avoid premature breaks
-      this->announce_busy();
+      this->announce_busy_locked();
       lk.unlock();
 
       this->do_job(std::move(job));
@@ -211,14 +228,17 @@ ThreadPool::do_job(std::function<void()>&& job)
   try {
     job();
   } catch (...) {
-    std::lock_guard<std::mutex> lk(m_tasks_);
-    error_ptr_ = std::current_exception();
+    {
+      std::lock_guard<std::mutex> lk(m_tasks_);
+      error_ptr_ = std::current_exception();
+    }
+    cv_busy_.notify_one();
   }
 }
 
-//! signals that a worker is busy (must be called why locking m_tasks_).
+//! signals that a worker is busy (must be called while holding `m_tasks_`).
 inline void
-ThreadPool::announce_busy()
+ThreadPool::announce_busy_locked()
 {
   ++num_busy_;
   cv_busy_.notify_one();
@@ -258,31 +278,35 @@ ThreadPool::join_workers()
   }
 }
 
-//! checks if an error occurred.
+//! checks if an error occurred (must be called while holding `m_tasks_`).
 inline bool
-ThreadPool::has_errored()
+ThreadPool::has_errored_locked() const
 {
   return static_cast<bool>(error_ptr_);
 }
 
-//! check whether all jobs are done
+//! check whether all jobs are done (must be called while holding `m_tasks_`).
 inline bool
-ThreadPool::all_jobs_done()
+ThreadPool::all_jobs_done_locked() const
 {
   return (num_busy_ == 0) && jobs_.empty();
 }
 
-//! checks whether `wait()` needs to wake up
+//! checks whether `wait()` needs to wake up, i.e., all jobs are done or an
+//! error makes the jobs that have not started pointless.
+//! @param lk A lock on `m_tasks_` held by the caller; released while waiting.
 inline bool
-ThreadPool::wait_for_wake_up_event()
+ThreadPool::wait_for_wake_up_event(std::unique_lock<std::mutex>& lk)
 {
   static auto timeout = std::chrono::milliseconds(250);
-  auto wake_up_event_occured = [this] {
-    return this->all_jobs_done() || this->has_errored();
+  auto wake_up_event_occurred = [this] {
+    return this->all_jobs_done_locked() ||
+           (this->has_errored_locked() && !jobs_.empty());
   };
-  std::unique_lock<std::mutex> lk(m_tasks_);
-  cv_busy_.wait_for(lk, timeout, wake_up_event_occured);
-  return wake_up_event_occured();
+  // the timeout bounds the wait: `cv_busy_` is notified to a single waiter,
+  // and pushing a job does not notify it at all
+  cv_busy_.wait_for(lk, timeout, wake_up_event_occurred);
+  return wake_up_event_occurred();
 }
 
 //! rethrows exceptions (exceptions from workers are caught and stored; the
@@ -290,8 +314,14 @@ ThreadPool::wait_for_wake_up_event()
 inline void
 ThreadPool::rethrow_exceptions()
 {
-  if (this->has_errored())
-    std::rethrow_exception(error_ptr_);
+  std::exception_ptr error_ptr;
+  {
+    // must hold the lock while reading the stored exception
+    std::lock_guard<std::mutex> lk(m_tasks_);
+    error_ptr = error_ptr_;
+  }
+  if (error_ptr)
+    std::rethrow_exception(error_ptr);
 }
 
 }

--- a/include/vinecopulib/misc/tools_thread.hpp
+++ b/include/vinecopulib/misc/tools_thread.hpp
@@ -6,12 +6,16 @@
 
 #pragma once
 
-#include <atomic>
+#include <chrono>
 #include <condition_variable>
+#include <exception>
+#include <functional>
 #include <future>
 #include <mutex>
 #include <queue>
+#include <stdexcept>
 #include <thread>
+#include <utility>
 #include <vector>
 
 namespace vinecopulib {

--- a/test/src_test/test_tools_stats.cpp
+++ b/test/src_test/test_tools_stats.cpp
@@ -290,6 +290,17 @@ TEST(test_tools_stats, find_latent_sample)
                std::runtime_error);
 }
 
+// The sweep counter has to be as wide as `niter`, or a count above its range
+// wraps to zero and the loop never ends.
+TEST(test_tools_stats, find_latent_sample_sweeps_more_than_a_short_can_count)
+{
+  Eigen::MatrixXd u(2, 4);
+  u << 0.25, 0.75, 0.0, 0.5, 0.75, 0.25, 0.5, 0.0;
+
+  const size_t niter = 70000;
+  EXPECT_EQ(tools_stats::find_latent_sample(u, 0.1, niter).rows(), u.rows());
+}
+
 // Every random component is a fixed-seed quasi-random sequence, so the draw is
 // reproducible.
 TEST(test_tools_stats, find_latent_sample_is_deterministic)

--- a/test/src_test/test_tools_thread.cpp
+++ b/test/src_test/test_tools_thread.cpp
@@ -1,0 +1,147 @@
+// Copyright © 2016-2026 Thomas Nagler and Thibault Vatter
+//
+// This file is part of the vinecopulib library and licensed under the terms of
+// the MIT license. For a copy, see the LICENSE file in the root directory of
+// vinecopulib or https://vinecopulib.github.io/vinecopulib/.
+
+#include "gtest/gtest.h"
+#include <atomic>
+#include <chrono>
+#include <stdexcept>
+#include <thread>
+#include <vector>
+#include <vinecopulib/misc/tools_interface.hpp>
+
+namespace test_tools_thread {
+
+using namespace vinecopulib::tools_thread;
+
+// The pool's state is only consistent to the thread holding its mutex, so the
+// jobs below touch nothing but an atomic counter and every assertion is made
+// from the main thread after a wait(), join() or the destructor.
+
+TEST(test_tools_thread, runs_every_job)
+{
+  const int n_jobs = 1000;
+  const std::vector<size_t> worker_counts{ 0, 1, 4 };
+  for (size_t n_workers : worker_counts) {
+    std::atomic<int> ran{ 0 };
+    ThreadPool pool(n_workers);
+    for (int i = 0; i < n_jobs; ++i)
+      pool.push([&ran]() noexcept { ++ran; });
+    pool.wait();
+    EXPECT_EQ(ran.load(), n_jobs) << "with " << n_workers << " workers";
+    pool.join();
+  }
+}
+
+// Without workers the job runs at the push site, and so does its exception.
+TEST(test_tools_thread, no_workers_runs_inline)
+{
+  ThreadPool pool(0);
+  std::thread::id job_id;
+  pool.push([&job_id]() noexcept { job_id = std::this_thread::get_id(); });
+  EXPECT_EQ(job_id, std::this_thread::get_id());
+
+  EXPECT_THROW(pool.push([] { throw std::runtime_error("job failed"); }),
+               std::runtime_error);
+  EXPECT_NO_THROW(pool.wait());
+  EXPECT_NO_THROW(pool.join());
+}
+
+TEST(test_tools_thread, exception_propagates_from_wait)
+{
+  ThreadPool pool(2);
+  pool.push([] { throw std::runtime_error("job failed"); });
+  try {
+    pool.wait();
+    FAIL() << "wait() did not rethrow the job's exception";
+  } catch (const std::runtime_error& e) {
+    EXPECT_STREQ(e.what(), "job failed");
+  }
+}
+
+// An error cancels what has not started, but wait() still returns only once the
+// jobs already running have finished.
+TEST(test_tools_thread, error_cancels_queued_jobs)
+{
+  const int n_jobs = 200;
+  std::atomic<int> ran{ 0 };
+  int ran_on_return = 0;
+  {
+    ThreadPool pool(2);
+    pool.push([] { throw std::runtime_error("job failed"); });
+    for (int i = 0; i < n_jobs; ++i)
+      pool.push([&ran] {
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        ++ran;
+      });
+    EXPECT_THROW(pool.wait(), std::runtime_error);
+    ran_on_return = ran.load();
+    EXPECT_LT(ran_on_return, n_jobs);
+  }
+  EXPECT_EQ(ran.load(), ran_on_return) << "a job ran after wait() returned";
+}
+
+// A worker may only exit once the queue is drained, so the destructor runs
+// every job that was pushed.
+TEST(test_tools_thread, destructor_drains_queued_jobs)
+{
+  const int n_jobs = 100;
+  std::atomic<int> ran{ 0 };
+  {
+    ThreadPool pool(2);
+    for (int i = 0; i < n_jobs; ++i)
+      pool.push([&ran]() noexcept { ++ran; });
+  }
+  EXPECT_EQ(ran.load(), n_jobs);
+}
+
+TEST(test_tools_thread, clear_then_join_terminates)
+{
+  std::atomic<int> ran{ 0 };
+  ThreadPool pool(2);
+  for (int i = 0; i < 1000; ++i)
+    pool.push([&ran]() noexcept { ++ran; });
+  pool.clear();
+  EXPECT_NO_THROW(pool.join());
+  EXPECT_LE(ran.load(), 1000);
+}
+
+TEST(test_tools_thread, push_after_join_throws)
+{
+  ThreadPool pool(2);
+  pool.join();
+  EXPECT_THROW(pool.push([]() noexcept {}), std::runtime_error);
+  EXPECT_NO_THROW(pool.join());
+}
+
+// How VinecopSelector drives its pool: map and wait, once per tree.
+TEST(test_tools_thread, reusable_across_rounds)
+{
+  const int n_items = 100;
+  std::atomic<int> ran{ 0 };
+  ThreadPool pool(4);
+  for (int tree = 0; tree < 5; ++tree) {
+    std::vector<int> items(n_items, 0);
+    pool.map([&ran](int) noexcept { ++ran; }, items);
+    pool.wait();
+    EXPECT_EQ(ran.load(), n_items * (tree + 1));
+  }
+  pool.join();
+}
+
+// Repeated start/stop cycles, to be run under -fsanitize=thread.
+TEST(test_tools_thread, repeated_shutdown_is_consistent)
+{
+  const int n_jobs = 50;
+  for (int rep = 0; rep < 50; ++rep) {
+    std::atomic<int> ran{ 0 };
+    ThreadPool pool(4);
+    for (int i = 0; i < n_jobs; ++i)
+      pool.push([&ran]() noexcept { ++ran; });
+    pool.join();
+    EXPECT_EQ(ran.load(), n_jobs);
+  }
+}
+}


### PR DESCRIPTION
Fixes the CodeQL findings on hand-written code and narrows the analysis so the
Security tab reports only actionable results.

The Security tab currently holds **412 open alerts**: 243 from the Eigen tree
cloned into the workspace, 125 from the vendored `nlohmann_json.hpp`, and 44
from our own code — of which 33 are `cpp/poorly-documented-function` on the
generated derivative dispatch functions. That leaves 11 alerts on hand-written
code: **two actual defects**, three blocks of dead code, and six correct-by-intent
idioms.

Alerts point into the gitignored `build-codeql/generated/` tree, because CodeQL
analyses a `VINECOPULIB_PRECOMPILED=ON` build. The mapping is
`generated/src/<mod>/<name>.cpp:N` → `<mod>/implementation/<name>.ipp:N-1`, and
generated headers are line-for-line with their sources.

## 1. Thread pool data race (#136, `cpp/incorrect-not-operator-usage`, high)

The flagged `while ((!stopped_) | (!jobs_.empty()))` was a symptom. The defect
was that `stopped_` and `jobs_` were read there **without holding `m_tasks_`**,
which `push()`, `clear()` and `announce_stop()` all mutate under it. Racing
`std::queue::empty()` against `pop()`/`swap()` is undefined behavior, so a
worker could exit with jobs still queued. `wait()` had the same defect (it
called `all_jobs_done()` and `has_errored()` unlocked), as did
`rethrow_exceptions()`.

Every access to `stopped_`, `jobs_`, `num_busy_` and `error_ptr_` is now under
the lock. Members requiring the caller to hold it are named `_locked`, and
`wait_for_wake_up_event` takes the `unique_lock` by reference because it
releases it while waiting. Kept deliberately:

- the plain `bool`/`size_t` members rather than atomics — every interesting
  predicate involves `jobs_`, which cannot be atomic, so atomics would legalize
  the individual loads while leaving the composite predicate torn;
- the 250 ms `cv_busy_.wait_for` timeout — `cv_busy_` is notified to a single
  waiter and `push()` does not notify it at all. `do_job()` now also notifies it
  when it stores an exception, which it previously did not.

`wait()`'s `std::this_thread::yield()` is gone: it existed to keep an unlocked
poll-spin from starving workers, and every iteration now blocks in `wait_for`.

New `test/src_test/test_tools_thread.cpp` (9 tests): job completion for 0/1/4
workers, inline execution with no workers, exception propagation out of
`wait()`, error-cancels-queued-jobs, destructor drains the queue,
`clear()`-then-`join()`, `push()` after `join()`, repeated map/wait rounds, and
50 start/stop cycles.

## 2. Sweep counter overflow (#415, `cpp/comparison-with-wider-type`, high)

`tools_stats::find_latent_sample` counted sweeps in a `uint16_t` against its
`size_t niter`. `niter` defaults to 3, but the function is public and called
directly in the test suite, so a caller passing more than 65535 wrapped the
counter to zero and the loop never terminated. The counter is now `size_t`; the
seeds derived from it are unchanged (`uint16_t` already promoted to `int` in
those braced lists), so the result stays **bit-identical** — which the golden
value and determinism tests pin.

## 3. Dead code (#125, #171, #127, `cpp/commented-out-code`)

A commented-out `ArchimedeanBicop::pdf`, a commented-out pure-virtual
`generator_derivative2` declaration, and an f2c `d_sign` breadcrumb.
`generator_derivative2` exists nowhere else in the tree, and `ArchimedeanBicop`
declares no `pdf` at all. Deleted even though §5 stops the rule that found them
from running.

## 4. Six alerts left open deliberately

Verified correct as written, to be dismissed in the UI rather than worked
around:

- `cpp/equality-on-floats` on `frank.ipp:702` (`sum != sumold` is a
  converged-to-machine-precision test), `student.ipp:548` (`nu == round(nu)`
  selects the exact `pbvt` path) and `tools_select.ipp:1263` (`fit_id` is a
  deliberate fingerprint for reusing pair-copula fits; identical data gives an
  identical sum).
- `cpp/loop-variable-changed` on `tools_eigen.ipp:26,53` (`remove_nans`'
  swap-to-the-end partition, which terminates for every input including a
  zero-row matrix) and `frank.ipp:705` (`debye1`'s paired even/odd term
  accumulation — `koeff` is `std::array<double, 71>` and the maximum index
  reached is exactly 70).

## 5. Narrowing the analysis

**Eigen (243 alerts).** `.github/actions/install-dependencies` clones Eigen to
`eigen-src` in the workspace and configures a build tree there, which registers
itself in CMake's user package registry advertising the *source* directory as
the include path. The `EIGEN3_INCLUDE_DIR` line meant to prevent this never
worked: it is exported as an *environment* variable, while
`findDependencies.cmake:14` tests `if(NOT DEFINED EIGEN3_INCLUDE_DIR)`, a CMake
variable. So `find_package` fell through to the registry and compiled against
the in-workspace tree, putting Eigen's headers inside the analyzed source root.

Note this cannot be fixed by passing `-DEIGEN3_INCLUDE_DIR=...`: that skips
`find_package`, and `buildTargets.cmake` links `Eigen3::Eigen` unconditionally,
so the configure would fail. Instead Eigen installs to `$RUNNER_TEMP` and
`Eigen3_ROOT` is exported, which CMP0074 honors and which is searched ahead of
the package registry. Boost already produces zero alerts for exactly this
reason — it installs outside the workspace.

There are **no** path filters. GitHub documents `paths-ignore` for interpreted
languages or compiled languages analyzed *without* building; I tried it anyway
and measured it filtering nothing here, so it is gone rather than left in place
implying the vendored header is handled.

**Query filters.** `cpp/poorly-documented-function` fires only on the generated
derivative dispatch functions (up to 1,940 lines of dense algebra); satisfying
its 2% comment threshold would mean filler comments, against this repo's own
rule that comments are documentation. `cpp/commented-out-code` fires on the
vendored JSON header's `// #include <nlohmann/detail/...>` amalgamation markers
— 99 of its 105 alerts there — which are upstream's provenance trail.

## Verification

- 747/747 tests pass in a strict Debug build (`VINECOPULIB_STRICT_COMPILER=ON`,
  so `-Werror -Wconversion -Wshadow -Wnoexcept -Wold-style-cast`), with the R
  parity tests enabled.
- 747/747 pass in a `VINECOPULIB_PRECOMPILED=ON` release build, and the fixes
  were confirmed present in the derived translation units — the path CodeQL
  actually analyses.
- clang-format 14 and codespell 2.4.3 clean.

**ThreadSanitizer confirms the fix**, using clang rather than GCC:

| build | TSan result |
| --- | --- |
| pre-fix (`main`'s `tools_thread.hpp`) | **3 data races** — `announce_stop()` writing `stopped_`, plus two on `jobs_.empty()` via `deque::operator==`: exactly the unsynchronized reads in the old `while ((!stopped_) \| (!jobs_.empty()))` guard |
| post-fix (this branch) | **0 warnings**, clean exit |
| `test_tools_thread` (9 tests) | **0 warnings**, all pass |

GCC 11's libtsan cannot be used for this and produced only false positives. It
is not the kernel, as I first assumed: it mis-tracks the mutex across
`pthread_cond_timedwait`, so any code using `std::condition_variable::wait_for`
— which `wait()` does — loses its happens-before edge and every access that
mutex protects is reported. Reduced to 20 lines:

```cpp
// provably correct: both threads touch payload/ready only under m
std::mutex m; std::condition_variable cv; bool ready = false; long payload = 0;
// producer: { lock_guard lk(m); payload = i; ready = true; } cv.notify_one();
// consumer: unique_lock lk(m); cv.wait_for(lk, 10us, [&]{ return ready; });
```

g++-11 reports a data race and a "double lock"; plain `cv.wait` is clean; clang
14 and 16 are clean. A textbook worker pool with no vinecopulib code gets 9
warnings under g++-11 and 0 under clang-16, which is what identified the
runtime rather than the code as the problem.

Reproduce:

```
cmake -S . -B build/tsan -DCMAKE_BUILD_TYPE=Debug \
  -DCMAKE_CXX_COMPILER=clang++-16 -DVINECOPULIB_SANITIZERS=OFF \
  -DCMAKE_CXX_FLAGS="-fsanitize=thread -fno-omit-frame-pointer -g"
cmake --build build/tsan --target test_tools_thread_only
setarch "$(uname -m)" -R build/tsan/bin/test_tools_thread_only
```

`setarch -R` is needed only to get past a startup `FATAL: unexpected memory
mapping` from this kernel's ASLR entropy; it does not affect the verdict.
See #769 for adding this to CI.

## Measured effect

A `workflow_dispatch` run on this branch — **not** a `pull_request` run, which
CodeQL restricts to the diff (`Persisted 38 diff range(s) across 7 file(s)`),
making PR runs useless for measuring a total — reports **25 alerts against 412
on `main`**:

| | `main` | this branch |
| --- | --- | --- |
| `eigen-src/` | 243 | **0** |
| vendored `nlohmann_json.hpp` | 125 | 19 |
| hand-written vinecopulib code | 44 | **6** |
| **total** | **412** | **25** |

The 6 are exactly the intentional idioms listed above — both real defects are
gone, and nothing else in hand-written code is left. 177 rules were evaluated
against 179 on `main`, i.e. exactly the two exclusions.

The 19 in the vendored header are `long-switch` ×8, `use-of-goto` ×2,
`loop-variable-changed` ×2, `unused-local-variable` ×2, and one each of
`unused-static-variable`, `trivial-switch`, `complex-block`,
`stack-address-escape` and `missing-return`. They want a one-time dismissal —
best done after #765, which replaces that file and moves every line number.
Excluding those rules repo-wide is not an option: `stack-address-escape` and
`missing-return` are worth keeping on our own code.

## Cost of the extra locking

The fix adds locking, so it is fair to ask whether it costs anything. It does
not, and the accounting says why:

| | before | after |
| --- | --- | --- |
| lock acquisitions **per job** | 2 (worker loop + `announce_idle`) | 2 — unchanged |
| lock acquisitions **per `wait()`** | ≥1 per poll iteration, spinning with `yield()` | 1 held across the loop, +1 in `rethrow_exceptions` |

The worker hot path takes the same number of acquisitions and only loses two
unsynchronized loads. The one added acquisition is per `wait()`, which runs O(d)
times per fit (~19 at d=20), not per job — and the old `wait()` spin-polled,
which the new one replaces with a condition-variable block.

Measured with the thread-pool scaling benchmarks added in this PR (d = 5, 10, 20;
1/8/16/32 threads; `select` at n = 200/1000 where jobs are numerous and cheap,
`pdf` at n = 1000/10000), building `bench_all` twice from the same tree with only
`tools_thread.hpp` swapped:

- **Interleaved A/B/A/B, 4 rounds: −0.8% geometric mean** (i.e. marginally
  faster), per-cell scatter ±5%.
- A first, naive attempt — all of `before` then all of `after` — reported +2.1%.
  That was run-order drift, not the change: the `threads=1` cells map to
  `ThreadPool(0)` and run inline without ever touching the mutex, so they
  **cannot** be affected, yet they moved by the same +2%; and a same-binary
  `before`-vs-`before` control drifted +1.6%. Interleaving removes the offset and
  flips its sign.

So the difference is below the measurement floor on a quiet 64-core box, in the
direction the mechanism predicts.

## Follow-ups found along the way, not fixed here

- The `EIGEN3_INCLUDE_DIR` opt-out that AGENTS.md documents is broken for
  everyone, not just CodeQL: defining it skips `find_package(Eigen3)` while
  `buildTargets.cmake` links `Eigen3::Eigen` unconditionally. Same shape for
  `Boost_INCLUDE_DIRS`/`Boost::headers`. Six other workflow steps export the
  same ineffective variable.
- `ThreadPool::error_ptr_` is never cleared, so once a pool has errored every
  later `wait()`/`join()` rethrows the same exception. Not reachable today, but
  wrong for the long-lived `VinecopSelector::pool_`; fixing it means deciding
  whether `join()` should still stop the workers when `wait()` throws.
- `findHeaders.cmake`'s `.hpp` loop still uses `string(REGEX REPLACE)` on
  absolute paths, so a source directory containing `+` or `.` misbehaves. The
  `.ipp` loop was deliberately converted to `string(REPLACE)` for this reason.

A stacked PR will follow for the vendored nlohmann/json header (bump 3.9.1 →
3.12.0, re-vendored verbatim with the CRAN diagnostic-pragma patches
re-applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


