### PR TITLE
Fix the thread-pool error state, the dependency-path and generated-header builds, and add a ThreadSanitizer job

### DIFF
--- a/.github/actions/install-dependencies/action.yml
+++ b/.github/actions/install-dependencies/action.yml
@@ -116,6 +116,13 @@ runs:
             -DCMAKE_INSTALL_PREFIX="$prefix" \
             -DBUILD_TESTING=OFF
           cmake --build eigen-src/build --config Release --target install
+          echo "Eigen3_ROOT=$prefix" >> $GITHUB_ENV
+      shell: bash
+
+    # find_package reads both through CMP0074, so every caller needs them.
+    - name: Export the dependency roots
+      if: inputs.boost == 'true'
+      run: echo "BOOST_ROOT=${{ steps.boost.outputs.BOOST_ROOT }}" >> $GITHUB_ENV
       shell: bash
 
     - name: Install wdm (pinned to ${{inputs.wdm_ref}})

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -52,7 +52,6 @@ jobs:
       - name: Set environment variables
         run: |
           echo "BOOST_ROOT=${{ steps.install-dependencies.outputs.BOOST_ROOT }}" >> $GITHUB_ENV
-          echo "Boost_INCLUDE_DIR=${{ steps.install-dependencies.outputs.BOOST_ROOT }}/include" >> $GITHUB_ENV
           echo "Eigen3_ROOT=${{ runner.temp }}/eigen" >> $GITHUB_ENV
 
       # Precompiled, so the .ipp files become translation units CodeQL can see.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,14 +46,6 @@ jobs:
           R: false
           lcov: false
 
-      # BOOST_ROOT and Eigen3_ROOT must be exported: find_package picks them
-      # up via CMP0074, ahead of CMake's user package registry, where the
-      # in-workspace eigen-src build tree registers itself.
-      - name: Set environment variables
-        run: |
-          echo "BOOST_ROOT=${{ steps.install-dependencies.outputs.BOOST_ROOT }}" >> $GITHUB_ENV
-          echo "Eigen3_ROOT=${{ runner.temp }}/eigen" >> $GITHUB_ENV
-
       # Precompiled, so the .ipp files become translation units CodeQL can see.
       - name: Build (precompiled, so the .ipp tree is compiled)
         run: |

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -133,8 +133,11 @@ jobs:
             if [ "${{ matrix.cfg.os }}/${{ matrix.cfg.name }}" == "ubuntu-latest/GNU" ]; then
               cmake .. -DVINECOPULIB_STRICT_COMPILER=ON \
                 -DVINECOPULIB_CODE_COVERAGE=ON \
+                -DVINECOPULIB_SANITIZERS=ON \
                 -DCMAKE_BUILD_TYPE=Debug \
                 -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+              ASAN_OPTIONS=detect_leaks=1:detect_stack_use_after_return=1 \
+              UBSAN_OPTIONS=halt_on_error=1:print_stacktrace=1 \
               make vinecopulib_coverage
             else
               cmake .. -DCMAKE_BUILD_TYPE=Debug

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -120,13 +120,7 @@ jobs:
         run: |
           echo "CC=${{ matrix.cfg.cc }}" >> $GITHUB_ENV
           echo "CXX=${{ matrix.cfg.cxx }}" >> $GITHUB_ENV
-          echo "BOOST_ROOT=${{ steps.install-dependencies.outputs.BOOST_ROOT }}" >> $GITHUB_ENV
           if [ "${{ matrix.cfg.os }}" == "windows-latest" ]; then
-            # Linux and macOS runners ship an Eigen that find_package locates on
-            # its own; Windows does not, so point it at the one we installed.
-            # CMP0074 makes find_package honor <Package>_ROOT from the
-            # environment.
-            echo "Eigen3_ROOT=D:/" >> $GITHUB_ENV
             echo "D:\a\vinecopulib\vinecopulib\debug" >> $GITHUB_PATH
             echo "D:\a\vinecopulib\vinecopulib\release" >> $GITHUB_PATH
             echo "D:\a\vinecopulib\vinecopulib\release\Release" >> $GITHUB_PATH
@@ -239,12 +233,7 @@ jobs:
           os: ubuntu-latest
           boost_version: ${{ env.BOOST_VERSION }}
           eigen_version: ${{ env.EIGEN_VERSION }}
-          eigen_install_dir: ${{ runner.temp }}/eigen
           R: true
-      - name: Set environment variables
-        run: |
-          echo "BOOST_ROOT=${{ steps.install-dependencies.outputs.BOOST_ROOT }}" >> $GITHUB_ENV
-          echo "Eigen3_ROOT=${{ runner.temp }}/eigen" >> $GITHUB_ENV
       - name: Configure, build, test and install (header-only)
         run: |
           mkdir release && cd release
@@ -261,34 +250,14 @@ jobs:
           for ex in bicop vinecop; do
             ( cd "examples/$ex" && mkdir build && cd build && cmake .. && make && ../bin/main )
           done
-      # CMAKE_DISABLE_FIND_PACKAGE_* makes the consumer unable to find the
-      # dependencies, so the paths recorded in the package have to serve.
-      - name: Consume an install configured with dependency paths
-        run: |
-          cmake -S . -B build-prefix \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DBUILD_TESTING=OFF \
-            -DCMAKE_INSTALL_PREFIX="$RUNNER_TEMP/prefix" \
-            -DEIGEN3_INCLUDE_DIR="$RUNNER_TEMP/eigen/include/eigen3" \
-            -DBoost_INCLUDE_DIRS="$BOOST_ROOT/include" \
-            -Dwdm_INCLUDE_DIRS=/usr/local/include
-          cmake --install build-prefix
-          # without the build tree and binary the step above left behind
-          cp -a examples/bicop "$RUNNER_TEMP/consumer"
-          rm -rf "$RUNNER_TEMP/consumer/build" "$RUNNER_TEMP/consumer/bin"
-          cmake -S "$RUNNER_TEMP/consumer" -B "$RUNNER_TEMP/consumer/build" \
-            -DCMAKE_PREFIX_PATH="$RUNNER_TEMP/prefix" \
-            -DCMAKE_DISABLE_FIND_PACKAGE_Eigen3=ON \
-            -DCMAKE_DISABLE_FIND_PACKAGE_Boost=ON \
-            -DCMAKE_DISABLE_FIND_PACKAGE_wdm=ON
-          cmake --build "$RUNNER_TEMP/consumer/build" -j"$(nproc)"
-          "$RUNNER_TEMP/consumer/bin/main" > /dev/null
 
-  # Two configure-time defects the matrix cannot reach; nothing is compiled.
-  configure-checks:
-    name: cmake configure checks (ubuntu)
+  # What the build system promises users: dependency paths that work, a
+  # generated tree that does not depend on the source path, and an installed
+  # package a consumer can resolve. Only the last one compiles anything.
+  packaging:
+    name: packaging (ubuntu)
     runs-on: ubuntu-latest
-    timeout-minutes: 20
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
       - name: Install dependencies
@@ -301,74 +270,56 @@ jobs:
           eigen_install_dir: ${{ runner.temp }}/eigen
           R: false
           lcov: false
-      # The second step configures the way an ordinary build does.
-      - name: Set environment variables
+      - name: Record where the dependencies were installed
         run: |
-          echo "BOOST_ROOT=${{ steps.install-dependencies.outputs.BOOST_ROOT }}" >> $GITHUB_ENV
-          echo "Eigen3_ROOT=${{ runner.temp }}/eigen" >> $GITHUB_ENV
-      # A missing namespaced target fails generation, but the plain name wdm
-      # would only fail at link time, so check the generated link line too.
+          eigen="$RUNNER_TEMP/eigen/include/eigen3"
+          test -f "$eigen/Eigen/Dense" || { echo "::error::no Eigen in $eigen"; exit 1; }
+          test -d "$BOOST_ROOT/include/boost" || { echo "::error::no Boost in $BOOST_ROOT"; exit 1; }
+          test -f /usr/local/include/wdm.hpp || { echo "::error::no wdm in /usr/local"; exit 1; }
+          echo "DEP_PATHS=-DEIGEN3_INCLUDE_DIR=$eigen -DBoost_INCLUDE_DIRS=$BOOST_ROOT/include -Dwdm_INCLUDE_DIRS=/usr/local/include" >> $GITHUB_ENV
+      # A missing namespaced target fails generation; the plain name wdm would
+      # only fail at link time, so check the generated link line too.
       - name: Configure with caller-supplied dependency paths
         run: |
-          # Assert the layout, so a change to it fails as itself.
-          eigen_inc="${{ runner.temp }}/eigen/include/eigen3"
-          boost_inc="$BOOST_ROOT/include"
-          test -f "$eigen_inc/Eigen/Dense" \
-            || { echo "::error::no Eigen headers under $eigen_inc"; exit 1; }
-          test -d "$boost_inc/boost" \
-            || { echo "::error::no Boost headers under $boost_inc"; exit 1; }
-          test -f /usr/local/include/wdm.hpp \
-            || { echo "::error::no wdm headers under /usr/local/include"; exit 1; }
-          cmake -S . -B build-dep-paths \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DVINECOPULIB_PRECOMPILED=ON \
-            -DBUILD_SHARED_LIBS=ON \
-            -DBUILD_TESTING=OFF \
-            -DEIGEN3_INCLUDE_DIR="$eigen_inc" \
-            -DBoost_INCLUDE_DIRS="$boost_inc" \
-            -Dwdm_INCLUDE_DIRS=/usr/local/include
-          link_txt=build-dep-paths/CMakeFiles/vinecopulib.dir/link.txt
-          if [ ! -f "$link_txt" ]; then
-            echo "::error::$link_txt was not generated; the check below is void"
-            exit 1
+          cmake -S . -B build-paths -DVINECOPULIB_PRECOMPILED=ON \
+            -DBUILD_TESTING=OFF -DBUILD_SHARED_LIBS=ON $DEP_PATHS
+          if grep -q -- '-lwdm' build-paths/CMakeFiles/vinecopulib.dir/link.txt; then
+            echo "::error::wdm reached the link line as -lwdm"; exit 1
           fi
-          if grep -q -- '-lwdm' "$link_txt"; then
-            echo "::error::wdm reached the link line as -lwdm; its target is missing"
-            exit 1
-          fi
-        shell: bash
       # The translation runs at configure time, so these counts are final.
       - name: Configure from a source path containing regex metacharacters
         run: |
           src="$RUNNER_TEMP/vine+copu.lib"
           cp -a "$GITHUB_WORKSPACE" "$src"
-          cmake -S "$src" -B "$src/build" \
-            -DCMAKE_BUILD_TYPE=Release \
-            -DVINECOPULIB_PRECOMPILED=ON \
-            -DBUILD_TESTING=OFF
-          expected_hpp=$(find "$src/include/vinecopulib" -name '*.hpp' | wc -l)
-          actual_hpp=$(find "$src/build/generated/include/vinecopulib" \
-            -name '*.hpp' 2>/dev/null | wc -l)
-          expected_cpp=$(find "$src/include" -name '*.ipp' | wc -l)
-          actual_cpp=$(find "$src/build/generated/src" \
-            -name '*.cpp' 2>/dev/null | wc -l)
-          echo "headers $actual_hpp/$expected_hpp, sources $actual_cpp/$expected_cpp"
-          if [ "$actual_hpp" -ne "$expected_hpp" ] \
-             || [ "$actual_cpp" -ne "$expected_cpp" ]; then
-            echo "::error::the generated tree is incomplete"
-            exit 1
-          fi
+          cmake -S "$src" -B "$src/build" -DVINECOPULIB_PRECOMPILED=ON -DBUILD_TESTING=OFF
+          count() { find "$1" -name "$2" 2>/dev/null | wc -l; }
+          hpp=$(count "$src/build/generated/include/vinecopulib" '*.hpp')
+          cpp=$(count "$src/build/generated/src" '*.cpp')
+          echo "generated $hpp/$(count "$src/include/vinecopulib" '*.hpp') headers," \
+               "$cpp/$(count "$src/include" '*.ipp') sources"
+          [ "$hpp" -eq "$(count "$src/include/vinecopulib" '*.hpp')" ] \
+            && [ "$cpp" -eq "$(count "$src/include" '*.ipp')" ] \
+            || { echo "::error::the generated tree is incomplete"; exit 1; }
           # A leftover .ipp include gets the implementation compiled twice.
-          if grep -rl '\.ipp>' "$src/build/generated/include"; then
-            echo "::error::a generated header still includes its .ipp"
-            exit 1
-          fi
+          ! grep -rl '\.ipp>' "$src/build/generated/include" || exit 1
           # An untranslated destination path stays in the source tree.
-          if [ -n "$(git -C "$src" status --porcelain -- include)" ]; then
-            echo "::error::configure wrote into the source tree"
-            exit 1
-          fi
-        shell: bash
+          [ -z "$(git -C "$src" status --porcelain -- include)" ] \
+            || { echo "::error::configure wrote into the source tree"; exit 1; }
+      # CMAKE_DISABLE_FIND_PACKAGE_* leaves the consumer unable to find the
+      # dependencies, so the paths recorded in the package have to serve.
+      - name: Install with those paths, then consume the package without them
+        run: |
+          cmake -S . -B build-install -DCMAKE_INSTALL_PREFIX="$RUNNER_TEMP/prefix" \
+            -DBUILD_TESTING=OFF $DEP_PATHS
+          cmake --install build-install
+          cp -a examples/bicop "$RUNNER_TEMP/consumer"
+          cmake -S "$RUNNER_TEMP/consumer" -B "$RUNNER_TEMP/consumer/build" \
+            -DCMAKE_PREFIX_PATH="$RUNNER_TEMP/prefix" \
+            -DCMAKE_DISABLE_FIND_PACKAGE_Eigen3=ON \
+            -DCMAKE_DISABLE_FIND_PACKAGE_Boost=ON \
+            -DCMAKE_DISABLE_FIND_PACKAGE_wdm=ON
+          cmake --build "$RUNNER_TEMP/consumer/build" -j"$(nproc)"
+          "$RUNNER_TEMP/consumer/bin/main" > /dev/null
 
   # VINECOPULIB_SANITIZERS cannot see a data race and cannot be combined
   # with -fsanitize=thread, so this needs a build tree of its own. clang,
@@ -395,11 +346,6 @@ jobs:
           eigen_install_dir: ${{ runner.temp }}/eigen
           R: true
           lcov: false
-      # find_package picks both up via CMP0074.
-      - name: Set environment variables
-        run: |
-          echo "BOOST_ROOT=${{ steps.install-dependencies.outputs.BOOST_ROOT }}" >> $GITHUB_ENV
-          echo "Eigen3_ROOT=${{ runner.temp }}/eigen" >> $GITHUB_ENV
       # RelWithDebInfo, because ThreadSanitizer multiplies an already slow
       # Debug suite; the <area>_only targets build three areas, not fourteen.
       - name: Configure and build with ThreadSanitizer
@@ -416,15 +362,16 @@ jobs:
       # shadow mapping supports; unlike the sysctl it needs no privileges.
       - name: Run the thread-pool tests under ThreadSanitizer
         run: |
-          arch=$(uname -m)
-          setarch "$arch" -R build-tsan/bin/test_tools_thread_only
-          setarch "$arch" -R build-tsan/bin/test_bicop_select_only
+          # A filter that matches nothing exits 0, so count what passed.
+          run() {
+            setarch "$(uname -m)" -R "build-tsan/bin/$1" "${@:2}" | tee tsan.log
+            grep -qE '^\[  PASSED  \] [1-9][0-9]* test' tsan.log
+          }
+          run test_tools_thread_only
+          run test_bicop_select_only
           # Only the fits that ask for more than one thread use the pool.
-          setarch "$arch" -R build-tsan/bin/test_vinecop_class_only \
-            --gtest_filter='VinecopFit.parallel_fit_matches_serial:VinecopTest.works_multi_threaded:VinecopTest.tree_criterion_*:VinecopTest.inverse_rosenblatt_is_safe_for_concurrent_calls' \
-            | tee tsan-vinecop.log
-          # A filter that matches nothing exits 0.
-          grep -qE '^\[  PASSED  \] [1-9][0-9]* test' tsan-vinecop.log
+          run test_vinecop_class_only \
+            --gtest_filter='VinecopFit.parallel_fit_matches_serial:VinecopTest.works_multi_threaded:VinecopTest.tree_criterion_*:VinecopTest.inverse_rosenblatt_is_safe_for_concurrent_calls'
         shell: bash
 
   # Keeps the benchmark and parity targets compiling. The self-comparison
@@ -443,9 +390,6 @@ jobs:
           boost_version: ${{ env.BOOST_VERSION }}
           eigen_version: ${{ env.EIGEN_VERSION }}
           R: false
-      - name: Set environment variables
-        run: |
-          echo "BOOST_ROOT=${{ steps.install-dependencies.outputs.BOOST_ROOT }}" >> $GITHUB_ENV
       - name: Build bench_all and parity_dump
         run: |
           mkdir build-bench && cd build-bench
@@ -491,10 +435,6 @@ jobs:
           eigen_version: ${{ env.EIGEN_VERSION }}
           R: false
           lcov: false
-      # BOOST_ROOT must be exported: find_package picks it up via CMP0074.
-      - name: Set environment variables
-        run: |
-          echo "BOOST_ROOT=${{ steps.install-dependencies.outputs.BOOST_ROOT }}" >> $GITHUB_ENV
       - name: Configure
         run: |
           mkdir build-docs && cd build-docs
@@ -563,9 +503,6 @@ jobs:
           boost_version: ${{ env.BOOST_VERSION }}
           eigen_version: ${{ env.EIGEN_VERSION }}
           R: true
-      - name: Set environment variables
-        run: |
-          echo "BOOST_ROOT=${{ steps.install-dependencies.outputs.BOOST_ROOT }}" >> $GITHUB_ENV
       - name: Configure to generate compile_commands.json
         run: |
           mkdir build-tidy && cd build-tidy

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -273,7 +273,9 @@ jobs:
             -DBoost_INCLUDE_DIRS="$BOOST_ROOT/include" \
             -Dwdm_INCLUDE_DIRS=/usr/local/include
           cmake --install build-prefix
+          # without the build tree and binary the step above left behind
           cp -a examples/bicop "$RUNNER_TEMP/consumer"
+          rm -rf "$RUNNER_TEMP/consumer/build" "$RUNNER_TEMP/consumer/bin"
           cmake -S "$RUNNER_TEMP/consumer" -B "$RUNNER_TEMP/consumer/build" \
             -DCMAKE_PREFIX_PATH="$RUNNER_TEMP/prefix" \
             -DCMAKE_DISABLE_FIND_PACKAGE_Eigen3=ON \

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -121,8 +121,6 @@ jobs:
           echo "CC=${{ matrix.cfg.cc }}" >> $GITHUB_ENV
           echo "CXX=${{ matrix.cfg.cxx }}" >> $GITHUB_ENV
           echo "BOOST_ROOT=${{ steps.install-dependencies.outputs.BOOST_ROOT }}" >> $GITHUB_ENV
-          echo "Boost_INCLUDE_DIR=${{ steps.install-dependencies.outputs.BOOST_ROOT }}/include" >> $GITHUB_ENV
-          echo "EIGEN3_INCLUDE_DIR=${{ steps.install-dependencies.outputs.EIGEN3_ROOT }}/include/eigen3" >> $GITHUB_ENV
           if [ "${{ matrix.cfg.os }}" == "windows-latest" ]; then
             # Linux and macOS runners ship an Eigen that find_package locates on
             # its own; Windows does not, so point it at the one we installed.
@@ -245,8 +243,6 @@ jobs:
       - name: Set environment variables
         run: |
           echo "BOOST_ROOT=${{ steps.install-dependencies.outputs.BOOST_ROOT }}" >> $GITHUB_ENV
-          echo "Boost_INCLUDE_DIR=${{ steps.install-dependencies.outputs.BOOST_ROOT }}/include" >> $GITHUB_ENV
-          echo "EIGEN3_INCLUDE_DIR=${{ steps.install-dependencies.outputs.EIGEN3_ROOT }}/include/eigen3" >> $GITHUB_ENV
       - name: Configure, build, test and install (header-only)
         run: |
           mkdir release && cd release
@@ -263,6 +259,159 @@ jobs:
           for ex in bicop vinecop; do
             ( cd "examples/$ex" && mkdir build && cd build && cmake .. && make && ../bin/main )
           done
+
+  # Two configure-time behaviors the matrix above cannot reach: it lets
+  # find_package do the work, from a conventional source path. Nothing is
+  # compiled here, because both defects are visible by the end of generation.
+  configure-checks:
+    name: cmake configure checks (ubuntu)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install dependencies
+        id: install-dependencies
+        uses: ./.github/actions/install-dependencies
+        with:
+          os: ubuntu-latest
+          boost_version: ${{ env.BOOST_VERSION }}
+          eigen_version: ${{ env.EIGEN_VERSION }}
+          R: false
+          lcov: false
+      # Each of these skips a find_package, so the imported target the link
+      # line names has to come from the path instead. Eigen3::Eigen and
+      # Boost::headers are namespaced and fail generation when missing; the
+      # plain name wdm would only fail at link time, so check the generated
+      # link line, which BUILD_SHARED_LIBS writes at generate time.
+      - name: Configure with caller-supplied dependency paths
+        run: |
+          cmake -S . -B build-dep-paths \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DVINECOPULIB_PRECOMPILED=ON \
+            -DBUILD_SHARED_LIBS=ON \
+            -DBUILD_TESTING=OFF \
+            -DEIGEN3_INCLUDE_DIR="${{ steps.install-dependencies.outputs.EIGEN3_ROOT }}/include/eigen3" \
+            -DBoost_INCLUDE_DIRS="${{ steps.install-dependencies.outputs.BOOST_ROOT }}/include" \
+            -Dwdm_INCLUDE_DIRS=/usr/local/include
+          link_txt=build-dep-paths/CMakeFiles/vinecopulib.dir/link.txt
+          if [ ! -f "$link_txt" ]; then
+            echo "::error::$link_txt was not generated; the check below is void"
+            exit 1
+          fi
+          if grep -q -- '-lwdm' "$link_txt"; then
+            echo "::error::wdm reached the link line as -lwdm; its target is missing"
+            exit 1
+          fi
+        shell: bash
+      # findHeaders.cmake derives every generated source and header from paths,
+      # and a path is not a pattern: a metacharacter in the source directory
+      # left the generated headers unwritten, so each .ipp was both inlined and
+      # compiled. The translation runs at configure time, so these counts are
+      # already final.
+      - name: Configure from a source path containing regex metacharacters
+        run: |
+          src="$RUNNER_TEMP/vine+copu.lib"
+          cp -a "$GITHUB_WORKSPACE" "$src"
+          cmake -S "$src" -B "$src/build" \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DVINECOPULIB_PRECOMPILED=ON \
+            -DBUILD_TESTING=OFF
+          expected_hpp=$(find "$src/include/vinecopulib" -name '*.hpp' | wc -l)
+          actual_hpp=$(find "$src/build/generated/include/vinecopulib" \
+            -name '*.hpp' 2>/dev/null | wc -l)
+          expected_cpp=$(find "$src/include" -name '*.ipp' | wc -l)
+          actual_cpp=$(find "$src/build/generated/src" \
+            -name '*.cpp' 2>/dev/null | wc -l)
+          echo "headers $actual_hpp/$expected_hpp, sources $actual_cpp/$expected_cpp"
+          if [ "$actual_hpp" -ne "$expected_hpp" ] \
+             || [ "$actual_cpp" -ne "$expected_cpp" ]; then
+            echo "::error::the generated tree is incomplete"
+            exit 1
+          fi
+          # An .ipp left in a generated header is what makes an implementation
+          # both inlined and compiled as its own translation unit.
+          if grep -rl '\.ipp>' "$src/build/generated/include"; then
+            echo "::error::a generated header still includes its .ipp"
+            exit 1
+          fi
+          # A destination path that does not translate stays in the source
+          # tree, and the generated content is written over the original.
+          if [ -n "$(git -C "$src" status --porcelain -- include)" ]; then
+            echo "::error::configure wrote into the source tree"
+            exit 1
+          fi
+        shell: bash
+
+  # -fsanitize=address,undefined, which VINECOPULIB_SANITIZERS adds to the
+  # Debug builds above, cannot see a data race, and cannot be combined with
+  # -fsanitize=thread either — hence a build tree of its own. Only the areas
+  # that drive the thread pool are built and run, since ThreadSanitizer slows
+  # execution by an order of magnitude.
+  #
+  # clang, not GCC: GCC 11's libtsan loses the happens-before edge across
+  # pthread_cond_timedwait, so every access the mutex protects is reported for
+  # any use of std::condition_variable::wait_for. ThreadPool::wait() is one,
+  # which would make a GCC job pure false positives.
+  thread-sanitizer:
+    name: thread sanitizer (ubuntu, clang)
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    env:
+      # A report exits 66, which fails the step. halt_on_error stops at the
+      # first one rather than grinding through an instrumented suite that is
+      # already going to fail, and second_deadlock_stack makes a lock-order
+      # report name both acquisition sites.
+      TSAN_OPTIONS: halt_on_error=1 second_deadlock_stack=1
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v7
+      # R, because the VinecopTest fixture skips every one of its tests when
+      # Rscript was not found, and those are the vine fits that use the pool.
+      - name: Install dependencies
+        id: install-dependencies
+        uses: ./.github/actions/install-dependencies
+        with:
+          os: ubuntu-latest
+          boost_version: ${{ env.BOOST_VERSION }}
+          eigen_version: ${{ env.EIGEN_VERSION }}
+          R: true
+          lcov: false
+      # RelWithDebInfo, not Debug: the suite takes twenty minutes unoptimized
+      # before ThreadSanitizer multiplies it, and race detection is a
+      # happens-before analysis that does not depend on the optimization level.
+      # VINECOPULIB_SANITIZERS is left off so that the address sanitizer is not
+      # added. The <area>_only executables are EXCLUDE_FROM_ALL and share their
+      # objects with test_all, so this compiles three areas instead of fourteen.
+      - name: Configure and build with ThreadSanitizer
+        run: |
+          cmake -S . -B build-tsan \
+            -DCMAKE_BUILD_TYPE=RelWithDebInfo \
+            -DCMAKE_CXX_COMPILER=clang++ \
+            -DCMAKE_CXX_FLAGS="-fsanitize=thread -fno-omit-frame-pointer -g" \
+            -DCMAKE_EXE_LINKER_FLAGS="-fsanitize=thread"
+          cmake --build build-tsan -j"$(nproc)" --target \
+            test_tools_thread_only test_bicop_select_only test_vinecop_class_only
+        shell: bash
+      # setarch -R, because ThreadSanitizer's shadow memory assumes a bounded
+      # mmap randomization and aborts with "unexpected memory mapping" when the
+      # kernel's vm.mmap_rnd_bits exceeds it. The wrapper needs no privileges,
+      # unlike lowering the sysctl, so the job does not depend on the runner's
+      # kernel settings.
+      - name: Run the thread-pool tests under ThreadSanitizer
+        run: |
+          arch=$(uname -m)
+          setarch "$arch" -R build-tsan/bin/test_tools_thread_only
+          setarch "$arch" -R build-tsan/bin/test_bicop_select_only
+          # Only the fits that ask for more than one thread are worth the
+          # slowdown: the rest of this area runs the pool with no workers,
+          # executing each job inline at the push site.
+          setarch "$arch" -R build-tsan/bin/test_vinecop_class_only \
+            --gtest_filter='VinecopFit.parallel_fit_matches_serial:VinecopTest.works_multi_threaded:VinecopTest.tree_criterion_*:VinecopTest.inverse_rosenblatt_is_safe_for_concurrent_calls' \
+            | tee tsan-vinecop.log
+          # A filter that matches nothing exits 0, which would leave this job
+          # green while running none of it.
+          grep -qE '^\[  PASSED  \] [1-9][0-9]* test' tsan-vinecop.log
+        shell: bash
 
   # Keeps the benchmark and parity targets compiling. The self-comparison
   # checks that every group is populated and that the gates file parses.
@@ -283,8 +432,6 @@ jobs:
       - name: Set environment variables
         run: |
           echo "BOOST_ROOT=${{ steps.install-dependencies.outputs.BOOST_ROOT }}" >> $GITHUB_ENV
-          echo "Boost_INCLUDE_DIR=${{ steps.install-dependencies.outputs.BOOST_ROOT }}/include" >> $GITHUB_ENV
-          echo "EIGEN3_INCLUDE_DIR=${{ steps.install-dependencies.outputs.EIGEN3_ROOT }}/include/eigen3" >> $GITHUB_ENV
       - name: Build bench_all and parity_dump
         run: |
           mkdir build-bench && cd build-bench
@@ -334,8 +481,6 @@ jobs:
       - name: Set environment variables
         run: |
           echo "BOOST_ROOT=${{ steps.install-dependencies.outputs.BOOST_ROOT }}" >> $GITHUB_ENV
-          echo "Boost_INCLUDE_DIR=${{ steps.install-dependencies.outputs.BOOST_ROOT }}/include" >> $GITHUB_ENV
-          echo "EIGEN3_INCLUDE_DIR=${{ steps.install-dependencies.outputs.EIGEN3_ROOT }}/include/eigen3" >> $GITHUB_ENV
       - name: Configure
         run: |
           mkdir build-docs && cd build-docs
@@ -407,8 +552,6 @@ jobs:
       - name: Set environment variables
         run: |
           echo "BOOST_ROOT=${{ steps.install-dependencies.outputs.BOOST_ROOT }}" >> $GITHUB_ENV
-          echo "Boost_INCLUDE_DIR=${{ steps.install-dependencies.outputs.BOOST_ROOT }}/include" >> $GITHUB_ENV
-          echo "EIGEN3_INCLUDE_DIR=${{ steps.install-dependencies.outputs.EIGEN3_ROOT }}/include/eigen3" >> $GITHUB_ENV
       - name: Configure to generate compile_commands.json
         run: |
           mkdir build-tidy && cd build-tidy

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -276,8 +276,15 @@ jobs:
           os: ubuntu-latest
           boost_version: ${{ env.BOOST_VERSION }}
           eigen_version: ${{ env.EIGEN_VERSION }}
+          eigen_install_dir: ${{ runner.temp }}/eigen
           R: false
           lcov: false
+      # find_package picks both up via CMP0074, which the second step needs:
+      # it configures the way an ordinary build does.
+      - name: Set environment variables
+        run: |
+          echo "BOOST_ROOT=${{ steps.install-dependencies.outputs.BOOST_ROOT }}" >> $GITHUB_ENV
+          echo "Eigen3_ROOT=${{ runner.temp }}/eigen" >> $GITHUB_ENV
       # Each of these skips a find_package, so the imported target the link
       # line names has to come from the path instead. Eigen3::Eigen and
       # Boost::headers are namespaced and fail generation when missing; the
@@ -285,13 +292,24 @@ jobs:
       # link line, which BUILD_SHARED_LIBS writes at generate time.
       - name: Configure with caller-supplied dependency paths
         run: |
+          # Each dependency keeps its headers under <prefix>/include, Eigen one
+          # level further down. Assert that before configuring, so a change in
+          # the layout fails here instead of looking like the defect below.
+          eigen_inc="${{ runner.temp }}/eigen/include/eigen3"
+          boost_inc="$BOOST_ROOT/include"
+          test -f "$eigen_inc/Eigen/Dense" \
+            || { echo "::error::no Eigen headers under $eigen_inc"; exit 1; }
+          test -d "$boost_inc/boost" \
+            || { echo "::error::no Boost headers under $boost_inc"; exit 1; }
+          test -f /usr/local/include/wdm.hpp \
+            || { echo "::error::no wdm headers under /usr/local/include"; exit 1; }
           cmake -S . -B build-dep-paths \
             -DCMAKE_BUILD_TYPE=Release \
             -DVINECOPULIB_PRECOMPILED=ON \
             -DBUILD_SHARED_LIBS=ON \
             -DBUILD_TESTING=OFF \
-            -DEIGEN3_INCLUDE_DIR="${{ steps.install-dependencies.outputs.EIGEN3_ROOT }}/include/eigen3" \
-            -DBoost_INCLUDE_DIRS="${{ steps.install-dependencies.outputs.BOOST_ROOT }}/include" \
+            -DEIGEN3_INCLUDE_DIR="$eigen_inc" \
+            -DBoost_INCLUDE_DIRS="$boost_inc" \
             -Dwdm_INCLUDE_DIRS=/usr/local/include
           link_txt=build-dep-paths/CMakeFiles/vinecopulib.dir/link.txt
           if [ ! -f "$link_txt" ]; then
@@ -374,8 +392,14 @@ jobs:
           os: ubuntu-latest
           boost_version: ${{ env.BOOST_VERSION }}
           eigen_version: ${{ env.EIGEN_VERSION }}
+          eigen_install_dir: ${{ runner.temp }}/eigen
           R: true
           lcov: false
+      # find_package picks both up via CMP0074.
+      - name: Set environment variables
+        run: |
+          echo "BOOST_ROOT=${{ steps.install-dependencies.outputs.BOOST_ROOT }}" >> $GITHUB_ENV
+          echo "Eigen3_ROOT=${{ runner.temp }}/eigen" >> $GITHUB_ENV
       # RelWithDebInfo, not Debug: the suite takes twenty minutes unoptimized
       # before ThreadSanitizer multiplies it, and race detection is a
       # happens-before analysis that does not depend on the optimization level.

--- a/.github/workflows/continuous_integration.yml
+++ b/.github/workflows/continuous_integration.yml
@@ -239,10 +239,12 @@ jobs:
           os: ubuntu-latest
           boost_version: ${{ env.BOOST_VERSION }}
           eigen_version: ${{ env.EIGEN_VERSION }}
+          eigen_install_dir: ${{ runner.temp }}/eigen
           R: true
       - name: Set environment variables
         run: |
           echo "BOOST_ROOT=${{ steps.install-dependencies.outputs.BOOST_ROOT }}" >> $GITHUB_ENV
+          echo "Eigen3_ROOT=${{ runner.temp }}/eigen" >> $GITHUB_ENV
       - name: Configure, build, test and install (header-only)
         run: |
           mkdir release && cd release
@@ -259,10 +261,28 @@ jobs:
           for ex in bicop vinecop; do
             ( cd "examples/$ex" && mkdir build && cd build && cmake .. && make && ../bin/main )
           done
+      # CMAKE_DISABLE_FIND_PACKAGE_* makes the consumer unable to find the
+      # dependencies, so the paths recorded in the package have to serve.
+      - name: Consume an install configured with dependency paths
+        run: |
+          cmake -S . -B build-prefix \
+            -DCMAKE_BUILD_TYPE=Release \
+            -DBUILD_TESTING=OFF \
+            -DCMAKE_INSTALL_PREFIX="$RUNNER_TEMP/prefix" \
+            -DEIGEN3_INCLUDE_DIR="$RUNNER_TEMP/eigen/include/eigen3" \
+            -DBoost_INCLUDE_DIRS="$BOOST_ROOT/include" \
+            -Dwdm_INCLUDE_DIRS=/usr/local/include
+          cmake --install build-prefix
+          cp -a examples/bicop "$RUNNER_TEMP/consumer"
+          cmake -S "$RUNNER_TEMP/consumer" -B "$RUNNER_TEMP/consumer/build" \
+            -DCMAKE_PREFIX_PATH="$RUNNER_TEMP/prefix" \
+            -DCMAKE_DISABLE_FIND_PACKAGE_Eigen3=ON \
+            -DCMAKE_DISABLE_FIND_PACKAGE_Boost=ON \
+            -DCMAKE_DISABLE_FIND_PACKAGE_wdm=ON
+          cmake --build "$RUNNER_TEMP/consumer/build" -j"$(nproc)"
+          "$RUNNER_TEMP/consumer/bin/main" > /dev/null
 
-  # Two configure-time behaviors the matrix above cannot reach: it lets
-  # find_package do the work, from a conventional source path. Nothing is
-  # compiled here, because both defects are visible by the end of generation.
+  # Two configure-time defects the matrix cannot reach; nothing is compiled.
   configure-checks:
     name: cmake configure checks (ubuntu)
     runs-on: ubuntu-latest
@@ -279,22 +299,16 @@ jobs:
           eigen_install_dir: ${{ runner.temp }}/eigen
           R: false
           lcov: false
-      # find_package picks both up via CMP0074, which the second step needs:
-      # it configures the way an ordinary build does.
+      # The second step configures the way an ordinary build does.
       - name: Set environment variables
         run: |
           echo "BOOST_ROOT=${{ steps.install-dependencies.outputs.BOOST_ROOT }}" >> $GITHUB_ENV
           echo "Eigen3_ROOT=${{ runner.temp }}/eigen" >> $GITHUB_ENV
-      # Each of these skips a find_package, so the imported target the link
-      # line names has to come from the path instead. Eigen3::Eigen and
-      # Boost::headers are namespaced and fail generation when missing; the
-      # plain name wdm would only fail at link time, so check the generated
-      # link line, which BUILD_SHARED_LIBS writes at generate time.
+      # A missing namespaced target fails generation, but the plain name wdm
+      # would only fail at link time, so check the generated link line too.
       - name: Configure with caller-supplied dependency paths
         run: |
-          # Each dependency keeps its headers under <prefix>/include, Eigen one
-          # level further down. Assert that before configuring, so a change in
-          # the layout fails here instead of looking like the defect below.
+          # Assert the layout, so a change to it fails as itself.
           eigen_inc="${{ runner.temp }}/eigen/include/eigen3"
           boost_inc="$BOOST_ROOT/include"
           test -f "$eigen_inc/Eigen/Dense" \
@@ -321,11 +335,7 @@ jobs:
             exit 1
           fi
         shell: bash
-      # findHeaders.cmake derives every generated source and header from paths,
-      # and a path is not a pattern: a metacharacter in the source directory
-      # left the generated headers unwritten, so each .ipp was both inlined and
-      # compiled. The translation runs at configure time, so these counts are
-      # already final.
+      # The translation runs at configure time, so these counts are final.
       - name: Configure from a source path containing regex metacharacters
         run: |
           src="$RUNNER_TEMP/vine+copu.lib"
@@ -346,45 +356,33 @@ jobs:
             echo "::error::the generated tree is incomplete"
             exit 1
           fi
-          # An .ipp left in a generated header is what makes an implementation
-          # both inlined and compiled as its own translation unit.
+          # A leftover .ipp include gets the implementation compiled twice.
           if grep -rl '\.ipp>' "$src/build/generated/include"; then
             echo "::error::a generated header still includes its .ipp"
             exit 1
           fi
-          # A destination path that does not translate stays in the source
-          # tree, and the generated content is written over the original.
+          # An untranslated destination path stays in the source tree.
           if [ -n "$(git -C "$src" status --porcelain -- include)" ]; then
             echo "::error::configure wrote into the source tree"
             exit 1
           fi
         shell: bash
 
-  # -fsanitize=address,undefined, which VINECOPULIB_SANITIZERS adds to the
-  # Debug builds above, cannot see a data race, and cannot be combined with
-  # -fsanitize=thread either — hence a build tree of its own. Only the areas
-  # that drive the thread pool are built and run, since ThreadSanitizer slows
-  # execution by an order of magnitude.
-  #
-  # clang, not GCC: GCC 11's libtsan loses the happens-before edge across
-  # pthread_cond_timedwait, so every access the mutex protects is reported for
-  # any use of std::condition_variable::wait_for. ThreadPool::wait() is one,
-  # which would make a GCC job pure false positives.
+  # VINECOPULIB_SANITIZERS cannot see a data race and cannot be combined
+  # with -fsanitize=thread, so this needs a build tree of its own. clang,
+  # because GCC's libtsan reports false races on
+  # std::condition_variable::wait_for, which ThreadPool::wait() uses.
   thread-sanitizer:
     name: thread sanitizer (ubuntu, clang)
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
-      # A report exits 66, which fails the step. halt_on_error stops at the
-      # first one rather than grinding through an instrumented suite that is
-      # already going to fail, and second_deadlock_stack makes a lock-order
-      # report name both acquisition sites.
+      # A report exits 66, which fails the step.
       TSAN_OPTIONS: halt_on_error=1 second_deadlock_stack=1
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: actions/checkout@v7
-      # R, because the VinecopTest fixture skips every one of its tests when
-      # Rscript was not found, and those are the vine fits that use the pool.
+      # R, or the VinecopTest fixture skips every one of its tests.
       - name: Install dependencies
         id: install-dependencies
         uses: ./.github/actions/install-dependencies
@@ -400,12 +398,8 @@ jobs:
         run: |
           echo "BOOST_ROOT=${{ steps.install-dependencies.outputs.BOOST_ROOT }}" >> $GITHUB_ENV
           echo "Eigen3_ROOT=${{ runner.temp }}/eigen" >> $GITHUB_ENV
-      # RelWithDebInfo, not Debug: the suite takes twenty minutes unoptimized
-      # before ThreadSanitizer multiplies it, and race detection is a
-      # happens-before analysis that does not depend on the optimization level.
-      # VINECOPULIB_SANITIZERS is left off so that the address sanitizer is not
-      # added. The <area>_only executables are EXCLUDE_FROM_ALL and share their
-      # objects with test_all, so this compiles three areas instead of fourteen.
+      # RelWithDebInfo, because ThreadSanitizer multiplies an already slow
+      # Debug suite; the <area>_only targets build three areas, not fourteen.
       - name: Configure and build with ThreadSanitizer
         run: |
           cmake -S . -B build-tsan \
@@ -416,24 +410,18 @@ jobs:
           cmake --build build-tsan -j"$(nproc)" --target \
             test_tools_thread_only test_bicop_select_only test_vinecop_class_only
         shell: bash
-      # setarch -R, because ThreadSanitizer's shadow memory assumes a bounded
-      # mmap randomization and aborts with "unexpected memory mapping" when the
-      # kernel's vm.mmap_rnd_bits exceeds it. The wrapper needs no privileges,
-      # unlike lowering the sysctl, so the job does not depend on the runner's
-      # kernel settings.
+      # setarch -R, or TSan aborts when vm.mmap_rnd_bits exceeds what its
+      # shadow mapping supports; unlike the sysctl it needs no privileges.
       - name: Run the thread-pool tests under ThreadSanitizer
         run: |
           arch=$(uname -m)
           setarch "$arch" -R build-tsan/bin/test_tools_thread_only
           setarch "$arch" -R build-tsan/bin/test_bicop_select_only
-          # Only the fits that ask for more than one thread are worth the
-          # slowdown: the rest of this area runs the pool with no workers,
-          # executing each job inline at the push site.
+          # Only the fits that ask for more than one thread use the pool.
           setarch "$arch" -R build-tsan/bin/test_vinecop_class_only \
             --gtest_filter='VinecopFit.parallel_fit_matches_serial:VinecopTest.works_multi_threaded:VinecopTest.tree_criterion_*:VinecopTest.inverse_rosenblatt_is_safe_for_concurrent_calls' \
             | tee tsan-vinecop.log
-          # A filter that matches nothing exits 0, which would leave this job
-          # green while running none of it.
+          # A filter that matches nothing exits 0.
           grep -qE '^\[  PASSED  \] [1-9][0-9]* test' tsan-vinecop.log
         shell: bash
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -56,11 +56,6 @@ jobs:
           R: false
           lcov: false
 
-      # BOOST_ROOT must be exported: find_package picks it up via CMP0074.
-      - name: Set environment variables
-        run: |
-          echo "BOOST_ROOT=${{ steps.install-dependencies.outputs.BOOST_ROOT }}" >> $GITHUB_ENV
-
       - name: Configure
         run: cmake -S . -B build-docs -DVINECOPULIB_BUILD_DOC=ON -DBUILD_TESTING=OFF
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -60,8 +60,6 @@ jobs:
       - name: Set environment variables
         run: |
           echo "BOOST_ROOT=${{ steps.install-dependencies.outputs.BOOST_ROOT }}" >> $GITHUB_ENV
-          echo "Boost_INCLUDE_DIR=${{ steps.install-dependencies.outputs.BOOST_ROOT }}/include" >> $GITHUB_ENV
-          echo "EIGEN3_INCLUDE_DIR=${{ steps.install-dependencies.outputs.EIGEN3_ROOT }}/include/eigen3" >> $GITHUB_ENV
 
       - name: Configure
         run: cmake -S . -B build-docs -DVINECOPULIB_BUILD_DOC=ON -DBUILD_TESTING=OFF

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -246,7 +246,7 @@ Discovered in
 - **Eigen3** — `find_package(Eigen3 REQUIRED CONFIG)`; or set
   `EIGEN3_INCLUDE_DIR`. Target: `Eigen3::Eigen`.
 - **Boost ≥ 1.75** — CONFIG mode then MODULE fallback; or set
-  `Boost_INCLUDE_DIRS`. Target: `Boost::boost`. Deliberately narrowed to three
+  `Boost_INCLUDE_DIRS`. Target: `Boost::headers`. Deliberately narrowed to three
   header-only components — keep it that way, and prefer the standard library
   when it suffices: **Graph** (`adjacency_list` and the spanning-tree engines
   behind `tree_algorithm`), **Math** (distributions, constants, special
@@ -260,6 +260,13 @@ Discovered in
 - **Rscript** (optional) — enables the R parity tests; see
   [cmake/findR.cmake](cmake/findR.cmake).
 - **Doxygen** — only when `VINECOPULIB_BUILD_DOC`.
+
+Setting `EIGEN3_INCLUDE_DIR`, `Boost_INCLUDE_DIRS` or `wdm_INCLUDE_DIRS` skips
+the matching `find_package`. The build links these dependencies by target name,
+so `findDependencies.cmake` defines the target from the given path instead
+(`vinecopulib_add_header_only_target`). A dependency added to a link line needs
+the same treatment, or a caller-supplied path configures and then fails to
+link.
 
 Global compile definitions set in
 [cmake/compilerDefOpt.cmake](cmake/compilerDefOpt.cmake) (and mirrored in

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -611,6 +611,14 @@ Conventions:
   (default ON iff Rscript is found). The `cmake/templates/*.R` scripts
   cross-check parametric bicop / vinecop results against **VineCopula >= 2.6.2
   from GitHub, not CRAN**; with the option off the tests skip rather than fail.
+  The whole `VinecopTest` fixture skips with them, so an area filtered down to
+  those tests runs nothing.
+- **Data races** are outside what `VINECOPULIB_SANITIZERS` covers: the address
+  and UB sanitizers cannot see one, and neither can be combined with
+  `-fsanitize=thread`. The `thread sanitizer` CI job builds the areas that
+  drive the thread pool with that flag, in a build tree of its own and with
+  clang — GCC 11's runtime loses the happens-before edge across
+  `pthread_cond_timedwait`, which `ThreadPool::wait()` relies on.
 - **Golden values and parity**: the golden-value tests are the CI-enforced part;
   the before/after `parity_dump` comparison is a manual tool for numerical
   changes. Both are documented in [scripts/README.md](scripts/README.md).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -198,7 +198,7 @@ workflow lives in [CONTRIBUTING.md](CONTRIBUTING.md), this file, and CI.
 
 ## Build & tooling
 
-CMake **≥ 3.14**, C++ **17**. The 24-line root
+CMake **3.20–4.0**, C++ **17**. The 24-line root
 [CMakeLists.txt](CMakeLists.txt) sets the standard, the project version,
 and includes the `cmake/` modules in order.
 
@@ -245,7 +245,7 @@ Discovered in
 
 - **Eigen3** — `find_package(Eigen3 REQUIRED CONFIG)`; or set
   `EIGEN3_INCLUDE_DIR`. Target: `Eigen3::Eigen`.
-- **Boost ≥ 1.75** — CONFIG mode then MODULE fallback; or set
+- **Boost ≥ 1.75** — CONFIG mode only (`CMP0167` removes `FindBoost`); or set
   `Boost_INCLUDE_DIRS`. Target: `Boost::headers`. Deliberately narrowed to three
   header-only components — keep it that way, and prefer the standard library
   when it suffices: **Graph** (`adjacency_list` and the spanning-tree engines
@@ -253,8 +253,7 @@ Discovered in
   functions, `quadrature::tanh_sinh` for 1-d integration, `tools::minima`),
   and **Random** (`mt19937`, behind QRNG scrambling and structure simulation).
 - **wdm 0.3.0** — `find_package(wdm 0.3.0 QUIET)` with a **FetchContent
-  fallback** that clones `tnagler/wdm`. Installed under
-  `<prefix>/include/vinecopulib/wdm/`.
+  fallback** that clones `tnagler/wdm`. This project does not install it.
 - **Threads** — required.
 - **GoogleTest 1.14** — FetchContent, only when `BUILD_TESTING`.
 - **Rscript** (optional) — enables the R parity tests; see
@@ -264,9 +263,9 @@ Discovered in
 Setting `EIGEN3_INCLUDE_DIR`, `Boost_INCLUDE_DIRS` or `wdm_INCLUDE_DIRS` skips
 the matching `find_package`. The build links these dependencies by target name,
 so `findDependencies.cmake` defines the target from the given path instead
-(`vinecopulib_add_header_only_target`). A dependency added to a link line needs
-the same treatment, or a caller-supplied path configures and then fails to
-link.
+(`vinecopulib_add_header_only_target`), and records it in the installed package
+so a consumer can resolve it too. A dependency added to a link line needs both,
+or a caller-supplied path configures and then fails to link.
 
 Global compile definitions set in
 [cmake/compilerDefOpt.cmake](cmake/compilerDefOpt.cmake) (and mirrored in
@@ -398,10 +397,10 @@ For any behavior change:
 
   ```cmake
   # documentation — states the constraint
-  # 3.14 for FetchContent_MakeAvailable; do not lower.
+  # 3.20 for cmake_path(); the upper bound opts into policies up to 4.0.
 
   # history — only makes sense against the old code
-  # 3.14 is the real floor: the previous 3.10 could not configure at all.
+  # 3.20 is the real floor: the previous 3.14 could not configure at all.
   ```
 
 - **American English** in code, comments, documentation, commit messages, and

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-# 3.14 for FetchContent_MakeAvailable; do not lower.
-cmake_minimum_required(VERSION 3.14)
+# 3.20 for cmake_path(); the upper bound opts into policies up to 4.0.
+cmake_minimum_required(VERSION 3.20...4.0)
 
 project(vinecopulib VERSION 1.0.0 LANGUAGES CXX)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -202,6 +202,16 @@ wrong thing.
 
 ### BUG FIXES
 
+* `Vinecop::fit()` no longer lets the edges of a tree race on the h-functions.
+  Each edge reads columns that edges of higher index write, so only the serial
+  order gave every one of them the previous tree's values; with more than one
+  thread they now read a snapshot of it (#774)
+
+* `ThreadPool::wait()` and `join()` consume the exception they report, so a
+  pool that ran a failing job is usable again; it used to rethrow the stale
+  exception and silently drop the jobs pushed since. `join()` now stops its
+  threads even when a job threw (#774)
+
 * `Vinecop::loglik()` leaves out the observations that have no likelihood
   instead of returning `NaN` for the whole sample, matching `Bicop::loglik()`;
   `aic()`, `bic()` and `mbicv()` follow it. Evaluation is unchanged and still
@@ -363,6 +373,24 @@ wrong thing.
 
 ### BUILD SYSTEM AND DEPENDENCIES
 
+* Require CMake 3.20, with an upper bound of 4.0, and find Boost in CONFIG
+  mode only, since `CMP0167` removes the `FindBoost` module. `findHeaders.cmake`
+  takes paths apart with `cmake_path()` rather than matching them as text
+  (#774)
+
+* Record the dependency include paths in the installed package, so a build
+  configured with `-DEIGEN3_INCLUDE_DIR` and friends produces one that a
+  consumer can resolve (#774)
+
+* Fix `-DEIGEN3_INCLUDE_DIR=<path>` and `-DBoost_INCLUDE_DIRS=<path>`: either
+  skips the matching `find_package`, and the build links Eigen and Boost by
+  target name, so that target was never defined. All three dependency paths now
+  define the target they stand in for, as `wdm_INCLUDE_DIRS` already did (#774)
+
+* Fix the precompiled build when the source path contains a regex
+  metacharacter, such as `vine+copulib`: `findHeaders.cmake` matched
+  path-derived patterns as regexes, and generated none of the headers (#774)
+
 * Update the vendored nlohmann/json from 3.9.1 to 3.12.0, now stored verbatim
   instead of reformatted, with the patches that remove its suppressed compiler
   diagnostics re-applied. The on-disk JSON and CBOR formats are unchanged
@@ -441,6 +469,10 @@ wrong thing.
 * Seed the RNG-dependent unit tests to remove flakiness (#686)
 
 * Decompose `VinecopSelector` for readability (#695)
+
+* Add a ThreadSanitizer CI job, and one covering what the build system
+  promises users. `VINECOPULIB_SANITIZERS` adds the address and UB sanitizers,
+  neither of which sees a data race (#774)
 
 * Add a codespell-based spelling and prose check, run in CI and available as a
   pre-commit hook: `en-GB_to_en-US` enforces American English, and

--- a/NEWS.md
+++ b/NEWS.md
@@ -377,6 +377,20 @@ wrong thing.
 
 ### BUILD SYSTEM AND DEPENDENCIES
 
+* Require CMake 3.20, with an upper bound of 4.0, and find Boost in CONFIG
+  mode only. `CMP0167` removes the `FindBoost` module, so the MODULE fallback
+  was going to stop working; Boost has shipped a config package since 1.70,
+  below the 1.75 required here. The `CMP0074` and `CMP0144` blocks go with it,
+  and `findHeaders.cmake` takes paths apart with `cmake_path()` rather than
+  matching them as text (#774)
+
+* Carry the dependency paths into the installed package. The exported link
+  interface names `Eigen3::Eigen`, `Boost::headers` and `wdm`, and the
+  installed config resolved each with `find_dependency`, so a build pointed at
+  a directory rather than a package shipped a package that failed on the
+  consumer's side. Those directories are now recorded and used when the
+  package cannot be found (#774)
+
 * Fix `-DEIGEN3_INCLUDE_DIR=<path>` and `-DBoost_INCLUDE_DIRS=<path>`. Either
   one skips the matching `find_package`, and the build links Eigen and Boost by
   target name, so a precompiled build failed at generate time and a build with
@@ -390,6 +404,7 @@ wrong thing.
   so a directory such as `vine+copulib` generated none of the headers and left
   every `.ipp` both inlined and compiled as its own translation unit, for a
   `redefinition of ...` error against an installed copy of the headers. Paths
+  are now taken apart with `cmake_path()` (#774)
   are now compared literally (#774)
 * Update the vendored nlohmann/json from 3.9.1 to 3.12.0, now stored verbatim
   instead of reformatted, with the patches that remove its suppressed compiler

--- a/NEWS.md
+++ b/NEWS.md
@@ -202,6 +202,20 @@ wrong thing.
 
 ### BUG FIXES
 
+* `Vinecop::fit()` no longer lets the edges of a tree race on the h-functions.
+  Every edge reads `hfunc1`/`hfunc2` columns that edges of higher index in the
+  same tree write, so the serial order gave each of them the previous tree's
+  values and running the edges concurrently removed that guarantee: an edge
+  could be fitted against the current tree's h-functions instead. With more
+  than one thread the edges now read a snapshot of the previous tree (#774)
+
+* `ThreadPool::wait()` and `join()` consume the exception they report, so a
+  pool that ran a failing job can be used again. The stored exception was kept
+  after being rethrown, so every later `wait()` rethrew it and, because a
+  stored exception cancels the queue, dropped the jobs pushed in the meantime
+  without running them. `join()` stops and joins its threads even when a job
+  threw, and the first exception is the one reported when several jobs fail
+  (#774)
 * `Vinecop::loglik()` leaves out the observations that have no likelihood
   instead of returning `NaN` for the whole sample, matching `Bicop::loglik()`;
   `aic()`, `bic()` and `mbicv()` follow it. Evaluation is unchanged and still
@@ -363,6 +377,20 @@ wrong thing.
 
 ### BUILD SYSTEM AND DEPENDENCIES
 
+* Fix `-DEIGEN3_INCLUDE_DIR=<path>` and `-DBoost_INCLUDE_DIRS=<path>`. Either
+  one skips the matching `find_package`, and the build links Eigen and Boost by
+  target name, so a precompiled build failed at generate time and a build with
+  no in-tree consumer of the target exported a `vinecopulibTargets.cmake` that
+  only broke for consumers. All three dependency paths now define the target
+  they stand in for, as `wdm_INCLUDE_DIRS` already did, which also supplies the
+  `Boost::headers` that CMake 3.14's `FindBoost` module predates (#774)
+
+* Fix the precompiled build when the source path contains a regex
+  metacharacter. `findHeaders.cmake` matched path-derived patterns as regexes,
+  so a directory such as `vine+copulib` generated none of the headers and left
+  every `.ipp` both inlined and compiled as its own translation unit, for a
+  `redefinition of ...` error against an installed copy of the headers. Paths
+  are now compared literally (#774)
 * Update the vendored nlohmann/json from 3.9.1 to 3.12.0, now stored verbatim
   instead of reformatted, with the patches that remove its suppressed compiler
   diagnostics re-applied. The on-disk JSON and CBOR formats are unchanged
@@ -441,6 +469,15 @@ wrong thing.
 * Seed the RNG-dependent unit tests to remove flakiness (#686)
 
 * Decompose `VinecopSelector` for readability (#695)
+
+* Add a ThreadSanitizer CI job. `VINECOPULIB_SANITIZERS` adds the address and
+  UB sanitizers, neither of which sees a data race, so the thread-pool race
+  fixed in #764 and the h-function race fixed in #774 were both green in CI
+  throughout. The job builds the test areas that drive the thread pool with
+  `-fsanitize=thread` in a build tree of its own, since that flag cannot be
+  combined with the address sanitizer, and uses clang, whose runtime does not
+  lose the happens-before edge across `pthread_cond_timedwait`. A second job
+  covers the two defects above that are visible at configure time (#774)
 
 * Add a codespell-based spelling and prose check, run in CI and available as a
   pre-commit hook: `en-GB_to_en-US` enforces American English, and

--- a/NEWS.md
+++ b/NEWS.md
@@ -202,20 +202,6 @@ wrong thing.
 
 ### BUG FIXES
 
-* `Vinecop::fit()` no longer lets the edges of a tree race on the h-functions.
-  Every edge reads `hfunc1`/`hfunc2` columns that edges of higher index in the
-  same tree write, so the serial order gave each of them the previous tree's
-  values and running the edges concurrently removed that guarantee: an edge
-  could be fitted against the current tree's h-functions instead. With more
-  than one thread the edges now read a snapshot of the previous tree (#774)
-
-* `ThreadPool::wait()` and `join()` consume the exception they report, so a
-  pool that ran a failing job can be used again. The stored exception was kept
-  after being rethrown, so every later `wait()` rethrew it and, because a
-  stored exception cancels the queue, dropped the jobs pushed in the meantime
-  without running them. `join()` stops and joins its threads even when a job
-  threw, and the first exception is the one reported when several jobs fail
-  (#774)
 * `Vinecop::loglik()` leaves out the observations that have no likelihood
   instead of returning `NaN` for the whole sample, matching `Bicop::loglik()`;
   `aic()`, `bic()` and `mbicv()` follow it. Evaluation is unchanged and still
@@ -377,35 +363,6 @@ wrong thing.
 
 ### BUILD SYSTEM AND DEPENDENCIES
 
-* Require CMake 3.20, with an upper bound of 4.0, and find Boost in CONFIG
-  mode only. `CMP0167` removes the `FindBoost` module, so the MODULE fallback
-  was going to stop working; Boost has shipped a config package since 1.70,
-  below the 1.75 required here. The `CMP0074` and `CMP0144` blocks go with it,
-  and `findHeaders.cmake` takes paths apart with `cmake_path()` rather than
-  matching them as text (#774)
-
-* Carry the dependency paths into the installed package. The exported link
-  interface names `Eigen3::Eigen`, `Boost::headers` and `wdm`, and the
-  installed config resolved each with `find_dependency`, so a build pointed at
-  a directory rather than a package shipped a package that failed on the
-  consumer's side. Those directories are now recorded and used when the
-  package cannot be found (#774)
-
-* Fix `-DEIGEN3_INCLUDE_DIR=<path>` and `-DBoost_INCLUDE_DIRS=<path>`. Either
-  one skips the matching `find_package`, and the build links Eigen and Boost by
-  target name, so a precompiled build failed at generate time and a build with
-  no in-tree consumer of the target exported a `vinecopulibTargets.cmake` that
-  only broke for consumers. All three dependency paths now define the target
-  they stand in for, as `wdm_INCLUDE_DIRS` already did, which also supplies the
-  `Boost::headers` that CMake 3.14's `FindBoost` module predates (#774)
-
-* Fix the precompiled build when the source path contains a regex
-  metacharacter. `findHeaders.cmake` matched path-derived patterns as regexes,
-  so a directory such as `vine+copulib` generated none of the headers and left
-  every `.ipp` both inlined and compiled as its own translation unit, for a
-  `redefinition of ...` error against an installed copy of the headers. Paths
-  are now taken apart with `cmake_path()` (#774)
-  are now compared literally (#774)
 * Update the vendored nlohmann/json from 3.9.1 to 3.12.0, now stored verbatim
   instead of reformatted, with the patches that remove its suppressed compiler
   diagnostics re-applied. The on-disk JSON and CBOR formats are unchanged
@@ -484,15 +441,6 @@ wrong thing.
 * Seed the RNG-dependent unit tests to remove flakiness (#686)
 
 * Decompose `VinecopSelector` for readability (#695)
-
-* Add a ThreadSanitizer CI job. `VINECOPULIB_SANITIZERS` adds the address and
-  UB sanitizers, neither of which sees a data race, so the thread-pool race
-  fixed in #764 and the h-function race fixed in #774 were both green in CI
-  throughout. The job builds the test areas that drive the thread pool with
-  `-fsanitize=thread` in a build tree of its own, since that flag cannot be
-  combined with the address sanitizer, and uses clang, whose runtime does not
-  lose the happens-before edge across `pthread_cond_timedwait`. A second job
-  covers the two defects above that are visible at configure time (#774)
 
 * Add a codespell-based spelling and prose check, run in CI and available as a
   pre-commit hook: `en-GB_to_en-US` enforces American English, and

--- a/cmake/codeCoverage.cmake
+++ b/cmake/codeCoverage.cmake
@@ -156,8 +156,8 @@ FUNCTION(SETUP_TARGET_FOR_COVERAGE _targetname _testrunner _outputname)
 
     # Show info where to find the report
     ADD_CUSTOM_COMMAND(TARGET ${_targetname} POST_BUILD
-            COMMAND ;
-            COMMENT "Open ./${_outputname}/index.html in your browser to view the coverage report."
+            COMMAND ${CMAKE_COMMAND} -E echo
+                    "Open ./${_outputname}/index.html to view the coverage report."
             )
 
 ENDFUNCTION() # SETUP_TARGET_FOR_COVERAGE

--- a/cmake/findDependencies.cmake
+++ b/cmake/findDependencies.cmake
@@ -29,8 +29,7 @@ vinecopulib_add_header_only_target(Eigen3::Eigen EIGEN3_INCLUDE_DIR)
 
 # Check if Boost_INCLUDE_DIRS is defined and if not, try to find it
 if(NOT DEFINED Boost_INCLUDE_DIRS)
-  # CONFIG only: CMP0167 removed the FindBoost module, and Boost has shipped a
-  # config package since 1.70, below the 1.75 required here.
+  # CONFIG only: CMP0167 removes the FindBoost module.
   find_package(Boost 1.75 REQUIRED CONFIG)
   message(STATUS "Found Boost: ${Boost_DIR} (found suitable version \"${Boost_VERSION}\")")
 endif()

--- a/cmake/findDependencies.cmake
+++ b/cmake/findDependencies.cmake
@@ -8,6 +8,34 @@ if (POLICY CMP0144)
   cmake_policy(SET CMP0144 NEW)
 endif ()
 
+# The build links its header-only dependencies by target name. find_package
+# defines those targets, and FetchContent does for wdm, but a caller-supplied
+# include path does not: so every path variable also has to define the target
+# it stands in for. Without that, the namespaced names fail at generate time
+# with "links to Eigen3::Eigen ... not found", and the plain name wdm is taken
+# for a library to search for and fails every link on -lwdm.
+#
+# Call this after the find_package that may define the target, never before:
+# Eigen3Config and BoostConfig create their imported targets unconditionally
+# and abort on a name that already exists.
+#
+# GLOBAL, because an imported target created in a function is otherwise
+# visible only inside that function.
+function(vinecopulib_add_header_only_target target include_dirs_var)
+  if(TARGET ${target})
+    return()
+  endif()
+  if(NOT ${include_dirs_var})
+    message(FATAL_ERROR
+            "${target} is not defined and ${include_dirs_var} is empty. Set "
+            "${include_dirs_var} to the directory holding the headers, or "
+            "leave it unset and let find_package look for the package.")
+  endif()
+  add_library(${target} INTERFACE IMPORTED GLOBAL)
+  set_target_properties(${target} PROPERTIES
+                        INTERFACE_INCLUDE_DIRECTORIES "${${include_dirs_var}}")
+endfunction()
+
 # Find the main dependencies
 
 # Check if EIGEN3_INCLUDE_DIR is defined and if not, try to find it
@@ -25,6 +53,7 @@ if(NOT DEFINED EIGEN3_INCLUDE_DIR)
                         INTERFACE_INCLUDE_DIRECTORIES)
   endif()
 endif()
+vinecopulib_add_header_only_target(Eigen3::Eigen EIGEN3_INCLUDE_DIR)
 
 # Check if Boost_INCLUDE_DIRS is defined and if not, try to find it
 if(NOT DEFINED Boost_INCLUDE_DIRS)
@@ -37,6 +66,10 @@ if(NOT DEFINED Boost_INCLUDE_DIRS)
     find_package(Boost 1.75 MODULE REQUIRED)
   endif ()
 endif()
+# CMake's FindBoost module gained Boost::headers in 3.15, one minor version
+# above this project's floor, so the MODULE fallback can leave only
+# Boost::boost behind.
+vinecopulib_add_header_only_target(Boost::headers Boost_INCLUDE_DIRS)
 
 find_package(Threads                      REQUIRED)
 
@@ -59,14 +92,7 @@ if(NOT DEFINED wdm_INCLUDE_DIRS)
   endif()
 endif()
 
-# The build links wdm by target name, which find_package and FetchContent both
-# define but a caller-supplied wdm_INCLUDE_DIRS does not. Without this the name
-# is taken for a library to search for, and every link fails on -lwdm.
-if(NOT TARGET wdm)
-  add_library(wdm INTERFACE IMPORTED GLOBAL)
-  set_target_properties(wdm PROPERTIES
-                        INTERFACE_INCLUDE_DIRECTORIES "${wdm_INCLUDE_DIRS}")
-endif()
+vinecopulib_add_header_only_target(wdm wdm_INCLUDE_DIRS)
 
 # Ensure R is available and download googlestest
 if(BUILD_TESTING)

--- a/cmake/findDependencies.cmake
+++ b/cmake/findDependencies.cmake
@@ -1,26 +1,5 @@
-if (POLICY CMP0074)
-  # find_package() uses <PackageName>_ROOT variables
-  cmake_policy(SET CMP0074 NEW)
-endif ()
-
-if (POLICY CMP0144)
-  # find_package() uses upper-case <PACKAGENAME>_ROOT variables.
-  cmake_policy(SET CMP0144 NEW)
-endif ()
-
-# The build links its header-only dependencies by target name. find_package
-# defines those targets, and FetchContent does for wdm, but a caller-supplied
-# include path does not: so every path variable also has to define the target
-# it stands in for. Without that, the namespaced names fail at generate time
-# with "links to Eigen3::Eigen ... not found", and the plain name wdm is taken
-# for a library to search for and fails every link on -lwdm.
-#
-# Call this after the find_package that may define the target, never before:
-# Eigen3Config and BoostConfig create their imported targets unconditionally
-# and abort on a name that already exists.
-#
-# GLOBAL, because an imported target created in a function is otherwise
-# visible only inside that function.
+# The build links these by target name, so a caller-supplied path has to define
+# the target too. Call after the find_package that may already define it.
 function(vinecopulib_add_header_only_target target include_dirs_var)
   if(TARGET ${target})
     return()
@@ -41,34 +20,20 @@ endfunction()
 # Check if EIGEN3_INCLUDE_DIR is defined and if not, try to find it
 if(NOT DEFINED EIGEN3_INCLUDE_DIR)
   find_package(Eigen3 REQUIRED CONFIG)
-  if (Eigen3_FOUND)
-    message(STATUS "Found Eigen3: ${Eigen3_DIR} (found suitable version \"${Eigen3_VERSION}\")")
-  else()
-    message(FATAL_ERROR "Could not find Eigen3")
-  endif()
-  # Eigen 5.x exposes its include path only through the target and no longer
-  # sets EIGEN3_INCLUDE_DIR, which external_includes below needs.
-  if(TARGET Eigen3::Eigen)
-    get_target_property(EIGEN3_INCLUDE_DIR Eigen3::Eigen
-                        INTERFACE_INCLUDE_DIRECTORIES)
-  endif()
+  message(STATUS "Found Eigen3: ${Eigen3_DIR} (found suitable version \"${Eigen3_VERSION}\")")
+  # Eigen 5.x sets no EIGEN3_INCLUDE_DIR; external_includes below needs one.
+  get_target_property(EIGEN3_INCLUDE_DIR Eigen3::Eigen
+                      INTERFACE_INCLUDE_DIRECTORIES)
 endif()
 vinecopulib_add_header_only_target(Eigen3::Eigen EIGEN3_INCLUDE_DIR)
 
 # Check if Boost_INCLUDE_DIRS is defined and if not, try to find it
 if(NOT DEFINED Boost_INCLUDE_DIRS)
-  # try to find Boost in CONFIG mode first
-  find_package(Boost 1.75 CONFIG)
-  if (Boost_FOUND)
-    message(STATUS "Found Boost: ${Boost_DIR} (found suitable version \"${Boost_VERSION}\")")  
-  else ()
-    # fallback to MODULE mode
-    find_package(Boost 1.75 MODULE REQUIRED)
-  endif ()
+  # CONFIG only: CMP0167 removed the FindBoost module, and Boost has shipped a
+  # config package since 1.70, below the 1.75 required here.
+  find_package(Boost 1.75 REQUIRED CONFIG)
+  message(STATUS "Found Boost: ${Boost_DIR} (found suitable version \"${Boost_VERSION}\")")
 endif()
-# CMake's FindBoost module gained Boost::headers in 3.15, one minor version
-# above this project's floor, so the MODULE fallback can leave only
-# Boost::boost behind.
 vinecopulib_add_header_only_target(Boost::headers Boost_INCLUDE_DIRS)
 
 find_package(Threads                      REQUIRED)

--- a/cmake/findHeaders.cmake
+++ b/cmake/findHeaders.cmake
@@ -18,14 +18,18 @@ if(VINECOPULIB_PRECOMPILED)
     # contents as well, so that editing a header regenerates what it feeds.
     set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS
             ${vinecopulib_ipp} ${vinecopulib_all_hpp})
+    # Both loops below rewrite paths as literal text, with string(REPLACE):
+    # the source and binary directories come from the caller and may contain
+    # regex metacharacters such as '+' or '.', which a pattern reads as
+    # operators and then fails to match. A regex is right only where the
+    # pattern is written out here in full and merely the subject comes from a
+    # path.
     foreach (file ${vinecopulib_ipp})
 
-        # Get directory, name and path for header/source files. Paths are
-        # manipulated with string(REPLACE), not regexes: the source directory is
-        # arbitrary and may contain regex metacharacters such as '+' or '.'.
+        # Get directory, name and path for header/source files.
         get_filename_component(name_without_extension ${file} NAME_WE)
         get_filename_component(directory ${file} DIRECTORY)
-        string(REGEX REPLACE "/implementation$" "" directory ${directory})
+        string(REGEX REPLACE "/implementation$" "" directory "${directory}")
         set(header_file ${directory}/${name_without_extension}.hpp)
         string(REPLACE "${vinecopulib_includes}/" ""
                 header_file ${header_file})
@@ -65,14 +69,14 @@ if(VINECOPULIB_PRECOMPILED)
         get_filename_component(name_without_extension ${file} NAME_WE)
         get_filename_component(directory ${file} DIRECTORY)
         set(ipp_file ${directory}/implementation/${name_without_extension}.ipp)
-        string(REGEX REPLACE "${vinecopulib_includes}/" "" ipp_file ${ipp_file})
-        string(REGEX REPLACE ${vinecopulib_includes} ${vinecopulib_generated_includes}
-                header_folder ${directory})
+        string(REPLACE "${vinecopulib_includes}/" "" ipp_file "${ipp_file}")
+        string(REPLACE "${vinecopulib_includes}"
+                "${vinecopulib_generated_includes}" header_folder "${directory}")
         set(header_file "${header_folder}/${name_without_extension}.hpp")
 
         # File scrap content and remove ipp include
         file(READ ${file} file_content)
-        string(REGEX REPLACE "#include <${ipp_file}>" ""
+        string(REPLACE "#include <${ipp_file}>" ""
                 file_content "${file_content}")
 
         # If header does not exists or has changed, generate new header file

--- a/cmake/findHeaders.cmake
+++ b/cmake/findHeaders.cmake
@@ -18,8 +18,8 @@ if(VINECOPULIB_PRECOMPILED)
     # contents as well, so that editing a header regenerates what it feeds.
     set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS
             ${vinecopulib_ipp} ${vinecopulib_all_hpp})
-    # Paths are taken apart with cmake_path, never matched as text: the source
-    # directory comes from the caller and may contain regex metacharacters.
+    # cmake_path, not text matching: the source directory comes from the
+    # caller and may contain regex metacharacters.
     foreach (file ${vinecopulib_ipp})
 
         # <includes>/vinecopulib/<mod>/implementation/<name>.ipp becomes

--- a/cmake/findHeaders.cmake
+++ b/cmake/findHeaders.cmake
@@ -18,24 +18,24 @@ if(VINECOPULIB_PRECOMPILED)
     # contents as well, so that editing a header regenerates what it feeds.
     set_property(DIRECTORY APPEND PROPERTY CMAKE_CONFIGURE_DEPENDS
             ${vinecopulib_ipp} ${vinecopulib_all_hpp})
-    # Both loops below rewrite paths as literal text, with string(REPLACE):
-    # the source and binary directories come from the caller and may contain
-    # regex metacharacters such as '+' or '.', which a pattern reads as
-    # operators and then fails to match. A regex is right only where the
-    # pattern is written out here in full and merely the subject comes from a
-    # path.
+    # Paths are taken apart with cmake_path, never matched as text: the source
+    # directory comes from the caller and may contain regex metacharacters.
     foreach (file ${vinecopulib_ipp})
 
-        # Get directory, name and path for header/source files.
-        get_filename_component(name_without_extension ${file} NAME_WE)
-        get_filename_component(directory ${file} DIRECTORY)
-        string(REGEX REPLACE "/implementation$" "" directory "${directory}")
-        set(header_file ${directory}/${name_without_extension}.hpp)
-        string(REPLACE "${vinecopulib_includes}/" ""
-                header_file ${header_file})
-        string(REPLACE "${vinecopulib_includes}/vinecopulib"
-                "${vinecopulib_generated_sources}" source_folder ${directory})
-        set(source_file "${source_folder}/${name_without_extension}.cpp")
+        # <includes>/vinecopulib/<mod>/implementation/<name>.ipp becomes
+        # <generated>/src/<mod>/<name>.cpp, including <mod>/<name>.hpp.
+        cmake_path(GET file STEM name_without_extension)
+        cmake_path(GET file PARENT_PATH directory)
+        cmake_path(GET directory PARENT_PATH directory)
+        cmake_path(RELATIVE_PATH directory
+                BASE_DIRECTORY "${vinecopulib_includes}"
+                OUTPUT_VARIABLE header_folder)
+        set(header_file "${header_folder}/${name_without_extension}.hpp")
+        cmake_path(RELATIVE_PATH directory
+                BASE_DIRECTORY "${vinecopulib_includes}/vinecopulib"
+                OUTPUT_VARIABLE module_folder)
+        set(source_file
+                "${vinecopulib_generated_sources}/${module_folder}/${name_without_extension}.cpp")
 
         # Turn the .ipp into a translation unit: drop the banner (re-added
         # below) and the `inline` keywords, then include the header.
@@ -65,16 +65,17 @@ if(VINECOPULIB_PRECOMPILED)
     file(GLOB_RECURSE vinecopulib_hpp CONFIGURE_DEPENDS
             ${vinecopulib_includes}/vinecopulib/*.hpp)
     foreach (file ${vinecopulib_hpp})
-        # Get directory, name and path for header/source files
-        get_filename_component(name_without_extension ${file} NAME_WE)
-        get_filename_component(directory ${file} DIRECTORY)
-        set(ipp_file ${directory}/implementation/${name_without_extension}.ipp)
-        string(REPLACE "${vinecopulib_includes}/" "" ipp_file "${ipp_file}")
-        string(REPLACE "${vinecopulib_includes}"
-                "${vinecopulib_generated_includes}" header_folder "${directory}")
-        set(header_file "${header_folder}/${name_without_extension}.hpp")
+        # The same header under <generated>/include, without its .ipp include.
+        cmake_path(GET file STEM name_without_extension)
+        cmake_path(GET file PARENT_PATH directory)
+        cmake_path(RELATIVE_PATH directory
+                BASE_DIRECTORY "${vinecopulib_includes}"
+                OUTPUT_VARIABLE header_folder)
+        set(ipp_file
+                "${header_folder}/implementation/${name_without_extension}.ipp")
+        set(header_file
+                "${vinecopulib_generated_includes}/${header_folder}/${name_without_extension}.hpp")
 
-        # File scrap content and remove ipp include
         file(READ ${file} file_content)
         string(REPLACE "#include <${ipp_file}>" ""
                 file_content "${file_content}")

--- a/cmake/templates/Config.cmake.in
+++ b/cmake/templates/Config.cmake.in
@@ -1,9 +1,39 @@
 @PACKAGE_INIT@
 
 include(CMakeFindDependencyMacro)
-find_dependency(Eigen3)
-find_dependency(wdm)
-find_dependency(Boost CONFIG)
+
+# The link interface names these targets, so each has to exist here. Where the
+# build was pointed at a directory instead of a package, that directory is
+# recorded below and used when the package cannot be found.
+macro(vinecopulib_find_dependency package target include_dirs)
+  if(NOT TARGET ${target})
+    find_package(${package} QUIET ${ARGN})
+  endif()
+  if(NOT TARGET ${target})
+    set(_vinecopulib_dirs "${include_dirs}")
+    foreach(_vinecopulib_dir IN LISTS _vinecopulib_dirs)
+      if(NOT IS_DIRECTORY "${_vinecopulib_dir}")
+        set(_vinecopulib_dirs "")
+        break()
+      endif()
+    endforeach()
+    if(_vinecopulib_dirs)
+      add_library(${target} INTERFACE IMPORTED)
+      set_target_properties(${target} PROPERTIES
+                            INTERFACE_INCLUDE_DIRECTORIES "${_vinecopulib_dirs}")
+    else()
+      set(${CMAKE_FIND_PACKAGE_NAME}_FOUND FALSE)
+      set(${CMAKE_FIND_PACKAGE_NAME}_NOT_FOUND_MESSAGE
+          "vinecopulib requires ${target}: ${package} was not found, and the \
+directory this build used (${include_dirs}) is not present either.")
+      return()
+    endif()
+  endif()
+endmacro()
+
+vinecopulib_find_dependency(Eigen3 Eigen3::Eigen "@EIGEN3_INCLUDE_DIR@" CONFIG)
+vinecopulib_find_dependency(Boost Boost::headers "@Boost_INCLUDE_DIRS@" 1.75 CONFIG)
+vinecopulib_find_dependency(wdm wdm "@wdm_INCLUDE_DIRS@" 0.3.0)
 # Threads::Threads appears in the exported link interface, so the consumer needs
 # the imported target to exist.
 find_dependency(Threads)

--- a/cmake/templates/Config.cmake.in
+++ b/cmake/templates/Config.cmake.in
@@ -2,9 +2,8 @@
 
 include(CMakeFindDependencyMacro)
 
-# The link interface names these targets, so each has to exist here. Where the
-# build was pointed at a directory instead of a package, that directory is
-# recorded below and used when the package cannot be found.
+# The link interface names these targets, so each has to exist here. A build
+# given a directory instead of a package records it, for use as a fallback.
 macro(vinecopulib_find_dependency package target include_dirs)
   if(NOT TARGET ${target})
     find_package(${package} QUIET ${ARGN})

--- a/examples/benchmark/CMakeLists.txt
+++ b/examples/benchmark/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.20...4.0)
 
 set(CMAKE_CXX_STANDARD 17)
 
@@ -13,16 +13,6 @@ if (NOT WIN32)
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -O3 -DNDEBUG")
   MESSAGE(STATUS "CMAKE_CXX_FLAGS: ${CMAKE_CXX_FLAGS}")
 endif()
-
-if (POLICY CMP0074)
-  # find_package() uses <PackageName>_ROOT variables
-  cmake_policy(SET CMP0074 NEW)
-endif ()
-
-if (POLICY CMP0144)
-  # find_package() uses upper-case <PACKAGENAME>_ROOT variables.
-  cmake_policy(SET CMP0144 NEW)
-endif ()
 
 # Find vinecopulib package and dependencies
 find_package(vinecopulib REQUIRED)

--- a/examples/bicop/CMakeLists.txt
+++ b/examples/bicop/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.20...4.0)
 
 set(CMAKE_CXX_STANDARD 17)
 
@@ -11,16 +11,6 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/bin)
 if (NOT WIN32)
   set(CMAKE_CXX_FLAGS "-Wextra -Wall -Wno-delete-non-virtual-dtor -Werror=return-type -O3 -DNDEBUG")
 endif()
-
-if (POLICY CMP0074)
-  # find_package() uses <PackageName>_ROOT variables
-  cmake_policy(SET CMP0074 NEW)
-endif ()
-
-if (POLICY CMP0144)
-  # find_package() uses upper-case <PACKAGENAME>_ROOT variables.
-  cmake_policy(SET CMP0144 NEW)
-endif ()
 
 # Find vinecopulib package and dependencies
 find_package(vinecopulib REQUIRED)

--- a/examples/vinecop/CMakeLists.txt
+++ b/examples/vinecop/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.16)
+cmake_minimum_required(VERSION 3.20...4.0)
 
 set(CMAKE_CXX_STANDARD 17)
 
@@ -11,16 +11,6 @@ set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/bin)
 if (NOT WIN32)
     set(CMAKE_CXX_FLAGS "-Wextra -Wall -Wno-delete-non-virtual-dtor -Werror=return-type -O3 -DNDEBUG")
 endif()
-
-if (POLICY CMP0074)
-  # find_package() uses <PackageName>_ROOT variables
-  cmake_policy(SET CMP0074 NEW)
-endif ()
-
-if (POLICY CMP0144)
-  # find_package() uses upper-case <PACKAGENAME>_ROOT variables.
-  cmake_policy(SET CMP0144 NEW)
-endif ()
 
 # Find vinecopulib package and dependencies
 find_package(vinecopulib REQUIRED)

--- a/include/vinecopulib/misc/tools_thread.hpp
+++ b/include/vinecopulib/misc/tools_thread.hpp
@@ -62,6 +62,7 @@ private:
 
   bool has_errored_locked() const;
   bool all_jobs_done_locked() const;
+  void wait_for_jobs();
   bool wait_for_wake_up_event(std::unique_lock<std::mutex>& lk);
   void rethrow_exceptions();
 
@@ -143,34 +144,28 @@ ThreadPool::map(F&& f, I&& items)
 }
 
 //! waits for all jobs to finish, but does not join the threads.
+//!
+//! If a job threw, its exception is rethrown here and the jobs that had not
+//! started are canceled. The exception is reported once, and the pool accepts
+//! new jobs afterwards.
 inline void
 ThreadPool::wait()
 {
-  {
-    // must hold the lock while reading the shared state; the wake up event
-    // releases it while waiting
-    std::unique_lock<std::mutex> lk(m_tasks_);
-    while (true) {
-      if (this->wait_for_wake_up_event(lk)) {
-        if (this->all_jobs_done_locked())
-          break;
-        // an error makes the jobs that have not started pointless; the ones
-        // already running still have to finish
-        this->clear_locked();
-      }
-    }
-  } // the lock must be released before the exception is rethrown
-
+  this->wait_for_jobs();
   this->rethrow_exceptions();
 }
 
 //! waits for all jobs to finish and joins all threads.
+//!
+//! The threads are stopped and joined even when a job threw; the exception is
+//! rethrown once they are. Jobs can no longer be pushed to the pool.
 inline void
 ThreadPool::join()
 {
-  this->wait();
+  this->wait_for_jobs();
   this->announce_stop();
   this->join_workers();
+  this->rethrow_exceptions();
 }
 
 //! clears the pool from all open jobs.
@@ -234,7 +229,10 @@ ThreadPool::do_job(std::function<void()>&& job)
   } catch (...) {
     {
       std::lock_guard<std::mutex> lk(m_tasks_);
-      error_ptr_ = std::current_exception();
+      // the first failure is the one that cancels the jobs that have not
+      // started, and the one reported to the caller
+      if (!this->has_errored_locked())
+        error_ptr_ = std::current_exception();
     }
     cv_busy_.notify_one();
   }
@@ -296,6 +294,27 @@ ThreadPool::all_jobs_done_locked() const
   return (num_busy_ == 0) && jobs_.empty();
 }
 
+//! waits until no job is queued or running.
+//!
+//! An error cancels the jobs that have not started; reporting it is left to
+//! `rethrow_exceptions()`, which the lock must be released for.
+inline void
+ThreadPool::wait_for_jobs()
+{
+  // must hold the lock while reading the shared state; the wake up event
+  // releases it while waiting
+  std::unique_lock<std::mutex> lk(m_tasks_);
+  while (true) {
+    if (this->wait_for_wake_up_event(lk)) {
+      if (this->all_jobs_done_locked())
+        return;
+      // an error makes the jobs that have not started pointless; the ones
+      // already running still have to finish
+      this->clear_locked();
+    }
+  }
+}
+
 //! checks whether `wait()` needs to wake up, i.e., all jobs are done or an
 //! error makes the jobs that have not started pointless.
 //! @param lk A lock on `m_tasks_` held by the caller; released while waiting.
@@ -313,8 +332,8 @@ ThreadPool::wait_for_wake_up_event(std::unique_lock<std::mutex>& lk)
   return wake_up_event_occurred();
 }
 
-//! rethrows exceptions (exceptions from workers are caught and stored; the
-//! wait loop only checks, but does not throw exceptions)
+//! rethrows the exception stored by a failing job, if there is one, and
+//! consumes it, so that it is reported to a single `wait()` or `join()`.
 inline void
 ThreadPool::rethrow_exceptions()
 {
@@ -322,7 +341,7 @@ ThreadPool::rethrow_exceptions()
   {
     // must hold the lock while reading the stored exception
     std::lock_guard<std::mutex> lk(m_tasks_);
-    error_ptr = error_ptr_;
+    std::swap(error_ptr, error_ptr_);
   }
   if (error_ptr)
     std::rethrow_exception(error_ptr);

--- a/include/vinecopulib/misc/tools_thread.hpp
+++ b/include/vinecopulib/misc/tools_thread.hpp
@@ -145,9 +145,7 @@ ThreadPool::map(F&& f, I&& items)
 
 //! waits for all jobs to finish, but does not join the threads.
 //!
-//! If a job threw, its exception is rethrown here and the jobs that had not
-//! started are canceled. The exception is reported once, and the pool accepts
-//! new jobs afterwards.
+//! A job's exception is rethrown here once, and leaves the pool reusable.
 inline void
 ThreadPool::wait()
 {
@@ -157,8 +155,7 @@ ThreadPool::wait()
 
 //! waits for all jobs to finish and joins all threads.
 //!
-//! The threads are stopped and joined even when a job threw; the exception is
-//! rethrown once they are. Jobs can no longer be pushed to the pool.
+//! The threads are stopped and joined even when a job threw.
 inline void
 ThreadPool::join()
 {
@@ -229,8 +226,7 @@ ThreadPool::do_job(std::function<void()>&& job)
   } catch (...) {
     {
       std::lock_guard<std::mutex> lk(m_tasks_);
-      // the first failure is the one that cancels the jobs that have not
-      // started, and the one reported to the caller
+      // the first failure is the one that cancels the queue
       if (!this->has_errored_locked())
         error_ptr_ = std::current_exception();
     }
@@ -295,9 +291,6 @@ ThreadPool::all_jobs_done_locked() const
 }
 
 //! waits until no job is queued or running.
-//!
-//! An error cancels the jobs that have not started; reporting it is left to
-//! `rethrow_exceptions()`, which the lock must be released for.
 inline void
 ThreadPool::wait_for_jobs()
 {
@@ -332,8 +325,7 @@ ThreadPool::wait_for_wake_up_event(std::unique_lock<std::mutex>& lk)
   return wake_up_event_occurred();
 }
 
-//! rethrows the exception stored by a failing job, if there is one, and
-//! consumes it, so that it is reported to a single `wait()` or `join()`.
+//! rethrows the exception stored by a failing job, and consumes it.
 inline void
 ThreadPool::rethrow_exceptions()
 {

--- a/include/vinecopulib/misc/tools_thread.hpp
+++ b/include/vinecopulib/misc/tools_thread.hpp
@@ -143,9 +143,10 @@ ThreadPool::map(F&& f, I&& items)
     this->push(f, item);
 }
 
-//! waits for all jobs to finish, but does not join the threads.
+//! @brief Waits for all jobs to finish, but does not join the threads.
 //!
-//! A job's exception is rethrown here once, and leaves the pool reusable.
+//! @details A job's exception is rethrown here once, and cancels the jobs that
+//! have not started. The pool stays usable afterwards.
 inline void
 ThreadPool::wait()
 {
@@ -153,9 +154,9 @@ ThreadPool::wait()
   this->rethrow_exceptions();
 }
 
-//! waits for all jobs to finish and joins all threads.
+//! @brief Waits for all jobs to finish and joins all threads.
 //!
-//! The threads are stopped and joined even when a job threw.
+//! @details The threads are stopped and joined even when a job threw.
 inline void
 ThreadPool::join()
 {
@@ -290,7 +291,7 @@ ThreadPool::all_jobs_done_locked() const
   return (num_busy_ == 0) && jobs_.empty();
 }
 
-//! waits until no job is queued or running.
+//! @brief Waits until no job is queued or running.
 inline void
 ThreadPool::wait_for_jobs()
 {
@@ -325,7 +326,7 @@ ThreadPool::wait_for_wake_up_event(std::unique_lock<std::mutex>& lk)
   return wake_up_event_occurred();
 }
 
-//! rethrows the exception stored by a failing job, and consumes it.
+//! @brief Rethrows the exception stored by a failing job, and consumes it.
 inline void
 ThreadPool::rethrow_exceptions()
 {

--- a/include/vinecopulib/vinecop/implementation/class.ipp
+++ b/include/vinecopulib/vinecop/implementation/class.ipp
@@ -659,6 +659,19 @@ Vinecop::fit(const Eigen::MatrixXd& data,
   // set up thread pool
   tools_thread::ThreadPool pool((num_threads == 1) ? 0 : num_threads);
 
+  // The edges of a tree are fitted concurrently, and an edge writes the
+  // h-function column that an edge of lower index in the same tree reads. When
+  // that can happen, the edges read a snapshot of the previous tree instead,
+  // which is what the serial order gives every one of them.
+  const bool snapshot_hfuncs = num_threads > 1;
+  Eigen::MatrixXd hfunc1_prev, hfunc2_prev, hfunc1_sub_prev, hfunc2_sub_prev;
+  const Eigen::MatrixXd& hfunc1_in = snapshot_hfuncs ? hfunc1_prev : hfunc1;
+  const Eigen::MatrixXd& hfunc2_in = snapshot_hfuncs ? hfunc2_prev : hfunc2;
+  const Eigen::MatrixXd& hfunc1_sub_in =
+    snapshot_hfuncs ? hfunc1_sub_prev : hfunc1_sub;
+  const Eigen::MatrixXd& hfunc2_sub_in =
+    snapshot_hfuncs ? hfunc2_sub_prev : hfunc2_sub;
+
   // fill first row of hfunc2 matrix with observed data;
   // points have to be reordered to correspond to natural order
   for (size_t j = 0; j < d_; ++j) {
@@ -670,6 +683,12 @@ Vinecop::fit(const Eigen::MatrixXd& data,
 
   for (size_t tree = 0; tree < trunc_lvl; ++tree) {
     tools_interface::check_user_interrupt();
+    if (snapshot_hfuncs) {
+      hfunc1_prev = hfunc1;
+      hfunc2_prev = hfunc2;
+      hfunc1_sub_prev = hfunc1_sub;
+      hfunc2_sub_prev = hfunc2_sub;
+    }
     // scale down the per-fit thread budget: the edges of this tree already
     // run concurrently on the pool, so nested threading would oversubscribe
     FitControlsBicop tree_controls = controls;
@@ -686,20 +705,20 @@ Vinecop::fit(const Eigen::MatrixXd& data,
       size_t m = rvine_structure_.min_array(tree, edge);
 
       Eigen::MatrixXd u_e(n, 2), u_e_sub;
-      u_e.col(0) = hfunc2.col(edge);
+      u_e.col(0) = hfunc2_in.col(edge);
       if (m == rvine_structure_.struct_array(tree, edge, true)) {
-        u_e.col(1) = hfunc2.col(m - 1);
+        u_e.col(1) = hfunc2_in.col(m - 1);
       } else {
-        u_e.col(1) = hfunc1.col(m - 1);
+        u_e.col(1) = hfunc1_in.col(m - 1);
       }
 
       if ((var_types[0] == "d") || (var_types[1] == "d")) {
         u_e.conservativeResize(n, 4);
-        u_e.col(2) = hfunc2_sub.col(edge);
+        u_e.col(2) = hfunc2_sub_in.col(edge);
         if (m == rvine_structure_.struct_array(tree, edge, true)) {
-          u_e.col(3) = hfunc2_sub.col(m - 1);
+          u_e.col(3) = hfunc2_sub_in.col(m - 1);
         } else {
-          u_e.col(3) = hfunc1_sub.col(m - 1);
+          u_e.col(3) = hfunc1_sub_in.col(m - 1);
         }
       }
 

--- a/include/vinecopulib/vinecop/implementation/class.ipp
+++ b/include/vinecopulib/vinecop/implementation/class.ipp
@@ -659,10 +659,8 @@ Vinecop::fit(const Eigen::MatrixXd& data,
   // set up thread pool
   tools_thread::ThreadPool pool((num_threads == 1) ? 0 : num_threads);
 
-  // The edges of a tree are fitted concurrently, and an edge writes the
-  // h-function column that an edge of lower index in the same tree reads. When
-  // that can happen, the edges read a snapshot of the previous tree instead,
-  // which is what the serial order gives every one of them.
+  // Concurrent edges write h-function columns their siblings read, so they
+  // read a snapshot of the previous tree, as the serial order gave them.
   const bool snapshot_hfuncs = num_threads > 1;
   Eigen::MatrixXd hfunc1_prev, hfunc2_prev, hfunc1_sub_prev, hfunc2_sub_prev;
   const Eigen::MatrixXd& hfunc1_in = snapshot_hfuncs ? hfunc1_prev : hfunc1;

--- a/include/vinecopulib/vinecop/implementation/class.ipp
+++ b/include/vinecopulib/vinecop/implementation/class.ipp
@@ -659,8 +659,7 @@ Vinecop::fit(const Eigen::MatrixXd& data,
   // set up thread pool
   tools_thread::ThreadPool pool((num_threads == 1) ? 0 : num_threads);
 
-  // Concurrent edges write h-function columns their siblings read, so they
-  // read a snapshot of the previous tree, as the serial order gave them.
+  // Concurrent edges write h-function columns their siblings read.
   const bool snapshot_hfuncs = num_threads > 1;
   Eigen::MatrixXd hfunc1_prev, hfunc2_prev, hfunc1_sub_prev, hfunc2_sub_prev;
   const Eigen::MatrixXd& hfunc1_in = snapshot_hfuncs ? hfunc1_prev : hfunc1;

--- a/test/src_test/test_tools_thread.cpp
+++ b/test/src_test/test_tools_thread.cpp
@@ -159,8 +159,7 @@ TEST(test_tools_thread, reusable_after_a_reported_error)
   EXPECT_NO_THROW(pool.join());
 }
 
-// join() shuts the pool down on both paths, so it is the same pool afterwards
-// whether or not a job threw.
+// join() shuts the pool down whether or not a job threw.
 TEST(test_tools_thread, join_stops_the_workers_after_an_error)
 {
   ThreadPool pool(2);
@@ -176,8 +175,7 @@ TEST(test_tools_thread, join_stops_the_workers_after_an_error)
   EXPECT_NO_THROW(pool.join());
 }
 
-// Jobs pushed after an error was reported are a new round of work, and none of
-// them is canceled.
+// Jobs pushed after an error was reported are not canceled.
 TEST(test_tools_thread, queued_jobs_survive_a_reported_error)
 {
   const int n_jobs = 200;
@@ -197,8 +195,7 @@ TEST(test_tools_thread, queued_jobs_survive_a_reported_error)
   pool.join();
 }
 
-// One worker runs the jobs in the order they were pushed, so the first of two
-// failures is the one the caller is told about.
+// One worker runs jobs in order, so the first failure is the one reported.
 TEST(test_tools_thread, first_error_is_the_one_reported)
 {
   std::atomic<int> failed{ 0 };

--- a/test/src_test/test_tools_thread.cpp
+++ b/test/src_test/test_tools_thread.cpp
@@ -144,4 +144,82 @@ TEST(test_tools_thread, repeated_shutdown_is_consistent)
     EXPECT_EQ(ran.load(), n_jobs);
   }
 }
+
+// A reported error is consumed, so the pool is ready for the next round.
+TEST(test_tools_thread, reusable_after_a_reported_error)
+{
+  ThreadPool pool(4);
+  pool.push([] { throw std::runtime_error("job failed"); });
+  EXPECT_THROW(pool.wait(), std::runtime_error);
+
+  std::atomic<int> ran{ 0 };
+  pool.push([&ran]() noexcept { ++ran; });
+  EXPECT_NO_THROW(pool.wait());
+  EXPECT_EQ(ran.load(), 1);
+  EXPECT_NO_THROW(pool.join());
+}
+
+// join() shuts the pool down on both paths, so it is the same pool afterwards
+// whether or not a job threw.
+TEST(test_tools_thread, join_stops_the_workers_after_an_error)
+{
+  ThreadPool pool(2);
+  pool.push([] { throw std::runtime_error("job failed"); });
+  EXPECT_THROW(pool.join(), std::runtime_error);
+
+  try {
+    pool.push([]() noexcept {});
+    FAIL() << "push() was accepted by a joined thread pool";
+  } catch (const std::runtime_error& e) {
+    EXPECT_STREQ(e.what(), "cannot push to joined thread pool");
+  }
+  EXPECT_NO_THROW(pool.join());
+}
+
+// Jobs pushed after an error was reported are a new round of work, and none of
+// them is canceled.
+TEST(test_tools_thread, queued_jobs_survive_a_reported_error)
+{
+  const int n_jobs = 200;
+  ThreadPool pool(1);
+  pool.push([] { throw std::runtime_error("job failed"); });
+  EXPECT_THROW(pool.wait(), std::runtime_error);
+
+  std::atomic<int> ran{ 0 };
+  pool.push([&ran] {
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    ++ran;
+  });
+  for (int i = 0; i < n_jobs; ++i)
+    pool.push([&ran]() noexcept { ++ran; });
+  EXPECT_NO_THROW(pool.wait());
+  EXPECT_EQ(ran.load(), n_jobs + 1);
+  pool.join();
+}
+
+// One worker runs the jobs in the order they were pushed, so the first of two
+// failures is the one the caller is told about.
+TEST(test_tools_thread, first_error_is_the_one_reported)
+{
+  std::atomic<int> failed{ 0 };
+  ThreadPool pool(1);
+  pool.push([&failed] {
+    ++failed;
+    throw std::runtime_error("first job failed");
+  });
+  pool.push([&failed] {
+    ++failed;
+    throw std::runtime_error("second job failed");
+  });
+  while (failed.load() < 2)
+    std::this_thread::yield();
+
+  try {
+    pool.wait();
+    FAIL() << "wait() did not rethrow a job's exception";
+  } catch (const std::runtime_error& e) {
+    EXPECT_STREQ(e.what(), "first job failed");
+  }
+  pool.join();
+}
 }

--- a/test/src_test/test_vinecop_class.cpp
+++ b/test/src_test/test_vinecop_class.cpp
@@ -2266,6 +2266,35 @@ TEST(VinecopDerivatives, per_obs_pdf_and_loglik)
   EXPECT_NEAR(ll_po, ll_ref, 1e-8 * (1.0 + std::abs(ll_ref)));
 }
 
+// An edge reads the h-function columns that edges of higher index in the same
+// tree write, so fitting the edges concurrently has to give the serial result.
+TEST(VinecopFit, parallel_fit_matches_serial)
+{
+  const size_t d = 8;
+  const auto u = tools_stats::simulate_uniform(300, d, false, { 3, 5, 7, 11 });
+  FitControlsVinecop controls(bicop_families::itau, "itau");
+
+  // one selected model, then the same pair copulas refitted both ways
+  const Vinecop model(u, RVineStructure(), {}, controls);
+  Vinecop serial(model.get_rvine_structure(), model.get_all_pair_copulas());
+  Vinecop parallel(model.get_rvine_structure(), model.get_all_pair_copulas());
+  serial.fit(u, controls, 1);
+  parallel.fit(u, controls, 4);
+
+  EXPECT_EQ(serial.loglik(u), parallel.loglik(u));
+  for (size_t tree = 0; tree < serial.get_trunc_lvl(); ++tree) {
+    for (size_t edge = 0; edge < d - tree - 1; ++edge) {
+      EXPECT_EQ(serial.get_family(tree, edge), parallel.get_family(tree, edge))
+        << "tree " << tree << ", edge " << edge;
+      EXPECT_TRUE(all_close(serial.get_parameters(tree, edge),
+                            parallel.get_parameters(tree, edge),
+                            0.0,
+                            0.0))
+        << "tree " << tree << ", edge " << edge;
+    }
+  }
+}
+
 TEST_F(VinecopTest, aic_bic_are_correct)
 {
   int d = 7;

--- a/test/src_test/test_vinecop_class.cpp
+++ b/test/src_test/test_vinecop_class.cpp
@@ -2266,8 +2266,7 @@ TEST(VinecopDerivatives, per_obs_pdf_and_loglik)
   EXPECT_NEAR(ll_po, ll_ref, 1e-8 * (1.0 + std::abs(ll_ref)));
 }
 
-// An edge reads the h-function columns that edges of higher index in the same
-// tree write, so fitting the edges concurrently has to give the serial result.
+// Fitting the edges concurrently must give the serial result.
 TEST(VinecopFit, parallel_fit_matches_serial)
 {
   const size_t d = 8;


### PR DESCRIPTION
Closes #766, #767, #768, #769, #775. Rebased onto `main` now that #764 merged.

## Fixes

- **#767** — `ThreadPool::error_ptr_` was never cleared, so after one throwing
  job every `wait()` rethrew it and dropped the work pushed since.
  `rethrow_exceptions()` consumes what it reports. That settles the question
  the issue raises about `join()`, which left its workers running when `wait()`
  threw: the wait loop moves into a private `wait_for_jobs()`, and `join()`
  stops and joins before rethrowing.
- **#766** — `-DEIGEN3_INCLUDE_DIR` / `-DBoost_INCLUDE_DIRS` skipped the
  `find_package` that defines the target the link line names. wdm's one-off fix
  (#754) becomes a function used for all three.
- **#768** — the `.hpp` loop matched path-derived patterns as regexes, so a
  path containing `+` or `.` generated 0 of 46 headers. `findHeaders.cmake` uses
  `cmake_path()`, which cannot have that bug rather than having it fixed.
- **#775** — the installed package resolved its dependencies with
  `find_dependency`, so a build given a directory shipped a package that failed
  for consumers. It records those directories and falls back to them.
- **#769** — a ThreadSanitizer job, plus a `packaging` job covering the three
  build-system promises above.

## Also fixed: a data race in `Vinecop::fit`

The TSan job reported one on its first run, pre-existing on `main`. Edges of a
tree are fitted concurrently and each reads `hfunc1`/`hfunc2` columns other
edges write (`class.ipp:718` against `:691`, and `:710` against `:693`).

Across 2800 random structures (d = 3..9, 47600 reads) the read column is always
of higher index than the reading edge, and 25% of reads hit a column another
edge of the same tree writes — so serial order was what made the in-place
scheme correct, and the pool removed that guarantee. With more than one thread
the edges read a snapshot of the previous tree; the serial path is unchanged.

The new test asserts a parallel fit reproduces the serial one, but it did not
fail in fifteen runs of the unfixed code: the read almost always wins. TSan
catches it every time, which is the argument for the job.

## CMake 3.20...4.0

For `cmake_path()`, and the range opts into the policies up to 4.0. Boost
becomes CONFIG-only, since `CMP0167` removes `FindBoost`; the `CMP0074` and
`CMP0144` blocks go with it. Two things the policies broke and this fixes:
`codeCoverage.cmake` used an empty `COMMAND ;`, which `CMP0175` rejects.

## Notes

- The TSan job uses **clang**: GCC's libtsan reports false races on any
  `std::condition_variable::wait_for`, which `ThreadPool::wait()` uses.
- It installs R, because the whole `VinecopTest` fixture skips without Rscript.
  The assertion on the `PASSED` count is what caught that.
- The composite action now exports `BOOST_ROOT` and `Eigen3_ROOT`, removing
  that step from six jobs across three workflows. The
  `EIGEN3_INCLUDE_DIR`/`Boost_INCLUDE_DIR` exports are gone: CMake never read
  them, and the Eigen path in them was wrong.

## Verification

Ubuntu 22.04, GCC 12 and clang 14: 755 tests pass with R parity on; TSan is
clean across the three areas and reports the race when the `fit` change is
reverted; #766 and #768 fail before and pass after; the generated tree is
byte-identical across the `cmake_path()` rewrite; the installed package
resolves its dependencies with `find_package` disabled for all three, and fails
against the previous config.

## Follow-up

#776 — `Vinecop::fit` ignores the `num_threads` its controls carry. Left out:
public API change, four reasonable fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
